### PR TITLE
adjusted ObjectNode to work with SetVariable Node

### DIFF
--- a/Sources/armory/logicnode/ObjectNode.hx
+++ b/Sources/armory/logicnode/ObjectNode.hx
@@ -12,7 +12,7 @@ class ObjectNode extends LogicNode {
 		super(tree);
 	}
 
-	override function get(from:Int):Dynamic { 
+	override function get(from:Int):Dynamic {
 		if (inputs.length > 0) return inputs[0].get();
 		value = objectName != "" ? iron.Scene.active.getChild(objectName) : tree.object;
 		return value;
@@ -20,6 +20,9 @@ class ObjectNode extends LogicNode {
 
 	override function set(value:Dynamic) {
 		if (inputs.length > 0) inputs[0].set(value);
-		else this.value = value;
+		else {
+			objectName = value.name;
+			this.value = value;
+		}
 	}
 }


### PR DESCRIPTION
The objectName was never ever set anywhere so the line
`value = objectName != "" ? iron.Scene.active.getChild(objectName) : tree.object;
`
would always return tree.object.
Thus using the set method had no effect at all as it set the value, which was then overridden because objectName was not set.
One might also consider to remove the value variable completely as I don't see it being used anywhere in thi script.