### PR TITLE
Changed HueSaturationValue node to work with all of its inputs

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -571,13 +571,16 @@ def parse_vector(node, socket):
         return 'pow({0}, vec3({1}))'.format(out_col, gamma)
 
     elif node.type == 'HUE_SAT':
+        curshader.add_function(c_functions.str_rgb_to_hsv)
         curshader.add_function(c_functions.str_hsv_to_rgb)
+        curshader.add_function(c_functions.str_hue_sat)
         hue = parse_value_input(node.inputs[0])
         sat = parse_value_input(node.inputs[1])
         val = parse_value_input(node.inputs[2])
-        # fac = parse_value_input(node.inputs[3])
-        # col = parse_vector_input(node.inputs[4])
-        return 'hsv_to_rgb(vec3({0} - 0.5, {1}, {2}))'.format(hue, sat, val)
+        fac = parse_value_input(node.inputs[3])
+        col = parse_vector_input(node.inputs[4])
+        # return 'hsv_to_rgb(vec3({0} - 0.5, {1}, {2}))'.format(hue, sat, val)
+        return 'hue_sat({0}, vec4({1}-0.5, {2}, {3}, 1-{4}))'.format(col, hue, sat, val, fac)
 
     elif node.type == 'INVERT':
         fac = parse_value_input(node.inputs[0])

--- a/blender/arm/material/cycles_functions.py
+++ b/blender/arm/material/cycles_functions.py
@@ -124,6 +124,24 @@ vec3 rgb_to_hsv(const vec3 c) {
 }
 """
 
+# col: the incoming color
+# shift: a vector containing the hue shift, the saturation modificator, the value modificator and the mix factor in this order
+# this does the following:
+# make rgb col to hsv
+# apply hue shift through addition, sat/val through multiplication
+# return an rgb color, mixed with the original one
+str_hue_sat = """
+vec3 hue_sat(const vec3 col, const vec4 shift) {
+    vec3 hsv = rgb_to_hsv(col);
+    
+    hsv.x += shift.x;
+    hsv.y *= shift.y;
+    hsv.z *= shift.z;
+    
+    return mix(hsv_to_rgb(hsv), col, shift.w);
+}
+"""
+
 # https://twitter.com/Donzanoid/status/903424376707657730
 str_wavelength_to_rgb = """
 vec3 wavelength_to_rgb(const float t) {


### PR DESCRIPTION
This pull request enables the HueSaturationValue Node to function properly based on its color and factor inputs. Previously it only used its hue, saturation and value inputs to generate a color. It was not possible to use it to modify an incoming color or texture (at least in my testing).

To achieve this, this pull request adds a new function in `cycles_functions.py` to convert an incoming rgb color to hsv, apply the modifications of the hsv node and return the result as an rgb color, mixed with the original color as defined by the factor input. It also changes the `cycles.py` file to read these factor/color inputs (they were already in place but commented out) and then call the new function.
I also added some comments to the function. If you don't like that, feel free to remove these comments.

Demonstration:

The setup contains two plains. The right plane has a very simple material. It just connects an image texture to a diffuse shader which then connects to the surface. The left plane has almost the same material, it only has an additional HueSaturationValue node between the texture and the diffuse shader.

Right Material: 
![matright](https://user-images.githubusercontent.com/39460066/44005431-ca368442-9e73-11e8-9d59-96fe7d7bed2f.png)

Left Material: 
![matleft](https://user-images.githubusercontent.com/39460066/44005435-d190222a-9e73-11e8-8f6b-136cfad67d6b.png)

I just played around with the input values a little. The sample texture I used was 4 pixels I colored in gimp.

Before:
![before](https://user-images.githubusercontent.com/39460066/44005439-d74df872-9e73-11e8-96c9-1b9983dcd13c.png)

After:
![after_changes](https://user-images.githubusercontent.com/39460066/44005442-de126f9e-9e73-11e8-89ab-ce27a59440d1.png)
