### PR TITLE
Remove double .json extension

### DIFF
--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -122,12 +122,8 @@ def parse(material, mat_data, mat_users, mat_armusers):
             const['name'] = 'receiveShadow'
             const['bool'] = material.arm_receive_shadow
             c['bind_constants'].append(const)
-    
-    shader_file_name = shader_data_name
-    if material.arm_custom_material != '':
-        shader_file_name += '.json'
 
     ext = '' if wrd.arm_minimize else '.json'
-    mat_data['shader'] = shader_file_name + ext + '/' + shader_data_name
+    mat_data['shader'] = shader_data_name + ext + '/' + shader_data_name
 
     return sd, rpasses


### PR DESCRIPTION
## Steps

1. Create a new material
2. Set Custom Material (eg.: MyCustomMaterial)
3. Hit F5 to play
4. Crash (Cannot find MyCustomMaterial.json.json)