### PR TITLE
Update Make Proxy script for Blender 2.8

### DIFF
--- a/blender/arm/proxy.py
+++ b/blender/arm/proxy.py
@@ -14,16 +14,16 @@ def traverse(obj, is_parent=False):
 
     override = bpy.context.copy()
     override['object'] = obj
-    bpy.context.scene.objects.active = obj
+    bpy.context.view_layer.objects.active = obj
     bpy.ops.object.proxy_make(override)
 
     # Reparent created proxies
     for c in obj.children:
         if c.proxy != None:
-            c.parent = bpy.context.scene.objects.active
-            c.matrix_parent_inverse = bpy.context.scene.objects.active.matrix_world.inverted()
+            c.parent = bpy.context.view_layer.objects.active
+            c.matrix_parent_inverse = bpy.context.view_layer.objects.active.matrix_world.inverted()
 
-    active = bpy.context.scene.objects.active
+    active = bpy.context.view_layer.objects.active
     sync_modifiers(active)
     # No transform sync for parent
     if is_parent:


### PR DESCRIPTION
Hey!

I noticed Make Proxy button fails with a stack trace in armory 0.6 alpha (archive downloaded from site) in `armsdk/armory/blender/arm/proxy.py` on line 17.

Looks like `bpy.context.scene.objects.active` is [no longer available](https://docs.blender.org/api/blender2.8/bpy.types.SceneObjects.html#bpy.types.SceneObjects) in Blender 2.8

After a quick search I found people use `context.view_layer.objects.active` [for the same purpose](https://blender.stackexchange.com/questions/126577/blender-2-8-api-python-set-active-object).

I never did extensive testing or research, but this simple fix seems to work for me.