### PR TITLE
Make the Output of the Look At Node Euler Rotation

### DIFF
--- a/Sources/armory/logicnode/LookAtNode.hx
+++ b/Sources/armory/logicnode/LookAtNode.hx
@@ -23,6 +23,6 @@ class LookAtNode extends LogicNode {
 		v2.setFrom(vto).sub(vfrom).normalize();
 
 		q.fromTo(v1, v2);
-		return q;
+		return q.getEuler();
 	}
 }


### PR DESCRIPTION
The Look At node previously output a quat for the rotation, which is
inconsistent and incompatible with the other logic nodes such as
Set Rotation.