### PR TITLE
Add #if to WasmScript - was breaking iOS builds

### DIFF
--- a/Sources/armory/trait/internal/WasmScript.hx
+++ b/Sources/armory/trait/internal/WasmScript.hx
@@ -1,5 +1,7 @@
 package armory.trait.internal;
 
+#if js
+
 import iron.data.Data;
 import iron.data.Wasm;
 
@@ -25,3 +27,5 @@ class WasmScript extends iron.Trait {
 		});
 	}
 }
+
+#end


### PR DESCRIPTION
I got latest this morning and after refreshing the gate node I could not build for iOS, I saw all the other WASM checking where wrapped in #if js