### PR TITLE
customizable socket labels (added by buttons)

### DIFF
--- a/Sources/armory/logicnode/AddGroupNode.hx
+++ b/Sources/armory/logicnode/AddGroupNode.hx
@@ -6,13 +6,13 @@ class AddGroupNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var groupName:String = inputs[1].get();
 		
 		if (iron.Scene.active.groups.get(groupName) == null) {
 			iron.Scene.active.groups.set(groupName, []);
 		}
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/AddTraitNode.hx
+++ b/Sources/armory/logicnode/AddTraitNode.hx
@@ -8,7 +8,7 @@ class AddTraitNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var trait:Dynamic = inputs[2].get();
 		
@@ -16,6 +16,6 @@ class AddTraitNode extends LogicNode {
 
 		object.addTrait(trait);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/AlternateNode.hx
+++ b/Sources/armory/logicnode/AlternateNode.hx
@@ -8,7 +8,7 @@ class AlternateNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		b ? runOutputs(0) : runOutputs(1);
 		b = !b;
 	}

--- a/Sources/armory/logicnode/AppendTransformNode.hx
+++ b/Sources/armory/logicnode/AppendTransformNode.hx
@@ -12,7 +12,7 @@ class AppendTransformNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var matrix:Mat4 = inputs[2].get();
 
@@ -25,6 +25,6 @@ class AppendTransformNode extends LogicNode {
 		if (rigidBody != null) rigidBody.syncTransform();
 		#end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ApplyForceAtLocationNode.hx
+++ b/Sources/armory/logicnode/ApplyForceAtLocationNode.hx
@@ -10,7 +10,7 @@ class ApplyForceAtLocationNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var force:Vec4 = inputs[2].get();
         var location:Vec4 = inputs[3].get();
@@ -22,6 +22,6 @@ class ApplyForceAtLocationNode extends LogicNode {
 		rb.applyForce(force, location);
 #end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ApplyForceNode.hx
+++ b/Sources/armory/logicnode/ApplyForceNode.hx
@@ -10,7 +10,7 @@ class ApplyForceNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var force:Vec4 = inputs[2].get();
 		
@@ -21,6 +21,6 @@ class ApplyForceNode extends LogicNode {
 		rb.applyForce(force);
 #end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ApplyImpulseAtLocationNode.hx
+++ b/Sources/armory/logicnode/ApplyImpulseAtLocationNode.hx
@@ -10,7 +10,7 @@ class ApplyImpulseAtLocationNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var impulse:Vec4 = inputs[2].get();
 		var location:Vec4 = inputs[3].get();
@@ -22,6 +22,6 @@ class ApplyImpulseAtLocationNode extends LogicNode {
 		rb.applyImpulse(impulse, location);
 #end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ApplyImpulseNode.hx
+++ b/Sources/armory/logicnode/ApplyImpulseNode.hx
@@ -10,7 +10,7 @@ class ApplyImpulseNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var impulse:Vec4 = inputs[2].get();
 		
@@ -21,6 +21,6 @@ class ApplyImpulseNode extends LogicNode {
 		rb.applyImpulse(impulse);
 #end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ArrayAddNode.hx
+++ b/Sources/armory/logicnode/ArrayAddNode.hx
@@ -6,7 +6,7 @@ class ArrayAddNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var ar:Array<Dynamic> = inputs[1].get();
 		if (ar == null) return;
 
@@ -17,6 +17,6 @@ class ArrayAddNode extends LogicNode {
 			}
 		}
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ArrayAddUniqueNode.hx
+++ b/Sources/armory/logicnode/ArrayAddUniqueNode.hx
@@ -6,7 +6,7 @@ class ArrayAddUniqueNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var ar:Array<Dynamic> = inputs[1].get();
 		if (ar == null) return;
 		
@@ -17,6 +17,6 @@ class ArrayAddUniqueNode extends LogicNode {
 			}
 		}
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ArrayLoopNode.hx
+++ b/Sources/armory/logicnode/ArrayLoopNode.hx
@@ -8,7 +8,7 @@ class ArrayLoopNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var ar:Array<Dynamic> = inputs[1].get();
 		if (ar == null) return;
 

--- a/Sources/armory/logicnode/ArrayRemoveNode.hx
+++ b/Sources/armory/logicnode/ArrayRemoveNode.hx
@@ -8,7 +8,7 @@ class ArrayRemoveNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var ar:Array<Dynamic> = inputs[1].get();
 		if (ar == null) return;
 

--- a/Sources/armory/logicnode/ArrayRemoveValueNode.hx
+++ b/Sources/armory/logicnode/ArrayRemoveValueNode.hx
@@ -8,7 +8,7 @@ class ArrayRemoveValueNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var ar:Array<Dynamic> = inputs[1].get();
 		if (ar == null) return;
 

--- a/Sources/armory/logicnode/ArraySetNode.hx
+++ b/Sources/armory/logicnode/ArraySetNode.hx
@@ -6,7 +6,7 @@ class ArraySetNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var ar:Array<Dynamic> = inputs[1].get();
 		if (ar == null) return;
 
@@ -16,6 +16,6 @@ class ArraySetNode extends LogicNode {
 		if (i < 0) ar[ar.length + i] = value;
 		else ar[i] = value;
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ArraySpliceNode.hx
+++ b/Sources/armory/logicnode/ArraySpliceNode.hx
@@ -6,7 +6,7 @@ class ArraySpliceNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var ar:Array<Dynamic> = inputs[1].get();
 		if (ar == null) return;
 
@@ -15,6 +15,6 @@ class ArraySpliceNode extends LogicNode {
 
         ar.splice(i, len);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/BranchNode.hx
+++ b/Sources/armory/logicnode/BranchNode.hx
@@ -6,7 +6,7 @@ class BranchNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var b:Bool = inputs[1].get();
 		b ? runOutputs(0) : runOutputs(1);
 	}

--- a/Sources/armory/logicnode/CallFunctionNode.hx
+++ b/Sources/armory/logicnode/CallFunctionNode.hx
@@ -10,7 +10,7 @@ class CallFunctionNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		if (object == null) return;
 		

--- a/Sources/armory/logicnode/CallGroupNode.hx
+++ b/Sources/armory/logicnode/CallGroupNode.hx
@@ -10,7 +10,7 @@ class CallGroupNode extends LogicNode {
 	}
 
 	@:access(iron.Trait)
-	override function run() {
+	override function run(node:LogicNode) {
 
 		if (callTree == null) {
 			var classType = Type.resolveClass(property0);

--- a/Sources/armory/logicnode/CallStaticFunctionNode.hx
+++ b/Sources/armory/logicnode/CallStaticFunctionNode.hx
@@ -8,7 +8,7 @@ class CallStaticFunctionNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		
 		var path:String = inputs[1].get();
 		if (path != '') {

--- a/Sources/armory/logicnode/CanvasSetTextNode.hx
+++ b/Sources/armory/logicnode/CanvasSetTextNode.hx
@@ -19,10 +19,10 @@ class CanvasSetTextNode extends LogicNode {
 		tree.removeUpdate(update);
 
 		canvas.getElement(element).text = Std.string(text);
-		super.run();
+		super.run(this);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		element = inputs[1].get();
 		text = inputs[2].get();
 		canvas = Scene.active.getTrait(CanvasScript);

--- a/Sources/armory/logicnode/ClearParentNode.hx
+++ b/Sources/armory/logicnode/ClearParentNode.hx
@@ -8,7 +8,7 @@ class ClearParentNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var keepTransform:Bool = inputs[2].get();
 		
@@ -17,6 +17,6 @@ class ClearParentNode extends LogicNode {
 		object.parent.removeChild(object, keepTransform);
 		iron.Scene.active.root.addChild(object, false);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ExpressionNode.hx
+++ b/Sources/armory/logicnode/ExpressionNode.hx
@@ -9,7 +9,7 @@ class ExpressionNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		#if arm_hscript
 		var expr = property0;

--- a/Sources/armory/logicnode/ExpressionNode.hx
+++ b/Sources/armory/logicnode/ExpressionNode.hx
@@ -10,12 +10,13 @@ class ExpressionNode extends LogicNode {
 	}
 
 	override function run(node:LogicNode) {
-
+		var values : Array<Dynamic> = [for (i in inputs.slice(2)) i.get()];
 		#if arm_hscript
-		var expr = property0;
+		var expr = inputs[1].get();
 		var parser = new hscript.Parser();
 		var ast = parser.parseString(expr);
 		var interp = new hscript.Interp();
+		for (i in 0...values)	interp.variables.set("v"+i,value[i]);
 		result = interp.execute(ast);
 		#end
 

--- a/Sources/armory/logicnode/GateNode.hx
+++ b/Sources/armory/logicnode/GateNode.hx
@@ -11,7 +11,7 @@ class GateNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		var v1:Dynamic = inputs[1].get();
 		var v2:Dynamic = inputs[2].get();

--- a/Sources/armory/logicnode/GoToLocationNode.hx
+++ b/Sources/armory/logicnode/GoToLocationNode.hx
@@ -10,7 +10,7 @@ class GoToLocationNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var location:Vec4 = inputs[2].get();
 		
@@ -26,6 +26,6 @@ class GoToLocationNode extends LogicNode {
 		});
 #end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/GroupOutputNode.hx
+++ b/Sources/armory/logicnode/GroupOutputNode.hx
@@ -6,8 +6,8 @@ class GroupOutputNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/InverseNode.hx
+++ b/Sources/armory/logicnode/InverseNode.hx
@@ -9,12 +9,12 @@ class InverseNode extends LogicNode {
 		tree.notifyOnUpdate(update);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		c = true;
 	}
 
 	function update() {
-		if (!c) super.run();
+		if (!c) super.run(this);
 		c = false;
 	}
 }

--- a/Sources/armory/logicnode/IsFalseNode.hx
+++ b/Sources/armory/logicnode/IsFalseNode.hx
@@ -6,9 +6,9 @@ class IsFalseNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		var v1:Bool = inputs[1].get();
-		if (!v1) super.run();
+		if (!v1) super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/IsNoneNode.hx
+++ b/Sources/armory/logicnode/IsNoneNode.hx
@@ -6,9 +6,9 @@ class IsNoneNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		var v1:Dynamic = inputs[1].get();
-		if (v1 == null) super.run();
+		if (v1 == null) super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/IsNotNoneNode.hx
+++ b/Sources/armory/logicnode/IsNotNoneNode.hx
@@ -6,9 +6,9 @@ class IsNotNoneNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		var v1:Dynamic = inputs[1].get();
-		if (v1 != null) super.run();
+		if (v1 != null) super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/IsTrueNode.hx
+++ b/Sources/armory/logicnode/IsTrueNode.hx
@@ -6,9 +6,9 @@ class IsTrueNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		var v1:Bool = inputs[1].get();
-		if (v1) super.run();
+		if (v1) super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/LogicNode.hx
+++ b/Sources/armory/logicnode/LogicNode.hx
@@ -26,9 +26,9 @@ class LogicNode {
 		outputs.push(nodes);
 	}
 
-	function run() { for (ar in outputs) for (o in ar) o.run(); }
+	function run(node:LogicNode) { for (ar in outputs) for (o in ar) o.run(this);}
 
-	function runOutputs(i:Int) { for (o in outputs[i]) o.run(); }
+	function runOutputs(i:Int,?node:LogicNode) { for (o in outputs[i]) o.run(this);}
 
 	@:allow(armory.logicnode.LogicNodeInput)
 	function get(from:Int):Dynamic { return this; }

--- a/Sources/armory/logicnode/LoopBreakNode.hx
+++ b/Sources/armory/logicnode/LoopBreakNode.hx
@@ -6,7 +6,7 @@ class LoopBreakNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		tree.loopBreak = true;
 	}
 }

--- a/Sources/armory/logicnode/LoopNode.hx
+++ b/Sources/armory/logicnode/LoopNode.hx
@@ -8,7 +8,7 @@ class LoopNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		index = 0;
 		var from:Int = inputs[1].get();
 		var to:Int = inputs[2].get();

--- a/Sources/armory/logicnode/MergeNode.hx
+++ b/Sources/armory/logicnode/MergeNode.hx
@@ -6,7 +6,7 @@ class MergeNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
-		super.run();
+	override function run(node:LogicNode) {
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/OnContactNode.hx
+++ b/Sources/armory/logicnode/OnContactNode.hx
@@ -52,6 +52,6 @@ class OnContactNode extends LogicNode {
 
 		lastContact = contact;
 
-		if (b) run();
+		if (b) run(this);
 	}
 }

--- a/Sources/armory/logicnode/OnEventNode.hx
+++ b/Sources/armory/logicnode/OnEventNode.hx
@@ -23,7 +23,7 @@ class OnEventNode extends LogicNode {
 	}
 
 	function onEvent() {
-		run();
+		run(this);
 	}
 
 	function onRemove() {

--- a/Sources/armory/logicnode/OnGamepadNode.hx
+++ b/Sources/armory/logicnode/OnGamepadNode.hx
@@ -28,6 +28,6 @@ class OnGamepadNode extends LogicNode {
 		// case "Moved Right":
 			// b = gamepad.rightStick.movementX != 0 || gamepad.rightStick.movementY != 0;
 		}
-		if (b) run();
+		if (b) run(this);
 	}
 }

--- a/Sources/armory/logicnode/OnInitNode.hx
+++ b/Sources/armory/logicnode/OnInitNode.hx
@@ -13,16 +13,16 @@ class OnInitNode extends LogicNode {
 	function init() {
 		#if arm_physics
 		var noPhysics = PhysicsWorld.active == null || PhysicsWorld.active._lateUpdate == null;
-		noPhysics ? run() : PhysicsWorld.active.notifyOnPreUpdate(physics_init);
+		noPhysics ? run(this) : PhysicsWorld.active.notifyOnPreUpdate(physics_init);
 		#else
-		run();
+		run(this);
 		#end
 	}
 
 	#if arm_physics
 	function physics_init() {
 		PhysicsWorld.active.removePreUpdate(physics_init);
-		run();
+		run(this);
 	}
 	#end
 }

--- a/Sources/armory/logicnode/OnKeyboardNode.hx
+++ b/Sources/armory/logicnode/OnKeyboardNode.hx
@@ -22,6 +22,6 @@ class OnKeyboardNode extends LogicNode {
 		case "Released":
 			b = keyboard.released(property1);
 		}
-		if (b) run();
+		if (b) run(this);
 	}
 }

--- a/Sources/armory/logicnode/OnMouseNode.hx
+++ b/Sources/armory/logicnode/OnMouseNode.hx
@@ -24,6 +24,6 @@ class OnMouseNode extends LogicNode {
 		case "Moved":
 			b = mouse.moved;
 		}
-		if (b) run();
+		if (b) run(this);
 	}
 }

--- a/Sources/armory/logicnode/OnSurfaceNode.hx
+++ b/Sources/armory/logicnode/OnSurfaceNode.hx
@@ -23,6 +23,6 @@ class OnSurfaceNode extends LogicNode {
 		case "Moved":
 			b = surface.moved;
 		}
-		if (b) run();
+		if (b) run(this);
 	}
 }

--- a/Sources/armory/logicnode/OnTimerNode.hx
+++ b/Sources/armory/logicnode/OnTimerNode.hx
@@ -21,7 +21,7 @@ class OnTimerNode extends LogicNode {
 		duration -= iron.system.Time.delta;
 		if (duration <= 0.0) {
 			if (!repeat) tree.removeUpdate(update);
-			run();
+			run(this);
 		}
 	}
 }

--- a/Sources/armory/logicnode/OnUpdateNode.hx
+++ b/Sources/armory/logicnode/OnUpdateNode.hx
@@ -9,6 +9,6 @@ class OnUpdateNode extends LogicNode {
 	}
 
 	function update() {
-		run();
+		run(this);
 	}
 }

--- a/Sources/armory/logicnode/OnVirtualButtonNode.hx
+++ b/Sources/armory/logicnode/OnVirtualButtonNode.hx
@@ -23,6 +23,6 @@ class OnVirtualButtonNode extends LogicNode {
 		case "Released":
 			b = vb.released;
 		}
-		if (b) run();
+		if (b) run(this);
 	}
 }

--- a/Sources/armory/logicnode/OnVolumeTriggerNode.hx
+++ b/Sources/armory/logicnode/OnVolumeTriggerNode.hx
@@ -47,6 +47,6 @@ class OnVolumeTriggerNode extends LogicNode {
 
 		lastOverlap = overlap;
 
-		if (b) run();
+		if (b) run(this);
 	}
 }

--- a/Sources/armory/logicnode/PauseActionNode.hx
+++ b/Sources/armory/logicnode/PauseActionNode.hx
@@ -8,7 +8,7 @@ class PauseActionNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		
 		if (object == null) return;
@@ -17,6 +17,6 @@ class PauseActionNode extends LogicNode {
 
 		animation.pause();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/PauseSoundNode.hx
+++ b/Sources/armory/logicnode/PauseSoundNode.hx
@@ -8,10 +8,10 @@ class PauseSoundNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:SpeakerObject = cast(inputs[1].get(), SpeakerObject);
 		if (object == null) return;
 		object.pause();
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/PauseTilesheetNode.hx
+++ b/Sources/armory/logicnode/PauseTilesheetNode.hx
@@ -8,13 +8,13 @@ class PauseTilesheetNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:MeshObject = inputs[1].get();
 		
 		if (object == null) return;
 
 		object.tilesheet.pause();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/PlayActionNode.hx
+++ b/Sources/armory/logicnode/PlayActionNode.hx
@@ -8,7 +8,7 @@ class PlayActionNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var action:String = inputs[2].get();
 		// TODO: assume input exists

--- a/Sources/armory/logicnode/PlaySoundNode.hx
+++ b/Sources/armory/logicnode/PlaySoundNode.hx
@@ -8,10 +8,10 @@ class PlaySoundNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:SpeakerObject = cast(inputs[1].get(), SpeakerObject);
 		if (object == null) return;
 		object.play();
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/PlaySoundRawNode.hx
+++ b/Sources/armory/logicnode/PlaySoundRawNode.hx
@@ -8,10 +8,10 @@ class PlaySoundRawNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		iron.data.Data.getSound(property0, function(sound:kha.Sound) {
 			iron.system.Audio.play(sound, false);
 		});
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/PlayTilesheetNode.hx
+++ b/Sources/armory/logicnode/PlayTilesheetNode.hx
@@ -8,7 +8,7 @@ class PlayTilesheetNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:MeshObject = inputs[1].get();
 		var action:String = inputs[2].get();
 		

--- a/Sources/armory/logicnode/PrintNode.hx
+++ b/Sources/armory/logicnode/PrintNode.hx
@@ -6,11 +6,11 @@ class PrintNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var value:Dynamic = inputs[1].get();
 	
 		trace(value);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/RemoveActiveSceneNode.hx
+++ b/Sources/armory/logicnode/RemoveActiveSceneNode.hx
@@ -6,7 +6,7 @@ class RemoveActiveSceneNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		iron.Scene.active.remove();
 		runOutputs(0);

--- a/Sources/armory/logicnode/RemoveGroupNode.hx
+++ b/Sources/armory/logicnode/RemoveGroupNode.hx
@@ -6,11 +6,11 @@ class RemoveGroupNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var groupName:String = inputs[1].get();
 		
 		iron.Scene.active.groups.remove(groupName);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/RemoveObjectNode.hx
+++ b/Sources/armory/logicnode/RemoveObjectNode.hx
@@ -8,13 +8,13 @@ class RemoveObjectNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		
 		if (object == null) return;
 
 		object.remove();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/RemoveTraitNode.hx
+++ b/Sources/armory/logicnode/RemoveTraitNode.hx
@@ -8,11 +8,11 @@ class RemoveTraitNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var trait:Dynamic = inputs[1].get();
 		if (trait == null) return;
 		trait.remove();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ResumeActionNode.hx
+++ b/Sources/armory/logicnode/ResumeActionNode.hx
@@ -8,7 +8,7 @@ class ResumeActionNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		
 		if (object == null) return;
@@ -17,6 +17,6 @@ class ResumeActionNode extends LogicNode {
 
 		animation.resume();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ResumeTilesheetNode.hx
+++ b/Sources/armory/logicnode/ResumeTilesheetNode.hx
@@ -8,13 +8,13 @@ class ResumeTilesheetNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:MeshObject = inputs[1].get();
 		
 		if (object == null) return;
 
 		object.tilesheet.resume();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/RotateObjectNode.hx
+++ b/Sources/armory/logicnode/RotateObjectNode.hx
@@ -14,7 +14,7 @@ class RotateObjectNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var vec:Vec4 = inputs[2].get();
 
@@ -30,6 +30,6 @@ class RotateObjectNode extends LogicNode {
 		if (rigidBody != null) rigidBody.syncTransform();
 		#end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ScaleObjectNode.hx
+++ b/Sources/armory/logicnode/ScaleObjectNode.hx
@@ -11,7 +11,7 @@ class ScaleObjectNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var vec:Vec4 = inputs[2].get();
 
@@ -25,6 +25,6 @@ class ScaleObjectNode extends LogicNode {
 		if (rigidBody != null) rigidBody.syncTransform();
 		#end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ScriptNode.hx
+++ b/Sources/armory/logicnode/ScriptNode.hx
@@ -15,7 +15,7 @@ class ScriptNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		var v:Dynamic = inputs[1].get();
 

--- a/Sources/armory/logicnode/SendEventNode.hx
+++ b/Sources/armory/logicnode/SendEventNode.hx
@@ -11,7 +11,7 @@ class SendEventNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var name:String = inputs[1].get();
 		var object:Object = inputs.length > 2 ? inputs[2].get() : tree.object;
 
@@ -27,6 +27,6 @@ class SendEventNode extends LogicNode {
 		if (entries == null) return;
 		for (e in entries) e.onEvent();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SendGlobalEventNode.hx
+++ b/Sources/armory/logicnode/SendGlobalEventNode.hx
@@ -11,7 +11,7 @@ class SendGlobalEventNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var name:String = inputs[1].get();
 		
 		// if (entries == null) {
@@ -20,6 +20,6 @@ class SendGlobalEventNode extends LogicNode {
 		if (entries == null) return; // Event does not exist
 		for (e in entries) e.onEvent();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SequenceNode.hx
+++ b/Sources/armory/logicnode/SequenceNode.hx
@@ -6,7 +6,7 @@ class SequenceNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
-		super.run();
+	override function run(node:LogicNode) {
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetActionSpeedNode.hx
+++ b/Sources/armory/logicnode/SetActionSpeedNode.hx
@@ -8,7 +8,7 @@ class SetActionSpeedNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var speed:Float = inputs[2].get();
 		
@@ -18,6 +18,6 @@ class SetActionSpeedNode extends LogicNode {
 
 		animation.speed = speed;
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetCameraFovNode.hx
+++ b/Sources/armory/logicnode/SetCameraFovNode.hx
@@ -8,7 +8,7 @@ class SetCameraFovNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var camera:CameraObject = inputs[1].get();
 		var fov:Float = inputs[2].get();
 		
@@ -17,6 +17,6 @@ class SetCameraFovNode extends LogicNode {
 		camera.data.raw.fov = fov;
 		camera.buildProjection();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetGravityNode.hx
+++ b/Sources/armory/logicnode/SetGravityNode.hx
@@ -10,7 +10,7 @@ class SetGravityNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var gravity:Vec4 = inputs[1].get();
 
 		if (gravity == null) return;
@@ -20,6 +20,6 @@ class SetGravityNode extends LogicNode {
 		physics.setGravity(gravity);
 #end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetLocationNode.hx
+++ b/Sources/armory/logicnode/SetLocationNode.hx
@@ -10,7 +10,7 @@ class SetLocationNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var vec:Vec4 = inputs[2].get();
 
@@ -24,6 +24,6 @@ class SetLocationNode extends LogicNode {
 		if (rigidBody != null) rigidBody.syncTransform();
 		#end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetMaterialImageParamNode.hx
+++ b/Sources/armory/logicnode/SetMaterialImageParamNode.hx
@@ -19,7 +19,7 @@ class SetMaterialImageParamNode extends LogicNode {
 		}
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		mat = inputs[1].get();
 		node = inputs[2].get();
 		if (mat == null || node == null) return;
@@ -29,7 +29,7 @@ class SetMaterialImageParamNode extends LogicNode {
 			image = img;
 		});
 
-		super.run();
+		super.run(this);
 	}
 
 	static function textureLink(object:Object, mat:MaterialData, link:String):kha.Image {

--- a/Sources/armory/logicnode/SetMaterialNode.hx
+++ b/Sources/armory/logicnode/SetMaterialNode.hx
@@ -9,7 +9,7 @@ class SetMaterialNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:MeshObject = inputs[1].get();
 		var mat:MaterialData = inputs[2].get();
 		
@@ -19,6 +19,6 @@ class SetMaterialNode extends LogicNode {
 			object.materials[i] = mat;
 		}
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetMaterialRgbParamNode.hx
+++ b/Sources/armory/logicnode/SetMaterialRgbParamNode.hx
@@ -19,12 +19,12 @@ class SetMaterialRgbParamNode extends LogicNode {
 		}
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		mat = inputs[1].get();
 		node = inputs[2].get();
 		col = inputs[3].get();
 
-		super.run();
+		super.run(this);
 	}
 
 	static function vec3Link(object:Object, mat:MaterialData, link:String):iron.math.Vec4 {

--- a/Sources/armory/logicnode/SetMaterialSlotNode.hx
+++ b/Sources/armory/logicnode/SetMaterialSlotNode.hx
@@ -9,7 +9,7 @@ class SetMaterialSlotNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:MeshObject = inputs[1].get();
 		var mat:MaterialData = inputs[2].get();
 		var slot:Int = inputs[3].get();
@@ -19,6 +19,6 @@ class SetMaterialSlotNode extends LogicNode {
 
 		object.materials[slot] = mat;
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetMaterialValueParamNode.hx
+++ b/Sources/armory/logicnode/SetMaterialValueParamNode.hx
@@ -19,12 +19,12 @@ class SetMaterialValueParamNode extends LogicNode {
 		}
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		mat = inputs[1].get();
 		node = inputs[2].get();
 		value = inputs[3].get();
 
-		super.run();
+		super.run(this);
 	}
 
 	static function floatLink(object:Object, mat:MaterialData, link:String):Null<kha.FastFloat> {

--- a/Sources/armory/logicnode/SetMeshNode.hx
+++ b/Sources/armory/logicnode/SetMeshNode.hx
@@ -9,7 +9,7 @@ class SetMeshNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:MeshObject = inputs[1].get();
 		var mesh:MeshData = inputs[2].get();
 		
@@ -17,6 +17,6 @@ class SetMeshNode extends LogicNode {
 
 		object.data = mesh;
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetMouseLockNode.hx
+++ b/Sources/armory/logicnode/SetMouseLockNode.hx
@@ -6,10 +6,10 @@ class SetMouseLockNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var lock:Bool = inputs[1].get();
 		var mouse = iron.system.Input.getMouse();
 		lock ? mouse.lock() : mouse.unlock();
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetNameNode.hx
+++ b/Sources/armory/logicnode/SetNameNode.hx
@@ -8,7 +8,7 @@ class SetNameNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var name:String = inputs[2].get();
 		
@@ -16,6 +16,6 @@ class SetNameNode extends LogicNode {
 
 		object.name = name;
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetNativePropertyNode.hx
+++ b/Sources/armory/logicnode/SetNativePropertyNode.hx
@@ -8,7 +8,7 @@ class SetNativePropertyNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var property:String = inputs[2].get();
 		var value:Dynamic = inputs[3].get();
@@ -17,6 +17,6 @@ class SetNativePropertyNode extends LogicNode {
 
 		Reflect.setProperty(object, property, value);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetParentBoneNode.hx
+++ b/Sources/armory/logicnode/SetParentBoneNode.hx
@@ -8,7 +8,7 @@ class SetParentBoneNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var parent:Object = inputs[2].get();
 		var bone:String = inputs[3].get();
@@ -23,6 +23,6 @@ class SetParentBoneNode extends LogicNode {
 		var banim = object.getParentArmature(object.parent.name);
 		banim.addBoneChild(bone, object);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetParentNode.hx
+++ b/Sources/armory/logicnode/SetParentNode.hx
@@ -8,7 +8,7 @@ class SetParentNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 
 		var parent:Object;
@@ -25,6 +25,6 @@ class SetParentNode extends LogicNode {
 		object.parent.removeChild(object, isUnparent); // keepTransform
 		parent.addChild(object, !isUnparent); // applyInverse
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetPropertyNode.hx
+++ b/Sources/armory/logicnode/SetPropertyNode.hx
@@ -8,7 +8,7 @@ class SetPropertyNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var property:String = inputs[2].get();
 		var value:Dynamic = inputs[3].get();
@@ -17,6 +17,6 @@ class SetPropertyNode extends LogicNode {
 		if (object.properties == null) object.properties = new Map();
 		object.properties.set(property, value);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetRotationNode.hx
+++ b/Sources/armory/logicnode/SetRotationNode.hx
@@ -10,7 +10,7 @@ class SetRotationNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var vec:Vec4 = inputs[2].get();
 
@@ -24,6 +24,6 @@ class SetRotationNode extends LogicNode {
 		if (rigidBody != null) rigidBody.syncTransform();
 		#end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetScaleNode.hx
+++ b/Sources/armory/logicnode/SetScaleNode.hx
@@ -10,7 +10,7 @@ class SetScaleNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var vec:Vec4 = inputs[2].get();
 
@@ -24,6 +24,6 @@ class SetScaleNode extends LogicNode {
 		if (rigidBody != null) rigidBody.syncTransform();
 		#end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetSceneNode.hx
+++ b/Sources/armory/logicnode/SetSceneNode.hx
@@ -10,7 +10,7 @@ class SetSceneNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var sceneName:String = inputs[1].get();
 
 		Scene.setActive(sceneName, function(o:iron.object.Object) {

--- a/Sources/armory/logicnode/SetStaticPropertyNode.hx
+++ b/Sources/armory/logicnode/SetStaticPropertyNode.hx
@@ -6,7 +6,7 @@ class SetStaticPropertyNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var className:String = inputs[1].get();
 		var property:String = inputs[2].get();
 		var value:Dynamic = inputs[3].get();
@@ -15,6 +15,6 @@ class SetStaticPropertyNode extends LogicNode {
 		if (cl == null) return;
         Reflect.setField(cl, property, value);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetTimeScaleNode.hx
+++ b/Sources/armory/logicnode/SetTimeScaleNode.hx
@@ -6,9 +6,9 @@ class SetTimeScaleNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var f:Float = inputs[1].get();
 		iron.system.Time.scale = f;
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetTransformNode.hx
+++ b/Sources/armory/logicnode/SetTransformNode.hx
@@ -10,7 +10,7 @@ class SetTransformNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var matrix:Mat4 = inputs[2].get();
 
@@ -23,6 +23,6 @@ class SetTransformNode extends LogicNode {
 		if (rigidBody != null) rigidBody.syncTransform();
 		#end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetVariableNode.hx
+++ b/Sources/armory/logicnode/SetVariableNode.hx
@@ -6,12 +6,12 @@ class SetVariableNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var variable = inputs[1];
 		var value:Dynamic = inputs[2].get();
 
 		variable.set(value);
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetVelocityNode.hx
+++ b/Sources/armory/logicnode/SetVelocityNode.hx
@@ -10,7 +10,7 @@ class SetVelocityNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var linear:Vec4 = inputs[2].get();
 		var linearFactor:Vec4 = inputs[3].get();
@@ -28,6 +28,6 @@ class SetVelocityNode extends LogicNode {
 		rb.setAngularFactor(angularFactor.x, angularFactor.y, angularFactor.z);
 #end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SetVisibleNode.hx
+++ b/Sources/armory/logicnode/SetVisibleNode.hx
@@ -8,7 +8,7 @@ class SetVisibleNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var visible:Bool = inputs[2].get();
 		
@@ -16,6 +16,6 @@ class SetVisibleNode extends LogicNode {
 
 		object.visible = visible;
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ShowMouseNode.hx
+++ b/Sources/armory/logicnode/ShowMouseNode.hx
@@ -6,10 +6,10 @@ class ShowMouseNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var show:Bool = inputs[1].get();
 		var mouse = iron.system.Input.getMouse();
 		show ? mouse.show() : mouse.hide();
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ShutdownNode.hx
+++ b/Sources/armory/logicnode/ShutdownNode.hx
@@ -6,7 +6,7 @@ class ShutdownNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		kha.System.requestShutdown();
 	}
 }

--- a/Sources/armory/logicnode/SleepNode.hx
+++ b/Sources/armory/logicnode/SleepNode.hx
@@ -6,12 +6,12 @@ class SleepNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var time:Float = inputs[1].get();
 		iron.system.Tween.timer(time, done);
 	}
 
 	function done() {
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/SpawnObjectNode.hx
+++ b/Sources/armory/logicnode/SpawnObjectNode.hx
@@ -12,7 +12,7 @@ class SpawnObjectNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		var objectName = "";
 		var objectInput = inputs[1].get();

--- a/Sources/armory/logicnode/SpawnSceneNode.hx
+++ b/Sources/armory/logicnode/SpawnSceneNode.hx
@@ -11,7 +11,7 @@ class SpawnSceneNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 
 		var sceneName:String = inputs[1].get();
 		var matrix:Mat4 = inputs[2].get();

--- a/Sources/armory/logicnode/StopAgentNode.hx
+++ b/Sources/armory/logicnode/StopAgentNode.hx
@@ -10,7 +10,7 @@ class StopAgentNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		
 		if (object == null) return;
@@ -20,6 +20,6 @@ class StopAgentNode extends LogicNode {
 		agent.stop();
 #end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/StopSoundNode.hx
+++ b/Sources/armory/logicnode/StopSoundNode.hx
@@ -8,10 +8,10 @@ class StopSoundNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:SpeakerObject = cast(inputs[1].get(), SpeakerObject);
 		if (object == null) return;
 		object.stop();
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/ToBoolNode.hx
+++ b/Sources/armory/logicnode/ToBoolNode.hx
@@ -9,7 +9,7 @@ class ToBoolNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		b = true;
 	}
 

--- a/Sources/armory/logicnode/TranslateObjectNode.hx
+++ b/Sources/armory/logicnode/TranslateObjectNode.hx
@@ -11,7 +11,7 @@ class TranslateObjectNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var vec:Vec4 = inputs[2].get();
 
@@ -25,6 +25,6 @@ class TranslateObjectNode extends LogicNode {
 		if (rigidBody != null) rigidBody.syncTransform();
 		#end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/TranslateOnLocalAxisNode.hx
+++ b/Sources/armory/logicnode/TranslateOnLocalAxisNode.hx
@@ -13,7 +13,7 @@ class TranslateOnLocalAxisNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var object:Object = inputs[1].get();
 		var sp:Float = inputs[2].get();
 		var l:Int = inputs[3].get();
@@ -43,6 +43,6 @@ class TranslateOnLocalAxisNode extends LogicNode {
 		if (rigidBody != null) rigidBody.syncTransform();
 		#end
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/Sources/armory/logicnode/WhileNode.hx
+++ b/Sources/armory/logicnode/WhileNode.hx
@@ -6,7 +6,7 @@ class WhileNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var b:Bool = inputs[1].get();
 		while (b) {
 			runOutputs(0);

--- a/Sources/armory/logicnode/WriteStorageNode.hx
+++ b/Sources/armory/logicnode/WriteStorageNode.hx
@@ -6,7 +6,7 @@ class WriteStorageNode extends LogicNode {
 		super(tree);
 	}
 
-	override function run() {
+	override function run(node:LogicNode) {
 		var key:String = inputs[1].get();
 		var value:Dynamic = inputs[2].get();
 
@@ -16,6 +16,6 @@ class WriteStorageNode extends LogicNode {
 		Reflect.setField(data, key, value);
 		iron.system.Storage.save();
 
-		super.run();
+		super.run(this);
 	}
 }

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -125,8 +125,10 @@ class ArmNodeAddInputButton(bpy.types.Operator):
 
     def execute(self, context):
         global array_nodes
-        inps = array_nodes[self.node_index].inputs
-        inps.new(self.socket_type, 'Input ' + str(len(inps)))
+        node = array_nodes[self.node_index]
+        inps = node.inputs
+        label_format = getattr(node, 'input_label', 'Input {0}')
+        inps.new(self.socket_type, label_format.format(len(inps)))
         return{'FINISHED'}
 
 class ArmNodeAddInputValueButton(bpy.types.Operator):
@@ -181,8 +183,10 @@ class ArmNodeAddOutputButton(bpy.types.Operator):
 
     def execute(self, context):
         global array_nodes
-        outs = array_nodes[self.node_index].outputs
-        outs.new(self.socket_type, 'Output ' + str(len(outs)))
+        node = array_nodes[self.node_index]
+        outs = node.outputs
+        label_format = getattr(node, 'output_label', 'Output {0}')
+        outs.new(self.socket_type, label_format.format(len(outs)))
         return{'FINISHED'}
 
 class ArmNodeRemoveOutputButton(bpy.types.Operator):

--- a/blender/arm/logicnode/logic_gate.py
+++ b/blender/arm/logicnode/logic_gate.py
@@ -27,13 +27,17 @@ class GateNode(Node, ArmLogicTreeNode):
     min_inputs = 3
     property1 = FloatProperty(name='Tolerance', description='Precision for float compare', default=0.0001)
     
+    @property
+    def input_label(self):
+        return 'Value {0}'.format(len(self.inputs)-1)
+    
     def __init__(self):
         array_nodes[str(id(self))] = self
 
     def init(self, context):
         self.inputs.new('ArmNodeSocketAction', 'In')
-        self.inputs.new('NodeSocketShader', 'Value')
-        self.inputs.new('NodeSocketShader', 'Value')
+        self.inputs.new('NodeSocketShader', 'Value 0')
+        self.inputs.new('NodeSocketShader', 'Value 1')
         self.outputs.new('ArmNodeSocketAction', 'True')
         self.outputs.new('ArmNodeSocketAction', 'False')
 

--- a/blender/arm/logicnode/logic_merge.py
+++ b/blender/arm/logicnode/logic_merge.py
@@ -8,6 +8,7 @@ class MergeNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNMergeNode'
     bl_label = 'Merge'
     bl_icon = 'GAME'
+    input_label = 'In {0}'
 
     def __init__(self):
         array_nodes[str(id(self))] = self

--- a/blender/arm/logicnode/logic_sequence.py
+++ b/blender/arm/logicnode/logic_sequence.py
@@ -8,6 +8,7 @@ class SequenceNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNSequenceNode'
     bl_label = 'Sequence'
     bl_icon = 'GAME'
+    output_label = 'Out {0}'
 
     def __init__(self):
         array_nodes[str(id(self))] = self

--- a/blender/arm/logicnode/native_expression.py
+++ b/blender/arm/logicnode/native_expression.py
@@ -8,15 +8,27 @@ class ExpressionNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNExpressionNode'
     bl_label = 'Expression'
     bl_icon = 'GAME'
-
-    property0 = StringProperty(name='', default='')
-
+    min_inputs = 2
+    @property
+    def input_label(self):
+        index = len(self.inputs)-2
+        default = 'v{0}'.format(index)
+        return default
+    def __init__(self):
+        array_nodes[str(id(self))] = self
     def init(self, context):
         self.inputs.new('ArmNodeSocketAction', 'In')
+        self.inputs.new('NodeSocketString', 'Expr')
         self.outputs.new('ArmNodeSocketAction', 'Out')
         self.outputs.new('NodeSocketShader', 'Result')
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'property0')
+        row = layout.row(align=True)
+
+        op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
+        op.node_index = str(id(self))
+        op.socket_type = 'NodeSocketShader'
+        op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
+        op2.node_index = str(id(self))
 
 add_node(ExpressionNode, category='Native')

--- a/blender/arm/logicnode/value_concatenate_string.py
+++ b/blender/arm/logicnode/value_concatenate_string.py
@@ -8,12 +8,13 @@ class ConcatenateStringNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNConcatenateStringNode'
     bl_label = 'Concatenate String'
     bl_icon = 'CURVE_PATH'
+    input_label = 'String {0}'
     
     def __init__(self):
         array_nodes[str(id(self))] = self
 
     def init(self, context):
-        self.inputs.new('NodeSocketString', 'Input 0')
+        self.inputs.new('NodeSocketString', 'String 0')
         self.outputs.new('NodeSocketString', 'String')
 
     def draw_buttons(self, context, layout):

--- a/blender/arm/logicnode/variable_array.py
+++ b/blender/arm/logicnode/variable_array.py
@@ -8,6 +8,7 @@ class ArrayNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNArrayNode'
     bl_label = 'Array'
     bl_icon = 'GAME'
+    input_label = 'Value[{0}]'
 
     def __init__(self):
         array_nodes[str(id(self))] = self

--- a/blender/arm/logicnode/variable_array_boolean.py
+++ b/blender/arm/logicnode/variable_array_boolean.py
@@ -8,6 +8,7 @@ class BooleanArrayNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNArrayBooleanNode'
     bl_label = 'Array (Boolean)'
     bl_icon = 'GAME'
+    input_label = 'Boolean[{0}]'
 
     def __init__(self):
         array_nodes[str(id(self))] = self

--- a/blender/arm/logicnode/variable_array_color.py
+++ b/blender/arm/logicnode/variable_array_color.py
@@ -8,6 +8,7 @@ class ColorArrayNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNArrayColorNode'
     bl_label = 'Array (Color)'
     bl_icon = 'GAME'
+    input_label = 'Color[{0}]'
 
     def __init__(self):
         array_nodes[str(id(self))] = self

--- a/blender/arm/logicnode/variable_array_float.py
+++ b/blender/arm/logicnode/variable_array_float.py
@@ -8,6 +8,7 @@ class FloatArrayNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNArrayFloatNode'
     bl_label = 'Array (Float)'
     bl_icon = 'GAME'
+    input_label = 'Float[{0}]'
 
     def __init__(self):
         array_nodes[str(id(self))] = self

--- a/blender/arm/logicnode/variable_array_integer.py
+++ b/blender/arm/logicnode/variable_array_integer.py
@@ -8,6 +8,7 @@ class IntegerArrayNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNArrayIntegerNode'
     bl_label = 'Array (Integer)'
     bl_icon = 'GAME'
+    input_label = 'Integer[{0}]'
 
     def __init__(self):
         array_nodes[str(id(self))] = self

--- a/blender/arm/logicnode/variable_array_object.py
+++ b/blender/arm/logicnode/variable_array_object.py
@@ -8,6 +8,7 @@ class ObjectArrayNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNArrayObjectNode'
     bl_label = 'Array (Object)'
     bl_icon = 'GAME'
+    input_label = 'Object[{0}]'
 
     def __init__(self):
         array_nodes[str(id(self))] = self

--- a/blender/arm/logicnode/variable_array_string.py
+++ b/blender/arm/logicnode/variable_array_string.py
@@ -8,6 +8,7 @@ class StringArrayNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNArrayStringNode'
     bl_label = 'Array (String)'
     bl_icon = 'GAME'
+    input_label = 'String[{0}]'
 
     def __init__(self):
         array_nodes[str(id(self))] = self

--- a/blender/arm/logicnode/variable_array_vector.py
+++ b/blender/arm/logicnode/variable_array_vector.py
@@ -8,6 +8,7 @@ class VectorArrayNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNArrayVectorNode'
     bl_label = 'Array (Vector)'
     bl_icon = 'GAME'
+    input_label = 'Vector[{0}]'
 
     def __init__(self):
         array_nodes[str(id(self))] = self


### PR DESCRIPTION
![custom_label](https://user-images.githubusercontent.com/22351407/42741510-f591336c-88ed-11e8-94c3-7cf87524f1d6.png)

Some buttons can more sockets that default by presseing the `New` button. However, the name is always fixed to `Input n` and `Output n`. The b2dca96 commit will enable to customize them and the 0cf8b79 shows the examples.
sample-file: [sample.zip](https://github.com/armory3d/armory/files/2196432/sample.zip)
