### PR TITLE
auto replace properties

### DIFF
--- a/Sources/armory/logicnode/MergedGamepadNode.hx
+++ b/Sources/armory/logicnode/MergedGamepadNode.hx
@@ -1,6 +1,6 @@
 package armory.logicnode;
 
-class GamepadNode extends LogicNode {
+class MergedGamepadNode extends LogicNode {
 
 	public var property0:String;
 	public var property1:String;

--- a/Sources/armory/logicnode/MergedKeyboardNode.hx
+++ b/Sources/armory/logicnode/MergedKeyboardNode.hx
@@ -1,6 +1,6 @@
 package armory.logicnode;
 
-class KeyboardNode extends LogicNode {
+class MergedKeyboardNode extends LogicNode {
 
 	public var property0:String;
 	public var property1:String;

--- a/Sources/armory/logicnode/MergedMouseNode.hx
+++ b/Sources/armory/logicnode/MergedMouseNode.hx
@@ -1,6 +1,6 @@
 package armory.logicnode;
 
-class MouseNode extends LogicNode {
+class MergedMouseNode extends LogicNode {
 
 	public var property0:String;
 	public var property1:String;

--- a/Sources/armory/logicnode/MergedSurfaceNode.hx
+++ b/Sources/armory/logicnode/MergedSurfaceNode.hx
@@ -1,6 +1,6 @@
 package armory.logicnode;
 
-class SurfaceNode extends LogicNode {
+class MergedSurfaceNode extends LogicNode {
 
 	public var property0:String;
 

--- a/Sources/armory/logicnode/MergedVirtualButtonNode.hx
+++ b/Sources/armory/logicnode/MergedVirtualButtonNode.hx
@@ -1,6 +1,6 @@
 package armory.logicnode;
 
-class VirtualButtonNode extends LogicNode {
+class MergedVirtualButtonNode extends LogicNode {
 
 	public var property0:String;
 	public var property1:String;

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -124,11 +124,12 @@ class Replacement:
     # to_node: the node type which takes from_node's place
     # *SocketMapping: a map which defines how the sockets of the old node shall be connected to the new node
     # {1: 2} means that anything connected to the socket with index 1 on the original node will be connected to the socket with index 2 on the new node
-    def __init__(self, from_node, to_node, in_socket_mapping, out_socket_mapping):
+    def __init__(self, from_node, to_node, in_socket_mapping, out_socket_mapping, property_mapping):
         self.from_node = from_node
         self.to_node = to_node
         self.in_socket_mapping = in_socket_mapping
         self.out_socket_mapping = out_socket_mapping
+        self.property_mapping = property_mapping
 
 # actual replacement code
 def replace(tree, node):
@@ -136,6 +137,10 @@ def replace(tree, node):
     newnode = tree.nodes.new(replacement.to_node)
     newnode.location = node.location
     newnode.parent = node.parent
+
+    # map properties
+    for prop in replacement.property_mapping.keys():
+        setattr(newnode, replacement.property_mapping.get(prop), getattr(node, prop))
 
     parent = node.parent
     while parent is not None:
@@ -186,20 +191,20 @@ class ReplaceNodesOperator(bpy.types.Operator):
         return context.space_data != None and context.space_data.type == 'NODE_EDITOR'
 
 # Input Replacement Rules
-add_replacement(Replacement("LNOnGamepadNode", "LNMergedGamepadNode", {}, {0: 0}))
-add_replacement(Replacement("LNGamepadNode", "LNMergedGamepadNode", {}, {0: 1}))
+add_replacement(Replacement("LNOnGamepadNode", "LNMergedGamepadNode", {}, {0: 0}, {"property0": "property0", "property1": "property1"}))
+add_replacement(Replacement("LNGamepadNode", "LNMergedGamepadNode", {}, {0: 1}, {"property0": "property0", "property1": "property1"}))
 
-add_replacement(Replacement("LNOnMouseNode", "LNMergedMouseNode", {}, {0: 0}))
-add_replacement(Replacement("LNMouseNode", "LNMergedMouseNode", {}, {0: 1}))
+add_replacement(Replacement("LNOnMouseNode", "LNMergedMouseNode", {}, {0: 0}, {"property0": "property0", "property1": "property1"}))
+add_replacement(Replacement("LNMouseNode", "LNMergedMouseNode", {}, {0: 1}, {"property0": "property0", "property1": "property1"}))
 
-add_replacement(Replacement("LNOnSurfaceNode", "LNMergedSurfaceNode", {}, {0: 0}))
-add_replacement(Replacement("LNSurfaceNode", "LNMergedSurfaceNode", {}, {0: 1}))
+add_replacement(Replacement("LNOnSurfaceNode", "LNMergedSurfaceNode", {}, {0: 0}, {"property0": "property0", "property1": "property1"}))
+add_replacement(Replacement("LNSurfaceNode", "LNMergedSurfaceNode", {}, {0: 1}, {"property0": "property0", "property1": "property1"}))
 
-add_replacement(Replacement("LNOnKeyboardNode", "LNMergedKeyboardNode", {}, {0: 0}))
-add_replacement(Replacement("LNKeyboardNode", "LNMergedKeyboardNode", {}, {0: 1}))
+add_replacement(Replacement("LNOnKeyboardNode", "LNMergedKeyboardNode", {}, {0: 0}, {"property0": "property0", "property1": "property1"}))
+add_replacement(Replacement("LNKeyboardNode", "LNMergedKeyboardNode", {}, {0: 1}, {"property0": "property0", "property1": "property1"}))
 
-add_replacement(Replacement("LNOnVirtualButtonNode", "LNMergedVirtualButtonNode", {}, {0: 0}))
-add_replacement(Replacement("LNVirtualButtonNode", "LNMergedVirtualButtonNode", {}, {0: 1}))
+add_replacement(Replacement("LNOnVirtualButtonNode", "LNMergedVirtualButtonNode", {}, {0: 0}, {"property0": "property0", "property1": "property1"}))
+add_replacement(Replacement("LNVirtualButtonNode", "LNMergedVirtualButtonNode", {}, {0: 1}, {"property0": "property0", "property1": "property1"}))
 
 def register():
     bpy.utils.register_class(ArmLogicTree)

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -138,16 +138,23 @@ def replace(tree, node):
     newnode.location = node.location
     newnode.parent = node.parent
 
-    # map properties
-    for prop in replacement.property_mapping.keys():
-        setattr(newnode, replacement.property_mapping.get(prop), getattr(node, prop))
-
     parent = node.parent
     while parent is not None:
         newnode.location[0] += parent.location[0]
         newnode.location[1] += parent.location[1]
         parent = parent.parent
     
+    
+    # map properties
+    for prop in replacement.property_mapping.keys():
+        setattr(newnode, replacement.property_mapping.get(prop), getattr(node, prop))
+    
+    # map unconnected inputs
+    for in_socket in replacement.in_socket_mapping.keys():
+        if not node.inputs[in_socket].is_linked:
+            newnode.inputs[replacement.in_socket_mapping.get(in_socket)].default_value = node.inputs[in_socket].default_value
+    
+    # map connected inputs
     for link in tree.links:
         if link.from_node == node:
             # this is an output link
@@ -191,14 +198,14 @@ class ReplaceNodesOperator(bpy.types.Operator):
         return context.space_data != None and context.space_data.type == 'NODE_EDITOR'
 
 # Input Replacement Rules
-add_replacement(Replacement("LNOnGamepadNode", "LNMergedGamepadNode", {}, {0: 0}, {"property0": "property0", "property1": "property1"}))
-add_replacement(Replacement("LNGamepadNode", "LNMergedGamepadNode", {}, {0: 1}, {"property0": "property0", "property1": "property1"}))
+add_replacement(Replacement("LNOnGamepadNode", "LNMergedGamepadNode", {0: 0}, {0: 0}, {"property0": "property0", "property1": "property1"}))
+add_replacement(Replacement("LNGamepadNode", "LNMergedGamepadNode", {0: 0}, {0: 1}, {"property0": "property0", "property1": "property1"}))
 
 add_replacement(Replacement("LNOnMouseNode", "LNMergedMouseNode", {}, {0: 0}, {"property0": "property0", "property1": "property1"}))
 add_replacement(Replacement("LNMouseNode", "LNMergedMouseNode", {}, {0: 1}, {"property0": "property0", "property1": "property1"}))
 
-add_replacement(Replacement("LNOnSurfaceNode", "LNMergedSurfaceNode", {}, {0: 0}, {"property0": "property0", "property1": "property1"}))
-add_replacement(Replacement("LNSurfaceNode", "LNMergedSurfaceNode", {}, {0: 1}, {"property0": "property0", "property1": "property1"}))
+add_replacement(Replacement("LNOnSurfaceNode", "LNMergedSurfaceNode", {}, {0: 0}, {"property0": "property0"}))
+add_replacement(Replacement("LNSurfaceNode", "LNMergedSurfaceNode", {}, {0: 1}, {"property0": "property0"}))
 
 add_replacement(Replacement("LNOnKeyboardNode", "LNMergedKeyboardNode", {}, {0: 0}, {"property0": "property0", "property1": "property1"}))
 add_replacement(Replacement("LNKeyboardNode", "LNMergedKeyboardNode", {}, {0: 1}, {"property0": "property0", "property1": "property1"}))


### PR DESCRIPTION
(Sorry for spamming the pull requests...)
I added the ability to map properties (which is especially important for the input nodes, since they would be resetted otherwise) and to map unconnected sockets as well.
I also realized that since the bl_idname is different now, I also had to rename the haxe classes.