### PR TITLE
Modding Workflow

### DIFF
--- a/Sources/armory/logicnode/GetTraitNode.hx
+++ b/Sources/armory/logicnode/GetTraitNode.hx
@@ -16,8 +16,12 @@ class GetTraitNode extends LogicNode {
 
 		if (object == null) return null;
 
+		if (cname == null) cname = cast Type.resolveClass(name);
+		// When building mods the Main class doesn't exist
+		#if !arm_modding_mod
 		if (cname == null) cname = cast Type.resolveClass(Main.projectPackage + "." + name);
 		if (cname == null) cname = cast Type.resolveClass(Main.projectPackage + ".node." + name);
+		#end
 		return object.getTrait(cname);
 	}
 }

--- a/Sources/armory/system/Modding.hx
+++ b/Sources/armory/system/Modding.hx
@@ -18,8 +18,9 @@ class Modding {
      * 
      * @param modListFile The path to the file containing the mod list
      * @param done Callback for when mods are finished
+	 * @param onload Callback called for each mod loaded
      */
-    static public function loadModsFromListFile(modListFile:String, done:() -> Void) {
+    static public function loadModsFromListFile(modListFile:String, done:() -> Void, onLoad:(modName:String) -> Void = null) {
 		iron.data.Data.getBlob(modListFile, (blob:kha.Blob) -> {
 			var modList = blob.toString().split("\n");
 			for (mod in modList) {
@@ -30,6 +31,7 @@ class Modding {
 				iron.data.Data.getBlob('Mods/$mod/krom.js', (b:kha.Blob) -> {
 					var code = b.toString();
 					untyped __js__("(1, eval)({0})", code);
+					if (onLoad != null) onLoad(mod);
 				});
 			}
 		});

--- a/Sources/armory/system/Modding.hx
+++ b/Sources/armory/system/Modding.hx
@@ -1,0 +1,104 @@
+package armory.system;
+
+using haxe.EnumTools;
+
+import haxe.macro.Type;
+import haxe.macro.Context;
+
+/**
+	Contains macros for helping with modding.
+**/
+class Modding {
+
+#if !macro
+
+    /**
+     * Load all mods referenced in a file. Each line in the file should be the name of a
+     * mod to enable.
+     * 
+     * @param modListFile The path to the file containing the mod list
+     * @param done Callback for when mods are finished
+     */
+    static public function loadModsFromListFile(modListFile:String, done:() -> Void) {
+		iron.data.Data.getBlob(modListFile, (blob:kha.Blob) -> {
+			var modList = blob.toString().split("\n");
+			for (mod in modList) {
+				if (mod == "") break;
+				// Load Mod code
+				trace('Loading mod: $mod');
+
+				iron.data.Data.getBlob('Mods/$mod/krom.js', (b:kha.Blob) -> {
+					var code = b.toString();
+					untyped __js__("(1, eval)({0})", code);
+				});
+			}
+		});
+		done();
+    }
+#elseif macro
+	/**
+		Expose classes and methods to the modding languages.
+	**/
+	static public function exposeClasses(patternStr:String) {
+        var pattern = new EReg(patternStr, "g");
+		Context.onAfterTyping(function (types:Array<ModuleType>) {
+			for (module in types) {
+				var moduleRef:Ref<ModuleType> = module.getParameters()[0];
+				var className = moduleRef.toString();
+				var baseModule:BaseType = cast moduleRef.get();
+
+                if (pattern.match(className)) {
+                    // Expose classes to Javascript
+                    if (Context.defined('js')) {
+                        baseModule.meta.add(":expose", [], baseModule.pos);
+                    }
+                }
+			}
+		});
+	}
+
+	//
+	// Macros below modified slightly from the haxe.macro.Compiler class
+	// from the standard library.
+	//
+
+	/**
+		Generate only the classes that match the given regex pattern.
+	**/
+	static public function generateOnlyClasses( patternStr : String ) {
+		var pattern = new EReg(patternStr, "g");
+		Context.onGenerate(function(types) {
+			for( t in types ) {
+				var b : BaseType, name;
+				switch( t ) {
+				case TInst(c, _):
+					name = c.toString();
+					b = c.get();
+				case TEnum(e, _):
+					name = e.toString();
+					b = e.get();
+				default: continue;
+				}
+				var classPath = '${b.pack.join(".")}.$name';
+
+				// If pattern is not matched, exclude class from compilation.
+				if( !pattern.match(classPath) )
+					excludeBaseType(b);
+			}
+		});
+	}
+
+	/**
+		Exclude a class or an enum without changing it to `@:nativeGen`.
+	**/
+	static private function excludeBaseType( baseType : BaseType ) : Void {
+		if (!baseType.isExtern) {
+			var meta = baseType.meta;
+			if (!meta.has(":nativeGen")) {
+				meta.add(":hxGen", [], baseType.pos);
+			}
+			baseType.exclude();
+		}
+	}
+#end
+}

--- a/Sources/armory/system/Modding.hx
+++ b/Sources/armory/system/Modding.hx
@@ -68,6 +68,9 @@ class Modding {
 
 	/**
 	 * Generate only the classes that match the given regex pattern.
+	 * 
+	 * @param patternStr The regular expression a class must match to be
+	 * included in compliation.
 	 */
 	static public function generateOnlyClasses( patternStr : String ) {
 		var pattern = new EReg(patternStr, "g");

--- a/Sources/armory/system/Modding.hx
+++ b/Sources/armory/system/Modding.hx
@@ -37,17 +37,19 @@ class Modding {
     }
 #elseif macro
 	/**
-		Expose classes and methods to the modding languages.
-	**/
-	static public function exposeClasses(patternStr:String) {
-        var pattern = new EReg(patternStr, "g");
+	 * Expose a package to modding languages. This allows mods to reference
+	 * functions and classes in that package and all subpackages.
+	 * 
+	 * @param package The name of the package to be exposed.
+	 */
+	static public function exposePack(pack:String) {
 		Context.onAfterTyping(function (types:Array<ModuleType>) {
 			for (module in types) {
 				var moduleRef:Ref<ModuleType> = module.getParameters()[0];
 				var className = moduleRef.toString();
 				var baseModule:BaseType = cast moduleRef.get();
 
-                if (pattern.match(className)) {
+                if (StringTools.startsWith(className, pack)) {
                     // Expose classes to Javascript
                     if (Context.defined('js')) {
                         baseModule.meta.add(":expose", [], baseModule.pos);
@@ -63,8 +65,8 @@ class Modding {
 	//
 
 	/**
-		Generate only the classes that match the given regex pattern.
-	**/
+	 * Generate only the classes that match the given regex pattern.
+	 */
 	static public function generateOnlyClasses( patternStr : String ) {
 		var pattern = new EReg(patternStr, "g");
 		Context.onGenerate(function(types) {
@@ -89,8 +91,8 @@ class Modding {
 	}
 
 	/**
-		Exclude a class or an enum without changing it to `@:nativeGen`.
-	**/
+	 * Exclude a class or an enum without changing it to `@:nativeGen`.
+	 */
 	static private function excludeBaseType( baseType : BaseType ) : Void {
 		if (!baseType.isExtern) {
 			var meta = baseType.meta;

--- a/Sources/armory/trait/physics/KinematicCharacterController.hx
+++ b/Sources/armory/trait/physics/KinematicCharacterController.hx
@@ -2,6 +2,8 @@ package armory.trait.physics;
 
 #if (!arm_physics)
 
+import iron.Trait;
+
 class KinematicCharacterController extends Trait { public function new() { super(); } }
 
 #else

--- a/Sources/armory/trait/physics/PhysicsConstraint.hx
+++ b/Sources/armory/trait/physics/PhysicsConstraint.hx
@@ -2,6 +2,8 @@ package armory.trait.physics;
 
 #if (!arm_physics)
 
+import iron.Trait;
+
 class PhysicsConstraint extends Trait { public function new() { super(); } }
 
 #else

--- a/Sources/armory/trait/physics/PhysicsHook.hx
+++ b/Sources/armory/trait/physics/PhysicsHook.hx
@@ -2,6 +2,8 @@ package armory.trait.physics;
 
 #if (!arm_physics)
 
+import iron.Trait;
+
 class PhysicsHook extends Trait { public function new() { super(); } }
 
 #else

--- a/Sources/armory/trait/physics/SoftBody.hx
+++ b/Sources/armory/trait/physics/SoftBody.hx
@@ -2,6 +2,8 @@ package armory.trait.physics;
 
 #if (!arm_physics_soft)
 
+import iron.Trait;
+
 class SoftBody extends Trait { public function new() { super(); } }
 
 #else

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -805,7 +805,7 @@ class ArmoryExporter:
                     ext = '' if not self.is_compress() else '.zip'
                     if ext == '' and not bpy.data.worlds['Arm'].arm_minimize:
                         ext = '.json'
-                    o['data_ref'] = 'mesh_' + oid + ext + '/' + oid
+                    o['data_ref'] = 'mesh_' + oid + ext + ':' + oid
                 else:
                     o['data_ref'] = oid
 

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1905,6 +1905,7 @@ class ArmoryExporter:
             self.export_mesh(o, scene)
 
     def execute(self, context, filepath, scene=None):
+        wrd = bpy.data.worlds['Arm']
         profile_time = time.time()
 
         self.output = {}
@@ -1958,7 +1959,11 @@ class ArmoryExporter:
 
         self.process_skinned_meshes()
 
-        self.output['name'] = arm.utils.safestr(self.scene.name)
+        scene_subpath = ''
+        if wrd.arm_modding_mode == 'Mod':
+            scene_subpath = wrd.arm_modding_folder + '/' + wrd.arm_project_package + '/'
+
+        self.output['name'] = scene_subpath + arm.utils.safestr(self.scene.name)
         if self.filepath.endswith('.zip'):
             self.output['name'] += '.zip'
         elif not bpy.data.worlds['Arm'].arm_minimize:

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2452,7 +2452,7 @@ class ArmoryExporter:
             self.add_constraints(bobject, o)
 
         for x in o['traits']:
-            ArmoryExporter.import_traits.append(x['class_name'])
+            if (x.get('import_trait') != False): ArmoryExporter.import_traits.append(x['class_name'])
 
     def add_constraints(self, bobject, o, bone=False):
         for con in bobject.constraints:
@@ -2516,6 +2516,11 @@ class ArmoryExporter:
                                 # Relative to the root/Bundled/canvas path
                                 asset = asset[6:] # Strip ../../ to start in project root
                                 assets.add(asset)
+                elif t.type_prop == 'External':
+                    x['type'] = 'Script'
+                    # We don't want to add imports for external traits
+                    x['import_trait'] = False
+                    x['class_name'] = t.class_name_prop
                 else: # Haxe/Bundled Script
                     if t.class_name_prop == '': # Empty class name, skip
                         continue

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -453,7 +453,7 @@ def build_success():
         shutil.rmtree(target_dir, ignore_errors=True)
         os.rename(src_dir, target_dir)
 
-        if wrd.arm_modding_mode == "Mod" and not state.is_publish and wrd.arm_play_runtime == 'Krom':
+        if wrd.arm_modding_mode == "Mod" and not state.is_publish and wrd.arm_runtime == 'Krom':
             # Copy the mod dir to parent game mod dir
             src_dir = os.path.join(arm.utils.get_fp_build(), 'debug/krom')
             game_blend_path = Path(wrd.arm_modding_game_blend.replace('//', ''))

--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -124,6 +124,6 @@ def parse(material, mat_data, mat_users, mat_armusers):
             c['bind_constants'].append(const)
 
     ext = '' if wrd.arm_minimize else '.json'
-    mat_data['shader'] = shader_data_name + ext + '/' + shader_data_name
+    mat_data['shader'] = shader_data_name + ext + ':' + shader_data_name
 
     return sd, rpasses

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -97,6 +97,8 @@ def init_properties():
         name="Modding Mode", default='None', description='The modding mode')
     bpy.types.World.arm_modding_game_blend = StringProperty(name="Game Blend", description="The .blend file for the parent game", default="", subtype="FILE_PATH")
     bpy.types.World.arm_modding_folder = StringProperty(name="Modding Folder", description="The name of the folder that mods will be put in", default="Mods")
+    bpy.types.World.arm_modding_expose_classes = StringProperty(name="Expose Classes", description="Regular expression for classes that should exposed to mods. Matches against full class path including package name.", default="(kha|iron|armory)")
+    bpy.types.World.arm_modding_include_packages = StringProperty(name="Include Packages", description="Comma separated list of packages to include in game. Use to ensure packages requried by mods don't get excluded from compilation.", default="armory.logicnode")
     bpy.types.World.arm_winmode = EnumProperty(
         items = [('Window', 'Window', 'Window'),
                  ('Fullscreen', 'Fullscreen', 'Fullscreen')],

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -103,7 +103,7 @@ def init_properties():
     bpy.types.World.arm_modding_expose_armory = BoolProperty(name="Armory", description="Expose Armory library to mods", default=True)
     bpy.types.World.arm_modding_expose_game = BoolProperty(name="Game", description="Expose the Game package ( default 'arm' ) to mods", default=True)
     bpy.types.World.arm_modding_expose_packages = StringProperty(name="Extra Packages", description="Comma separated list of extra packages to expose to mods.", default="")
-    bpy.types.World.arm_modding_extra_packages = StringProperty(name="Add Packages", description="Comma separated list of extra packages to add to the mod build. Add one for every extra Haxe package you mod depends on that is not included in the parent game.")
+    bpy.types.World.arm_modding_extra_packages = StringProperty(name="Add Packages", description="Comma separated list of extra packages to add to the mod build. Add one for every extra Haxe package your mod depends on that is not included in the parent game.")
     bpy.types.World.arm_winmode = EnumProperty(
         items = [('Window', 'Window', 'Window'),
                  ('Fullscreen', 'Fullscreen', 'Fullscreen')],

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -90,6 +90,12 @@ def init_properties():
     bpy.types.World.arm_asset_compression = BoolProperty(name="Asset Compression", description="Enable scene data compression", default=False, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_write_config = BoolProperty(name="Write Config", description="Allow this project to be configured at runtime via a JSON file", default=False, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_compiler_inline = BoolProperty(name="Compiler Inline", description="Favor speed over size", default=True, update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_modding_mode = EnumProperty(
+        items = [('None', 'None', 'None'),
+                 ('Game', 'Game', 'Game'),
+                 ('Mod', 'Mod', 'Mod')],
+        name="Modding Mode", default='None', description='The modding mode')
+    bpy.types.World.arm_modding_parent_project_dir = StringProperty(name="Parent Project Dir", description="The base dir of the parent project source.", default="", subtype="FILE_PATH")
     bpy.types.World.arm_winmode = EnumProperty(
         items = [('Window', 'Window', 'Window'),
                  ('Fullscreen', 'Fullscreen', 'Fullscreen')],

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -95,7 +95,8 @@ def init_properties():
                  ('Game', 'Game', 'Game'),
                  ('Mod', 'Mod', 'Mod')],
         name="Modding Mode", default='None', description='The modding mode')
-    bpy.types.World.arm_modding_parent_project_dir = StringProperty(name="Parent Project Dir", description="The base dir of the parent project source.", default="", subtype="FILE_PATH")
+    bpy.types.World.arm_modding_game_blend = StringProperty(name="Game Blend", description="The .blend file for the parent game", default="", subtype="FILE_PATH")
+    bpy.types.World.arm_modding_folder = StringProperty(name="Modding Folder", description="The name of the folder that mods will be put in", default="Mods")
     bpy.types.World.arm_winmode = EnumProperty(
         items = [('Window', 'Window', 'Window'),
                  ('Fullscreen', 'Fullscreen', 'Fullscreen')],

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -98,7 +98,11 @@ def init_properties():
     bpy.types.World.arm_modding_game_blend = StringProperty(name="Game Blend", description="The .blend file for the parent game", default="", subtype="FILE_PATH")
     bpy.types.World.arm_modding_folder = StringProperty(name="Modding Folder", description="The name of the folder that mods will be put in", default="Mods")
     bpy.types.World.arm_modding_expose_classes = StringProperty(name="Expose Classes", description="Regular expression for classes that should exposed to mods. Matches against full class path including package name.", default="(kha|iron|armory)")
-    bpy.types.World.arm_modding_include_packages = StringProperty(name="Include Packages", description="Comma separated list of packages to include in game. Use to ensure packages requried by mods don't get excluded from compilation.", default="armory.logicnode")
+    bpy.types.World.arm_modding_expose_kha = BoolProperty(name="Kha", description="Expose Kha library to mods", default=True)
+    bpy.types.World.arm_modding_expose_iron = BoolProperty(name="Iron", description="Expose Iron library to mods", default=True)
+    bpy.types.World.arm_modding_expose_armory = BoolProperty(name="Armory", description="Expose Armory library to mods", default=True)
+    bpy.types.World.arm_modding_expose_game = BoolProperty(name="Game", description="Expose the Game package ( default 'arm' ) to mods", default=True)
+    bpy.types.World.arm_modding_extra_packages = StringProperty(name="Extra Packages", description="Comma separated list of extra packages to expose to mods.", default="")
     bpy.types.World.arm_winmode = EnumProperty(
         items = [('Window', 'Window', 'Window'),
                  ('Fullscreen', 'Fullscreen', 'Fullscreen')],

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -102,7 +102,8 @@ def init_properties():
     bpy.types.World.arm_modding_expose_iron = BoolProperty(name="Iron", description="Expose Iron library to mods", default=True)
     bpy.types.World.arm_modding_expose_armory = BoolProperty(name="Armory", description="Expose Armory library to mods", default=True)
     bpy.types.World.arm_modding_expose_game = BoolProperty(name="Game", description="Expose the Game package ( default 'arm' ) to mods", default=True)
-    bpy.types.World.arm_modding_extra_packages = StringProperty(name="Extra Packages", description="Comma separated list of extra packages to expose to mods.", default="")
+    bpy.types.World.arm_modding_expose_packages = StringProperty(name="Extra Packages", description="Comma separated list of extra packages to expose to mods.", default="")
+    bpy.types.World.arm_modding_extra_packages = StringProperty(name="Add Packages", description="Comma separated list of extra packages to add to the mod build. Add one for every extra Haxe package you mod depends on that is not included in the parent game.")
     bpy.types.World.arm_winmode = EnumProperty(
         items = [('Window', 'Window', 'Window'),
                  ('Fullscreen', 'Fullscreen', 'Fullscreen')],

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -22,7 +22,7 @@ def update_trait_group(self, context):
     i = o.arm_traitlist_index
     if i >= 0 and i < len(o.arm_traitlist):
         t = o.arm_traitlist[i]
-        if t.type_prop == 'Haxe Script' or t.type_prop == 'Bundled Script':
+        if t.type_prop == 'Haxe Script' or t.type_prop == 'Bundled Script' or t.type_prop == 'External':
             t.name = t.class_name_prop
         elif t.type_prop == 'WebAssembly':
             t.name = t.webassembly_prop
@@ -58,7 +58,8 @@ class ArmTraitListItem(bpy.types.PropertyGroup):
                  ('WebAssembly', 'Wasm', 'WebAssembly'),
                  ('UI Canvas', 'UI', 'UI Canvas'),
                  ('Bundled Script', 'Bundled', 'Bundled Script'),
-                 ('Logic Nodes', 'Nodes', 'Logic Nodes')
+                 ('Logic Nodes', 'Nodes', 'Logic Nodes'),
+                 ('External', 'External', 'External')
                  ],
         name = "Type")
     class_name_prop: StringProperty(name="Class", description="A name for this item", default="", update=update_trait_group)
@@ -72,7 +73,7 @@ class ArmTraitList(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
         custom_icon = "NONE"
         custom_icon_value = 0
-        if item.type_prop == "Haxe Script":
+        if item.type_prop == "Haxe Script" or item.type_prop == "External":
             custom_icon_value = icons_dict["haxe"].icon_id
         elif item.type_prop == "WebAssembly":
             custom_icon_value = icons_dict["wasm"].icon_id
@@ -103,13 +104,14 @@ class ArmTraitListNewItem(bpy.types.Operator):
                  ('WebAssembly', 'Wasm', 'WebAssembly'),
                  ('UI Canvas', 'UI', 'UI Canvas'),
                  ('Bundled Script', 'Bundled', 'Bundled Script'),
-                 ('Logic Nodes', 'Nodes', 'Logic Nodes')
+                 ('Logic Nodes', 'Nodes', 'Logic Nodes'),
+                 ('External', 'External', 'External')
                  ],
         name = "Type")
 
     def invoke(self, context, event):
         wm = context.window_manager
-        return wm.invoke_props_dialog(self)
+        return wm.invoke_props_dialog(self, width=400)
 
     def draw(self,context):
         layout = self.layout
@@ -545,6 +547,10 @@ def draw_traits(layout, obj, is_object):
         elif item.type_prop == 'Logic Nodes':
             row = layout.row()
             row.prop_search(item, "node_tree_prop", bpy.data, "node_groups", text="Tree")
+
+        elif item.type_prop == 'External':
+            row = layout.row()
+            row.prop(item, "class_name_prop")
 
 def register():
     global icons_dict

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -327,6 +327,28 @@ class ArmoryProjectPanel(bpy.types.Panel):
         row.operator("arm.kode_studio")
         row.operator("arm.open_project_folder", icon="FILE_FOLDER")
 
+class ArmProjectModdingPanel(bpy.types.Panel):
+    bl_label = "Modding"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "render"
+    bl_parent_id = "ArmoryProjectPanel"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        wrd = bpy.data.worlds['Arm']
+        box = layout.box().column()
+        row = box.row()
+        row.prop(wrd, 'arm_modding_mode', expand=True)
+        col = box.column()
+        if wrd.arm_modding_mode == 'Game':
+            pass
+        if wrd.arm_modding_mode == 'Mod':
+            col2 = col.column()
+            col2.prop(wrd, 'arm_modding_parent_project_dir')
+
 class ArmProjectFlagsPanel(bpy.types.Panel):
     bl_label = "Flags"
     bl_space_type = "PROPERTIES"
@@ -1421,6 +1443,7 @@ def register():
     bpy.utils.register_class(ArmoryPlayerPanel)
     bpy.utils.register_class(ArmoryExporterPanel)
     bpy.utils.register_class(ArmoryProjectPanel)
+    bpy.utils.register_class(ArmProjectModdingPanel)
     bpy.utils.register_class(ArmProjectFlagsPanel)
     bpy.utils.register_class(ArmProjectWindowPanel)
     bpy.utils.register_class(ArmProjectModulesPanel)
@@ -1472,6 +1495,7 @@ def unregister():
     bpy.utils.unregister_class(ArmoryPlayerPanel)
     bpy.utils.unregister_class(ArmoryExporterPanel)
     bpy.utils.unregister_class(ArmoryProjectPanel)
+    bpy.utils.unregister_class(ArmProjectModdingPanel)
     bpy.utils.unregister_class(ArmProjectFlagsPanel)
     bpy.utils.unregister_class(ArmProjectWindowPanel)
     bpy.utils.unregister_class(ArmProjectModulesPanel)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -358,9 +358,9 @@ class ArmProjectModdingPanel(bpy.types.Panel):
             row = box.row()
             col = row.column()
             col.prop(wrd, 'arm_modding_game_blend')
+            col.prop(wrd, 'arm_project_package')
             col.prop(wrd, 'arm_modding_folder')
-            row = box.row()
-            row.prop(wrd, 'arm_modding_extra_packages')
+            col.prop(wrd, 'arm_modding_extra_packages')
 
 class ArmProjectFlagsPanel(bpy.types.Panel):
     bl_label = "Flags"

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -344,8 +344,10 @@ class ArmProjectModdingPanel(bpy.types.Panel):
         row.prop(wrd, 'arm_modding_mode', expand=True)
         col = box.column()
         if wrd.arm_modding_mode == 'Game':
-            pass
-        if wrd.arm_modding_mode == 'Mod':
+            col2 = col.column()
+            col2.prop(wrd, 'arm_modding_expose_classes')
+            col2.prop(wrd, 'arm_modding_include_packages')
+        elif wrd.arm_modding_mode == 'Mod':
             col2 = col.column()
             col2.prop(wrd, 'arm_modding_game_blend')
             col2.prop(wrd, 'arm_modding_folder')

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -353,12 +353,14 @@ class ArmProjectModdingPanel(bpy.types.Panel):
             col.prop(wrd, 'arm_modding_expose_armory')
             col.prop(wrd, 'arm_modding_expose_iron')
             row = box.row()
-            row.prop(wrd, 'arm_modding_extra_packages', text="Extra")
+            row.prop(wrd, 'arm_modding_expose_packages', text="Extra")
         elif wrd.arm_modding_mode == 'Mod':
             row = box.row()
             col = row.column()
             col.prop(wrd, 'arm_modding_game_blend')
             col.prop(wrd, 'arm_modding_folder')
+            row = box.row()
+            row.prop(wrd, 'arm_modding_extra_packages')
 
 class ArmProjectFlagsPanel(bpy.types.Panel):
     bl_label = "Flags"

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -342,15 +342,23 @@ class ArmProjectModdingPanel(bpy.types.Panel):
         box = layout.box().column()
         row = box.row()
         row.prop(wrd, 'arm_modding_mode', expand=True)
-        col = box.column()
         if wrd.arm_modding_mode == 'Game':
-            col2 = col.column()
-            col2.prop(wrd, 'arm_modding_expose_classes')
-            col2.prop(wrd, 'arm_modding_include_packages')
+            row = box.row()
+            row.label(text="Exposed Packages:")
+            row = box.row()
+            col = row.column()
+            col.prop(wrd, 'arm_modding_expose_game')
+            col.prop(wrd, 'arm_modding_expose_kha')
+            col = row.column()
+            col.prop(wrd, 'arm_modding_expose_armory')
+            col.prop(wrd, 'arm_modding_expose_iron')
+            row = box.row()
+            row.prop(wrd, 'arm_modding_extra_packages', text="Extra")
         elif wrd.arm_modding_mode == 'Mod':
-            col2 = col.column()
-            col2.prop(wrd, 'arm_modding_game_blend')
-            col2.prop(wrd, 'arm_modding_folder')
+            row = box.row()
+            col = row.column()
+            col.prop(wrd, 'arm_modding_game_blend')
+            col.prop(wrd, 'arm_modding_folder')
 
 class ArmProjectFlagsPanel(bpy.types.Panel):
     bl_label = "Flags"

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -347,7 +347,8 @@ class ArmProjectModdingPanel(bpy.types.Panel):
             pass
         if wrd.arm_modding_mode == 'Mod':
             col2 = col.column()
-            col2.prop(wrd, 'arm_modding_parent_project_dir')
+            col2.prop(wrd, 'arm_modding_game_blend')
+            col2.prop(wrd, 'arm_modding_folder')
 
 class ArmProjectFlagsPanel(bpy.types.Panel):
     bl_label = "Flags"

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -274,10 +274,20 @@ project.addSources('Sources');
         if wrd.arm_modding_mode != "None":
             assets.add_khafile_def('arm_modding')
             assets.add_khafile_def('arm_shaderload')
+
         if wrd.arm_modding_mode == "Game":
             assets.add_khafile_def('arm_modding_game')
+            # Expose selected game classes to mods
+            f.write('project.addParameter("--macro armory.system.Modding.exposeClasses(\'' + wrd.arm_modding_expose_classes + '\')");\n')
+            for package in wrd.arm_modding_include_packages.split(','):
+                f.write('project.addParameter("--macro include(\'' + package + '\')");\n')
         elif wrd.arm_modding_mode == "Mod":
             assets.add_khafile_def('arm_modding_mod')
+            # Expose mod classes to other mods
+            f.write('project.addParameter("--macro armory.system.Modding.exposeClasses(\'' + wrd.arm_project_package + '\')");\n')
+            # Generate only the mod's code ( i.e. not iron, Kha, and the rest of the game)
+            f.write('project.addParameter("--macro armory.system.Modding.generateOnlyClasses(\'(' + wrd.arm_project_package + ')\')");\n')
+            f.write('project.addParameter("-main ' + wrd.arm_project_package + '.Main");\n')
 
         for d in assets.khafile_defs:
             f.write("project.addDefine('" + d + "');\n")
@@ -350,7 +360,28 @@ def write_mainhx(scene_name, resx, resy, is_play, is_viewport, is_publish):
         pathpack = wrd.arm_project_package
     elif rpdat.rp_driver != 'Armory':
         pathpack = rpdat.rp_driver.lower()
+    
+    # Generate Main.hx for Mod
+    if wrd.arm_modding_mode == 'Mod':
+        main_file = 'Sources/' + wrd.arm_project_package + '/Main.hx'
+        if os.path.exists(main_file): return # Don't overwrite custom main file
+        with open(main_file, 'w') as f:
+            f.write(
+"""// Auto-generated
+package """ + wrd.arm_project_package + """;
+class Main {
+    public static function main() {
+        // DO NOT REMOVE FOLLOWING HACK!!!!
+        // Hack class resolution of mod traits
+		@:keep var hack = Type.resolveClass("Std");
 
+        // Any startup logic
+    }
+}
+""")
+        return
+
+    # Generate Main.hx for game
     with open('Sources/Main.hx', 'w') as f:
         f.write(
 """// Auto-generated

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -277,6 +277,10 @@ project.addSources('Sources');
 
         if wrd.arm_modding_mode == "Game":
             assets.add_khafile_def('arm_modding_game')
+            # Expose Haxe API to mods
+            f.write("""project.addParameter("--macro armory.system.Modding.exposePack('haxe')");""")
+            f.write("""project.addParameter("--macro include('haxe', ['haxe.macro.*'])");""")
+
             # Expose selected game classes to mods.
             # Kha, Iron, and Armory require certain exclusions in order to
             # compile without errors.
@@ -284,14 +288,14 @@ project.addSources('Sources');
                 f.write('project.addParameter("--macro armory.system.Modding.exposePack(\'' + wrd.arm_project_package + '\')");\n')
             if (wrd.arm_modding_expose_kha):
                 f.write("""project.addParameter("--macro armory.system.Modding.exposePack('kha')");""" + '\n')
-                f.write("""project.addParameter("--macro include('kha', ['kha.graphics4.hxsl.*', 'kha.network.NodeProcessClient', 'kha.HaxelibRunner', 'kha.internal.*'])");""" + '\n')
+                f.write("""project.addParameter("--macro include('kha', ['kha.graphics4.hxsl.*', 'kha.netsync.NodeProcessClient', 'kha.netsync.Example', 'kha.HaxelibRunner', 'kha.internal.*'])");""" + '\n')
             if (wrd.arm_modding_expose_iron):
                 f.write("""project.addParameter("--macro armory.system.Modding.exposePack('iron')");""" + '\n')
                 f.write("""project.addParameter("--macro include('iron', ['iron.data.GreasePencilData'])");""" + '\n')
             if (wrd.arm_modding_expose_armory):
                 f.write("""project.addParameter("--macro armory.system.Modding.exposePack('armory')");""" + '\n')
                 f.write("""project.addParameter("--macro include('armory', ['armory.system.*'])");""" + '\n')
-            for package in wrd.arm_modding_extra_packages.split(','):
+            for package in wrd.arm_modding_expose_packages.split(','):
                 if package == '': break;
                 f.write('project.addParameter("--macro include(\'' + package + '\')");\n')
                 f.write('project.addParameter("--macro armory.system.Modding.exposePack(\'' + package + '\')");\n')
@@ -299,8 +303,17 @@ project.addSources('Sources');
             assets.add_khafile_def('arm_modding_mod')
             # Expose mod classes to other mods
             f.write('project.addParameter("--macro armory.system.Modding.exposePack(\'' + wrd.arm_project_package + '\')");\n')
-            # Generate only the mod's code ( i.e. not iron, Kha, and the rest of the game)
-            f.write('project.addParameter("--macro armory.system.Modding.generateOnlyClasses(\'(' + wrd.arm_project_package + ')\')");\n')
+
+            extra_packs = '|'.join(wrd.arm_modding_extra_packages.split(','))
+            if extra_packs == '':
+                generate_only_classes = wrd.arm_project_package
+            else:
+                # Build package inclusion regex
+                generate_only_classes = '(' + extra_packs + '|' + wrd.arm_project_package + ')'
+            print(extra_packs)
+
+            # Generate only the mod's code and mod libraries ( i.e. not iron, Kha, and the rest of the game)
+            f.write('project.addParameter("--macro armory.system.Modding.generateOnlyClasses(\'' + generate_only_classes + '\')");\n')
             f.write('project.addParameter("-main ' + wrd.arm_project_package + '.Main");\n')
 
         for d in assets.khafile_defs:

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -277,14 +277,28 @@ project.addSources('Sources');
 
         if wrd.arm_modding_mode == "Game":
             assets.add_khafile_def('arm_modding_game')
-            # Expose selected game classes to mods
-            f.write('project.addParameter("--macro armory.system.Modding.exposeClasses(\'' + wrd.arm_modding_expose_classes + '\')");\n')
-            for package in wrd.arm_modding_include_packages.split(','):
+            # Expose selected game classes to mods.
+            # Kha, Iron, and Armory require certain exclusions in order to
+            # compile without errors.
+            if (wrd.arm_modding_expose_game):
+                f.write('project.addParameter("--macro armory.system.Modding.exposePack(\'' + wrd.arm_project_package + '\')");\n')
+            if (wrd.arm_modding_expose_kha):
+                f.write("""project.addParameter("--macro armory.system.Modding.exposePack('kha')");""" + '\n')
+                f.write("""project.addParameter("--macro include('kha', ['kha.graphics4.hxsl.*', 'kha.network.NodeProcessClient', 'kha.HaxelibRunner', 'kha.internal.*'])");""" + '\n')
+            if (wrd.arm_modding_expose_iron):
+                f.write("""project.addParameter("--macro armory.system.Modding.exposePack('iron')");""" + '\n')
+                f.write("""project.addParameter("--macro include('iron', ['iron.data.GreasePencilData'])");""" + '\n')
+            if (wrd.arm_modding_expose_armory):
+                f.write("""project.addParameter("--macro armory.system.Modding.exposePack('armory')");""" + '\n')
+                f.write("""project.addParameter("--macro include('armory', ['armory.system.*'])");""" + '\n')
+            for package in wrd.arm_modding_extra_packages.split(','):
+                if package == '': break;
                 f.write('project.addParameter("--macro include(\'' + package + '\')");\n')
+                f.write('project.addParameter("--macro armory.system.Modding.exposePack(\'' + package + '\')");\n')
         elif wrd.arm_modding_mode == "Mod":
             assets.add_khafile_def('arm_modding_mod')
             # Expose mod classes to other mods
-            f.write('project.addParameter("--macro armory.system.Modding.exposeClasses(\'' + wrd.arm_project_package + '\')");\n')
+            f.write('project.addParameter("--macro armory.system.Modding.exposePack(\'' + wrd.arm_project_package + '\')");\n')
             # Generate only the mod's code ( i.e. not iron, Kha, and the rest of the game)
             f.write('project.addParameter("--macro armory.system.Modding.generateOnlyClasses(\'(' + wrd.arm_project_package + ')\')");\n')
             f.write('project.addParameter("-main ' + wrd.arm_project_package + '.Main");\n')

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -271,6 +271,14 @@ project.addSources('Sources');
         # if bpy.data.scenes[0].unit_settings.system_rotation == 'DEGREES':
             # assets.add_khafile_def('arm_degrees')
 
+        if wrd.arm_modding_mode != "None":
+            assets.add_khafile_def('arm_modding')
+            assets.add_khafile_def('arm_shaderload')
+        if wrd.arm_modding_mode == "Game":
+            assets.add_khafile_def('arm_modding_game')
+        elif wrd.arm_modding_mode == "Mod":
+            assets.add_khafile_def('arm_modding_mod')
+
         for d in assets.khafile_defs:
             f.write("project.addDefine('" + d + "');\n")
 


### PR DESCRIPTION
A working implementation of modding for Armory! See [forum topic](http://forums.armory3d.org/t/im-adding-modding-to-armory/2031?u=zicklag).

Requires corresponding changes in armory3d/iron#49.

Fixes #748.

## Known Issues
* You cannot call `trace()` directly in mods. You have to call `Log.trace()`. I don't know exactly why this is. I will look into fixing it some time.
* When using the Forward renderer, objects spawned from mods render shadeless. I don't know much about the RenderPath system so I don't know how to go about fixing this one. It might just go away once Armory 0.6 gets more stable.