### PR TITLE
Add Late Update and Physics Pre-Update To The On Update Node

### DIFF
--- a/Sources/armory/logicnode/OnUpdateNode.hx
+++ b/Sources/armory/logicnode/OnUpdateNode.hx
@@ -1,11 +1,24 @@
 package armory.logicnode;
 
+import armory.trait.physics.bullet.PhysicsWorld;
+
 class OnUpdateNode extends LogicNode {
+
+	public var property0:String; // Update, Late Update, Physics Pre-Update
 
 	public function new(tree:LogicTree) {
 		super(tree);
+		tree.notifyOnInit(init);
+	}
 
-		tree.notifyOnUpdate(update);
+	function init() {
+		switch (property0) {
+		case "Late Update": tree.notifyOnLateUpdate(update);
+		#if arm_bullet
+		case "Physics Pre-Update": PhysicsWorld.active.notifyOnPreUpdate(update);
+		#end
+		default /* Update */: tree.notifyOnUpdate(update);
+		}
 	}
 
 	function update() {

--- a/blender/arm/logicnode/event_on_update.py
+++ b/blender/arm/logicnode/event_on_update.py
@@ -8,8 +8,16 @@ class OnUpdateNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNOnUpdateNode'
     bl_label = 'On Update'
     bl_icon = 'CURVE_PATH'
+    property0: EnumProperty(
+        items = [('Update', 'Update', 'Update'),
+                 ('Late Update', 'Late Update', 'Late Update'),
+                 ('Physics Pre-Update', 'Physics Pre-Update', 'Physics Pre-Update')],
+        name='On', default='Update')
     
     def init(self, context):
         self.outputs.new('ArmNodeSocketAction', 'Out')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
 
 add_node(OnUpdateNode, category='Event')


### PR DESCRIPTION
I added a dropdown to the On Update node to let you select between On Update, On Late Update, and On Physics Pre-Update. If you would rather these be separate nodes, just tell me and I'll split it out and update the PR.