### PR TITLE
Update utils.py

### DIFF
--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -12,6 +12,11 @@ import arm.lib.armpack
 import arm.make_state as state
 import arm.log as log
 
+if blenderVersion.find('2.7') != -1:
+    user_preferences = bpy.context.user_preferences
+elif blenderVersion.find('2.8') != -1:
+    user_preferences = bpy.context.preferences
+
 class NumpyEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
@@ -116,7 +121,6 @@ def bundled_sdk_path():
 # Passed by load_post handler when armsdk is found in project folder
 use_local_sdk = False
 def get_sdk_path():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons["armory"].preferences
     p = bundled_sdk_path()
     if use_local_sdk:
@@ -127,12 +131,10 @@ def get_sdk_path():
         return addon_prefs.sdk_path
 
 def get_ffmpeg_path():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     return addon_prefs.ffmpeg_path
 
 def get_renderdoc_path():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     p = addon_prefs.renderdoc_path
     if p == '' and get_os() == 'win':
@@ -142,43 +144,35 @@ def get_renderdoc_path():
     return p
 
 def get_player_gapi():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     return 'opengl' if not hasattr(addon_prefs, 'player_gapi_' + get_os()) else getattr(addon_prefs, 'player_gapi_' + get_os())
 
 def get_code_editor():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     return 'kodestudio' if not hasattr(addon_prefs, 'code_editor') else addon_prefs.code_editor
 
 def get_ui_scale():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     return 1.0 if not hasattr(addon_prefs, 'ui_scale') else addon_prefs.ui_scale
 
 def get_khamake_threads():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     return 1 if not hasattr(addon_prefs, 'khamake_threads') else addon_prefs.khamake_threads
 
 def get_save_on_build():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     return True if not hasattr(addon_prefs, 'save_on_build') else addon_prefs.save_on_build
 
 def get_viewport_controls():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     return 'qwerty' if not hasattr(addon_prefs, 'viewport_controls') else addon_prefs.viewport_controls
 
 def get_legacy_shaders():
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     return False if not hasattr(addon_prefs, 'legacy_shaders') else addon_prefs.legacy_shaders
 
 def get_relative_paths():
     # Convert absolute paths to relative
-    user_preferences = bpy.context.user_preferences
     addon_prefs = user_preferences.addons['armory'].preferences
     return False if not hasattr(addon_prefs, 'relative_paths') else addon_prefs.relative_paths
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -12,6 +12,7 @@ import arm.lib.armpack
 import arm.make_state as state
 import arm.log as log
 
+blenderVersion = bpy.app.version_string
 if blenderVersion.find('2.7') != -1:
     user_preferences = bpy.context.user_preferences
 elif blenderVersion.find('2.8') != -1:


### PR DESCRIPTION
Stop crashing when starting up Armory in Blender 2.8 as `user_preferences` has been replaced with `preferences` in Blender 2.8.