### PR TITLE
Allow Arbitrary Category Names for Nodes

### DIFF
--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -5,19 +5,6 @@ import arm.utils
 
 nodes = []
 category_items = {}
-category_items['Logic'] = []
-category_items['Event'] = []
-category_items['Action'] = []
-category_items['Value'] = []
-category_items['Variable'] = []
-category_items['Input'] = []
-category_items['Array'] = []
-category_items['Animation'] = []
-category_items['Physics'] = []
-category_items['Navmesh'] = []
-category_items['Sound'] = []
-category_items['Native'] = []
-category_items['Canvas'] = []
 
 object_sockets = dict()
 array_nodes = dict()
@@ -242,6 +229,8 @@ class ArmNodeRemoveInputOutputButton(bpy.types.Operator):
 def add_node(node_class, category):
     global nodes
     nodes.append(node_class)
+    if category_items.get(category) == None:
+        category_items[category] = []
     category_items[category].append(NodeItem(node_class.bl_idname))
 
 bpy.utils.register_class(ArmActionSocket)

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -30,21 +30,12 @@ def register_nodes():
         registered_nodes.append(n)
         bpy.utils.register_class(n)
 
-    node_categories = [
-        LogicNodeCategory('LogicLogicNodes', 'Logic', items=arm_nodes.category_items['Logic']),
-        LogicNodeCategory('LogicEventNodes', 'Event', items=arm_nodes.category_items['Event']),
-        LogicNodeCategory('LogicActionNodes', 'Action', items=arm_nodes.category_items['Action']),
-        LogicNodeCategory('LogicValueNodes', 'Value', items=arm_nodes.category_items['Value']),
-        LogicNodeCategory('LogicVariableNodes', 'Variable', items=arm_nodes.category_items['Variable']),
-        LogicNodeCategory('LogicInputNodes', 'Input', items=arm_nodes.category_items['Input']),
-        LogicNodeCategory('LogicArrayNodes', 'Array', items=arm_nodes.category_items['Array']),
-        LogicNodeCategory('LogicAnimationNodes', 'Animation', items=arm_nodes.category_items['Animation']),
-        LogicNodeCategory('LogicPhysicsNodes', 'Physics', items=arm_nodes.category_items['Physics']),
-        LogicNodeCategory('LogicNavmeshNodes', 'Navmesh', items=arm_nodes.category_items['Navmesh']),
-        LogicNodeCategory('LogicSoundNodes', 'Sound', items=arm_nodes.category_items['Sound']),
-        LogicNodeCategory('LogicNativeNodes', 'Native', items=arm_nodes.category_items['Native']),
-        LogicNodeCategory('LogicCanvasNodes', 'Canvas', items=arm_nodes.category_items['Canvas']),
-    ]
+    node_categories = []
+
+    for category in sorted(arm_nodes.category_items):
+        node_categories.append(
+            LogicNodeCategory('Logic' + category + 'Nodes', category, items=arm_nodes.category_items[category])
+        )
 
     nodeitems_utils.register_node_categories('ArmLogicNodes', node_categories)
 


### PR DESCRIPTION
Logic node categories are now created dynamically. This allows nodes be added to any arbitrarily named categories without having to maintain a global category list. This is useful because it allows custom logic nodes to be added to custom categories.