### PR TITLE
Fix Armory Bake Python Error

### DIFF
--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1002,7 +1002,7 @@ class ArmBakePanel(bpy.types.Panel):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
-        scn = context.scene
+        scn = bpy.data.scenes[context.scene.name]
 
         row = layout.row(align=True)
         row.alignment = 'EXPAND'
@@ -1034,7 +1034,7 @@ class ArmBakePanel(bpy.types.Panel):
 
         if scn.arm_bakelist_index >= 0 and len(scn.arm_bakelist) > 0:
             item = scn.arm_bakelist[scn.arm_bakelist_index]
-            layout.prop_search(item, "object_name", scn, "objects", text="Object")
+            layout.prop_search(item, "obj", bpy.data, "objects", text="Object")
             layout.prop(item, "res_x")
             layout.prop(item, "res_y")
 


### PR DESCRIPTION
From forum topic:
http://forums.armory3d.org/t/cnt-bake-traceback-error-comes-always/2451?u=zicklag

In [this](https://github.com/armory3d/armory/compare/master...katharostech:bug_armory-bake?diff=split&expand=1#diff-6c28ad04114826c2ba032cdea128c144L1037) line I removed the scene context for the Armory bake object search, which means that objects in the current or any scene will be included in the object search. I did this because there seems to be some kind of bug where you can't select the object from the dropdown when you use the `bpy.context.scene` as the search object.