### PR TITLE
Fix Force, switch X & Y for local, add option for "at location" nodes

### DIFF
--- a/Sources/armory/logicnode/ApplyForceAtLocationNode.hx
+++ b/Sources/armory/logicnode/ApplyForceAtLocationNode.hx
@@ -14,12 +14,23 @@ class ApplyForceAtLocationNode extends LogicNode {
 		var object:Object = inputs[1].get();
 		var force:Vec4 = inputs[2].get();
         var location:Vec4 = inputs[3].get();
+		var local:Bool = inputs.length > 3 ? inputs[3].get() : false;
 		
 		if (object == null || force == null || location == null) return;
 
 #if arm_physics
 		var rb:RigidBody = object.getTrait(RigidBody);
-		rb.applyForce(force, location);
+		if (!local) {
+			rb.applyForce(force, location);
+		}
+		else {
+			var look = object.transform.world.look().mult(force.y);
+			var right = object.transform.world.right().mult(force.x);
+			var up = object.transform.world.up().mult(force.z);
+			rb.applyForce(look, location);
+			rb.applyForce(right, location);
+			rb.applyForce(up, location);
+		}
 #end
 
 		runOutput(0);

--- a/Sources/armory/logicnode/ApplyForceNode.hx
+++ b/Sources/armory/logicnode/ApplyForceNode.hx
@@ -23,12 +23,12 @@ class ApplyForceNode extends LogicNode {
 			rb.applyForce(force);
 		}
 		else {
-			var look = object.transform.world.look().mult(force.x);
-			var right = object.transform.world.right().mult(force.y);
+			var look = object.transform.world.look().mult(force.y);
+			var right = object.transform.world.right().mult(force.x);
 			var up = object.transform.world.up().mult(force.z);
 			rb.applyForce(look);
-			rb.applyImpulse(right);
-			rb.applyImpulse(up);
+			rb.applyForce(right);
+			rb.applyForce(up);
 		}
 #end
 

--- a/Sources/armory/logicnode/ApplyImpulseAtLocationNode.hx
+++ b/Sources/armory/logicnode/ApplyImpulseAtLocationNode.hx
@@ -14,12 +14,22 @@ class ApplyImpulseAtLocationNode extends LogicNode {
 		var object:Object = inputs[1].get();
 		var impulse:Vec4 = inputs[2].get();
 		var location:Vec4 = inputs[3].get();
+		var local:Bool = inputs.length > 3 ? inputs[3].get() : false;
 		
 		if (object == null || impulse == null || location == null) return;
 
 #if arm_physics
 		var rb:RigidBody = object.getTrait(RigidBody);
-		rb.applyImpulse(impulse, location);
+		if (!local) {
+			rb.applyImpulse(impulse, location); }
+		else {
+			var look = object.transform.world.look().mult(impulse.y);
+			var right = object.transform.world.right().mult(impulse.x);
+			var up = object.transform.world.up().mult(impulse.z);
+			rb.applyImpulse(look, location);
+			rb.applyImpulse(right, location);
+			rb.applyImpulse(up, location);
+		}
 #end
 
 		runOutput(0);

--- a/Sources/armory/logicnode/ApplyImpulseNode.hx
+++ b/Sources/armory/logicnode/ApplyImpulseNode.hx
@@ -23,8 +23,8 @@ class ApplyImpulseNode extends LogicNode {
 			rb.applyImpulse(impulse);
 		}
 		else {
-			var look = object.transform.world.look().mult(impulse.x);
-			var right = object.transform.world.right().mult(impulse.y);
+			var look = object.transform.world.look().mult(impulse.y);
+			var right = object.transform.world.right().mult(impulse.x);
 			var up = object.transform.world.up().mult(impulse.z);
 			rb.applyImpulse(look);
 			rb.applyImpulse(right);

--- a/Sources/armory/logicnode/TranslateObjectNode.hx
+++ b/Sources/armory/logicnode/TranslateObjectNode.hx
@@ -23,8 +23,8 @@ class TranslateObjectNode extends LogicNode {
 			object.transform.buildMatrix();
 		}
 		else {
-			var look = object.transform.world.look().mult(vec.x);
-			var right = object.transform.world.right().mult(vec.y);
+			var look = object.transform.world.look().mult(vec.y);
+			var right = object.transform.world.right().mult(vec.x);
 			var up = object.transform.world.up().mult(vec.z);
 			object.transform.loc.add(look);
 			object.transform.loc.add(right);

--- a/blender/arm/logicnode/physics_apply_force_at_location.py
+++ b/blender/arm/logicnode/physics_apply_force_at_location.py
@@ -14,6 +14,7 @@ class ApplyForceAtLocationNode(Node, ArmLogicTreeNode):
         self.inputs.new('ArmNodeSocketObject', 'Object')
         self.inputs.new('NodeSocketVector', 'Force')
         self.inputs.new('NodeSocketVector', 'Location')
+        self.inputs.new('NodeSocketBool', 'On Local Axis')
         self.outputs.new('ArmNodeSocketAction', 'Out')
 
 add_node(ApplyForceAtLocationNode, category='Physics')

--- a/blender/arm/logicnode/physics_apply_impulse_at_location.py
+++ b/blender/arm/logicnode/physics_apply_impulse_at_location.py
@@ -14,6 +14,7 @@ class ApplyImpulseAtLocationNode(Node, ArmLogicTreeNode):
         self.inputs.new('ArmNodeSocketObject', 'Object')
         self.inputs.new('NodeSocketVector', 'Impulse')
         self.inputs.new('NodeSocketVector', 'Location')
+        self.inputs.new('NodeSocketBool', 'On Local Axis')
         self.outputs.new('ArmNodeSocketAction', 'Out')
 
 add_node(ApplyImpulseAtLocationNode, category='Physics')


### PR DESCRIPTION
1. The apply force node used applyImpulse for y and z. Fixed now.
2. In all nodes with the "local" option Y+ (instead of X+) is now look (or forward), as it traditionally is.
3. Apply Force/Impulse at Location now has the local option too.
