### PR TITLE
FollowCamera: use LateUpdate to avoid sync issues

### DIFF
--- a/Sources/armory/trait/FollowCamera.hx
+++ b/Sources/armory/trait/FollowCamera.hx
@@ -40,7 +40,7 @@ class FollowCamera extends iron.Trait {
 			}
 		});
 
-		notifyOnUpdate(function() {
+		notifyOnLateUpdate(function() {
 			if(!disabled){
 				if(targetObj != null) {
 					if(lerp){


### PR DESCRIPTION
Currently this could happen:

1. FollowCamera updates first, picked the old position of target
1. Target update its position then
1. Camera appears lagging one frame behind.

Using LateUpdate should fix it.