### PR TITLE
fix an exception where hitPointWorld gets null.

### DIFF
--- a/Sources/armory/logicnode/CastPhysicsRayNode.hx
+++ b/Sources/armory/logicnode/CastPhysicsRayNode.hx
@@ -25,12 +25,16 @@ class CastPhysicsRayNode extends LogicNode {
 		}
 		else if (from == 1) { // Hit
 			var hitPointWorld:Vec4 = rb != null ? physics.hitPointWorld : null;
-			v.set(hitPointWorld.x, hitPointWorld.y, hitPointWorld.z, 1);
-			return v;
+			if (hitPointWorld != null) {
+				v.set(hitPointWorld.x, hitPointWorld.y, hitPointWorld.z, 1);
+				return v;
+			}
 		} else { // Normal
 			var hitNormalWorld:Vec4 = rb != null ? physics.hitNormalWorld : null;
-			v.set(hitNormalWorld.x, hitNormalWorld.y, hitNormalWorld.z, 0);
-			return v;
+			if (hitNormalWorld != null) {
+				v.set(hitNormalWorld.x, hitNormalWorld.y, hitNormalWorld.z, 0);
+				return v;
+			}
 		}
 #end
 		return null;


### PR DESCRIPTION
...due to too short Rays set by the user.
Suggestion for the fix by zicklag, see here: http://forums.armory3d.org/t/bullet-physics-keeps-freezing-the-games/2925/2
Can confirm its working now.