### PR TITLE
LogicNodes: Compare and Multi-value And/Or Gate

### DIFF
--- a/Sources/armory/logicnode/CompareNode.hx
+++ b/Sources/armory/logicnode/CompareNode.hx
@@ -1,0 +1,33 @@
+package armory.logicnode;
+
+class CompareNode extends LogicNode {
+
+	public var property0:String;
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function get(from:Int):Bool {
+
+		var v1:Dynamic = inputs[0].get();
+		var v2:Dynamic = inputs[1].get();
+		var r:Bool = false;
+		switch (property0) {
+		case "Equal":
+			r = v1 == v2;
+		case "Not Equal":
+			r = v1 != v2;
+		case "Less Than":
+			r = v1 < v2;
+		case "Less Than or Equal":
+			r = v1 <= v2;
+		case "Greater Than":
+			r = v1 > v2;
+		case "Greater Than or Equal":
+			r = v1 >= v2;
+		}
+
+		return r;
+	}
+}

--- a/Sources/armory/logicnode/GateNode.hx
+++ b/Sources/armory/logicnode/GateNode.hx
@@ -28,9 +28,20 @@ class GateNode extends LogicNode {
 		case "Less Equal":
 			cond = v1 <= v2;
 		case "Or":
-			cond = v1 || v2;
+			for (i in 1...inputs.length) {
+				if (inputs[i].get()) {
+					cond = true;
+					break;
+				}
+			}
 		case "And":
-			cond = v1 && v2;
+			cond = true;
+			for (i in 1...inputs.length) {
+				if (!inputs[i].get()) {
+					cond = false;
+					break;
+				}
+			}
 		}
 
 		if (cond) super.run();

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -127,8 +127,10 @@ class ArmNodeRemoveInputButton(bpy.types.Operator):
 
     def execute(self, context):
         global array_nodes
-        inps = array_nodes[self.node_index].inputs
-        if len(inps) > 0:
+        node = array_nodes[self.node_index]
+        inps = node.inputs
+        min_inps = 0 if not hasattr(node, 'min_inputs') else node.min_inputs
+        if len(inps) > min_inps:
             inps.remove(inps.values()[-1])
         return{'FINISHED'}
 

--- a/blender/arm/logicnode/logic_gate.py
+++ b/blender/arm/logicnode/logic_gate.py
@@ -44,7 +44,7 @@ class GateNode(Node, ArmLogicTreeNode):
             row = layout.row(align=True)
             op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
             op.node_index = str(id(self))
-            op.socket_type = 'ArmNodeSocketAction'
+            op.socket_type = 'NodeSocketShader'
             op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
             op2.node_index = str(id(self))
 

--- a/blender/arm/logicnode/logic_gate.py
+++ b/blender/arm/logicnode/logic_gate.py
@@ -3,6 +3,13 @@ from bpy.props import *
 from bpy.types import Node, NodeSocket
 from arm.logicnode.arm_nodes import *
 
+def remove_extra_inputs(self, context):
+    # if not any(p == self.property0 for p in ['Or', 'And']):
+    #     if len(self.inputs) > self.min_inputs:
+    #         #FIXME: str(id(self)) gives us a key error here
+    #         bpy.ops.arm.node_remove_input('EXEC_DEFAULT', node_index=str(id(self)))
+    pass
+
 class GateNode(Node, ArmLogicTreeNode):
     '''Gate node'''
     bl_idname = 'LNGateNode'
@@ -17,8 +24,13 @@ class GateNode(Node, ArmLogicTreeNode):
                  ('Less Equal', 'Less Equal', 'Less Equal'),
                  ('Or', 'Or', 'Or'),
                  ('And', 'And', 'And')],
-        name='', default='Equal')
+        name='', default='Equal',
+        update=remove_extra_inputs)
+    min_inputs = 3
     
+    def __init__(self):
+        array_nodes[str(id(self))] = self
+
     def init(self, context):
         self.inputs.new('ArmNodeSocketAction', 'In')
         self.inputs.new('NodeSocketShader', 'Value')
@@ -27,5 +39,13 @@ class GateNode(Node, ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
+
+        if any(p == self.property0 for p in ['Or', 'And']):
+            row = layout.row(align=True)
+            op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
+            op.node_index = str(id(self))
+            op.socket_type = 'ArmNodeSocketAction'
+            op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
+            op2.node_index = str(id(self))
 
 add_node(GateNode, category='Logic')

--- a/blender/arm/logicnode/value_compare.py
+++ b/blender/arm/logicnode/value_compare.py
@@ -1,0 +1,29 @@
+import bpy
+from bpy.props import *
+from bpy.types import Node, NodeSocket
+from arm.logicnode.arm_nodes import *
+
+class CompareNode(Node, ArmLogicTreeNode):
+    '''Compare node'''
+    bl_idname = 'LNCompareNode'
+    bl_label = 'Compare'
+    bl_icon = 'GAME'
+    property0 = EnumProperty(
+        items = [('Equal', 'Equal', 'Equal'),
+                 ('Not Equal', 'Not Equal', 'Not Equal'),
+                 ('Less Than', 'Less Than', 'Less Than'),
+                 ('Less Than or Equal', 'Less Than or Equal', 'Less Than or Equal'),
+                 ('Greater Than', 'Greater Than', 'Greater Than'),
+                 ('Greater Than or Equal', 'Greater Than or Equal', 'Greater Than or Equal'),
+                 ],
+        name='', default='Equal')
+    
+    def init(self, context):
+        self.inputs.new('NodeSocketShader', 'Value')
+        self.inputs.new('NodeSocketShader', 'Value')
+        self.outputs.new('NodeSocketBool', 'Bool')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
+
+add_node(CompareNode, category='Value')


### PR DESCRIPTION
Logic Nodes: Added ability to add an arbitrary number of inputs to Gate nodes, but only in the "And" or "Or" mode. This addresses #390.

Also added a Compare Node that can compare 2 inputs and return a bool. (==, !=, <, <=, >, >=)

![image](https://user-images.githubusercontent.com/8147765/36653058-a5d25fa8-1a67-11e8-99e5-85f1eee2b992.png)
