### PR TITLE
Added support for script subfolder organisation using haxe package syntax

### DIFF
--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -261,7 +261,8 @@ class ArmEditScriptButton(bpy.types.Operator):
             obj = bpy.context.scene
         item = obj.arm_traitlist[obj.arm_traitlist_index]
         pkg = arm.utils.safestr(bpy.data.worlds['Arm'].arm_project_package)
-        hx_path = arm.utils.get_fp() + '/Sources/' + pkg + '/' + item.class_name_prop + '.hx'
+        # Replace the haxe package syntax with the os-dependent path syntax for opening
+        hx_path = arm.utils.get_fp() + '/Sources/' + pkg + '/' + item.class_name_prop.replace('.', os.sep) + '.hx'
         arm.utils.kode_studio(hx_path)
         return{'FINISHED'}
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -282,9 +282,11 @@ def fetch_script_names():
     sources_path = get_fp() + '/Sources/' + safestr(wrd.arm_project_package)
     if os.path.isdir(sources_path):
         os.chdir(sources_path)
-        for file in glob.glob('*.hx'):
+        # Glob supports recursive search since python 3.5 so it should cover both blender 2.79 and 2.8 integrated python
+        for file in glob.glob('**/*.hx', recursive=True):
             name = file.rsplit('.')[0]
-            wrd.arm_scripts_list.add().name = name
+            # Replace the path syntax for package syntax so that it can be searchable in blender traits "Class" dropdown
+            wrd.arm_scripts_list.add().name = name.replace(os.sep, '.')
             fetch_script_props(file)
 
     # Canvas

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -600,14 +600,20 @@ const float voxelgiOffset = """ + str(round(rpdat.arm_voxelgi_offset * 100) / 10
         f.write("""#endif // _COMPILED_GLSL_
 """)
 
-def write_traithx(class_name):
+def write_traithx(class_path):
     wrd = bpy.data.worlds['Arm']
-    package_path = arm.utils.get_fp() + '/Sources/' + arm.utils.safestr(wrd.arm_project_package)
+    # Split the haxe package syntax in components that will compose the path
+    path_components = class_path.split('.')
+    # extract the full file name (file + ext) from the components
+    class_name = path_components[-1]
+    # Create the absolute trait path (os-safe)
+    package_path = os.sep.join([arm.utils.get_fp(), 'Sources', arm.utils.safestr(wrd.arm_project_package)] + path_components[:-1])
     if not os.path.exists(package_path):
         os.makedirs(package_path)
+    package =  '.'.join([arm.utils.safestr(wrd.arm_project_package)] + path_components[:-1]);
     with open(package_path + '/' + class_name + '.hx', 'w') as f:
         f.write(
-"""package """ + arm.utils.safestr(wrd.arm_project_package) + """;
+"""package """ + package + """;
 
 class """ + class_name + """ extends iron.Trait {
 \tpublic function new() {


### PR DESCRIPTION
At the moment there is no way of visually splitting your trait files using subfolders directly from Blender, therefore all the haxe trait files will hang from "Sources/arm".

It would be beneficial specially for maintenance if users were able to split their projects into subfolders that map features/scenes or whatever makes more sense for the creator. Therefore this pull request includes functionality that will allow users to put their traits into subfolders by using haxe package syntax (package example.MyClass;)

This way, when the user creates a new haxe trait in blender, if s/he creates a name such as core.MyTrait, a new haxe script will be automatically created in "Sources/arm/core/" with name "MyTrait.hx" containing the correct package syntax "package arm.core;", that will be searchable in blender and will execute properly from the Armory final product.
The same way if the script name is "test.core.Trait", a trait called "Trait.hx" will be created in the folder "Sources/arm/test/core/", and so on. And if no haxe package syntax is used (no dots in the file name), the file will be created in "Sources/arm/" as usual

Trait creation:
![new_trait](https://user-images.githubusercontent.com/1613216/52055046-96e11e00-255e-11e9-9c92-221995462b68.png)

Searchable:
![searchable](https://user-images.githubusercontent.com/1613216/52055052-9e082c00-255e-11e9-8577-e4a94229d942.png)

Correct source:
![correct_source](https://user-images.githubusercontent.com/1613216/52055315-58982e80-255f-11e9-8156-b881ba3a6128.png)

Correct execution:
![correct_execution](https://user-images.githubusercontent.com/1613216/52055318-5b931f00-255f-11e9-9813-b7f824b894dc.png)

Hope it helps.