### PR TITLE
add send object event node

### DIFF
--- a/Sources/armory/logicnode/SendObjectEventNode.hx
+++ b/Sources/armory/logicnode/SendObjectEventNode.hx
@@ -1,0 +1,32 @@
+package armory.logicnode;
+
+import iron.object.Object;
+import armory.system.Event;
+
+class SendObjectEventNode extends LogicNode {
+
+	var entries:Array<TEvent> = null;
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function run() {
+		var object:Object = inputs[1].get();
+		var name:String = inputs[2].get();
+		
+		if (object == null) return null;
+
+		// if (entries == null) {
+			var all = Event.get(name);
+			if (all != null) {
+				entries = [];
+				for (e in all) if (e.mask == object.uid) entries.push(e);
+			}
+		// }
+		if (entries == null) return;
+		for (e in entries) e.onEvent();
+
+		super.run();
+	}
+}

--- a/blender/arm/logicnode/action_send_object_event.py
+++ b/blender/arm/logicnode/action_send_object_event.py
@@ -1,0 +1,18 @@
+import bpy
+from bpy.props import *
+from bpy.types import Node, NodeSocket
+from arm.logicnode.arm_nodes import *
+
+class SendObjectEventNode(Node, ArmLogicTreeNode):
+    '''Send object event node'''
+    bl_idname = 'LNSendObjectEventNode'
+    bl_label = 'Send Object Event'
+    bl_icon = 'CURVE_PATH'
+    
+    def init(self, context):
+        self.inputs.new('ArmNodeSocketAction', 'In')
+        self.inputs.new('ArmNodeSocketObject', 'Object')
+        self.inputs.new('NodeSocketString', 'Event')
+        self.outputs.new('ArmNodeSocketAction', 'Out')
+
+add_node(SendObjectEventNode, category='Action')


### PR DESCRIPTION
This is a pull request for an addirion for "send object event" node. This will send a event to a specific object.

Compared with send event node, this will send events to a different object.
Compared with send global event node, this will not corrupt the "Global namespace".

sample file: 
[send_obj_node.zip](https://github.com/armory3d/armory/files/2186152/send_obj_node.zip)