### PR TITLE
small fix for rotate around axis node

### DIFF
--- a/Sources/armory/logicnode/RotateObjectAroundAxisNode.hx
+++ b/Sources/armory/logicnode/RotateObjectAroundAxisNode.hx
@@ -12,13 +12,13 @@ class RotateObjectAroundAxisNode extends LogicNode {
 
 	override function run(from:Int) {
 		var object:Object = inputs[1].get();
-		var axis:Vec4 = inputs[2].get().normalize();
+		var axis:Vec4 = inputs[2].get();
 		var angle:Float = inputs[3].get();
 
 		if (object == null || axis == null) return;
 
 		// the rotate function already calls buildMatrix
-		object.transform.rotate(axis, angle);
+		object.transform.rotate(axis.normalize(), angle);
 
 		#if arm_physics
 		var rigidBody = object.getTrait(RigidBody);


### PR DESCRIPTION
this seems to fix the issue in http://forums.armory3d.org/t/fly-through-navigation-controller-how-to-adjust-axis-for-forward-and-back-movement/3038/7 for me.
The error which showed up in the web console stated that inputs[2].get().normalize was not a function.
I guess that inputs[2].get().normalize() might have created issues due to a null value...

It is weird though that this only happened when using the html5 exporter... F5 with Krom and Browser worked fine.