### PR TITLE
Activate process on play on macOS

### DIFF
--- a/blender/arm/mac_activate_proc.py
+++ b/blender/arm/mac_activate_proc.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python
+
+import sys
+from Cocoa import NSRunningApplication, NSApplicationActivateIgnoringOtherApps
+
+# see https://stackoverflow.com/questions/10655484/how-to-start-an-app-in-the-foreground-on-mac-os-x-with-python
+app = NSRunningApplication.runningApplicationWithProcessIdentifier_(int(sys.argv[1]))
+app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps)

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -25,12 +25,18 @@ exporter = ArmoryExporter()
 scripts_mtime = 0 # Monitor source changes
 profile_time = 0
 
+def mac_activate_proc(pid):
+    subprocess.call(["/usr/bin/python",
+        arm.utils.get_sdk_path() + "/armory/blender/arm/mac_activate_proc.py", str(pid)])
+
 def run_proc(cmd, done):
     def fn(p, done):
         p.wait()
         if done != None:
             done()
     p = subprocess.Popen(cmd)
+    if arm.utils.get_os() == 'mac':
+        mac_activate_proc(p.pid)
     threading.Thread(target=fn, args=(p, done)).start()
     return p
 


### PR DESCRIPTION
On macOS, when you press "Play" in Blender, the Krom process will start, but stay in the background, which is annoying. This PR activates the process, bringing it to the front, so that when you press "Play" you get the player process as front window.