### PR TITLE
Fixing issue, where "Clear Parent" node breaks execution in successive calls to "Set Parent"

### DIFF
--- a/Sources/armory/logicnode/ClearParentNode.hx
+++ b/Sources/armory/logicnode/ClearParentNode.hx
@@ -15,6 +15,7 @@ class ClearParentNode extends LogicNode {
 		if (object == null || object.parent == null) return;
 
 		object.parent.removeChild(object, keepTransform);
+		iron.Scene.active.root.addChild(object, false);
 
 		super.run();
 	}


### PR DESCRIPTION
Hi Lubos,

see this issue: https://github.com/armory3d/armory/issues/636

this simple fix solves the problem in this case. Let me know if this fix works in your opinion. And once again, thanks for your great work! 