### PR TITLE
Add a function to find a rigidBody by their id

### DIFF
--- a/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
+++ b/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
@@ -225,6 +225,12 @@ class PhysicsWorld extends Trait {
 		}
 		return res;
 	}
+	
+	public function findBody(id:Int):RigidBody{
+		if (rbMap.length == 0) return null;
+		var rb = rbMap.get(id);
+		return rb;
+	}
 
 	function lateUpdate() {
 		var t = Time.delta * timeScale;


### PR DESCRIPTION
I'm not sure why contactPairs stores ids instead of storing the references to the rigidBodies directly, so I added a function that lets you quickly search a rigidbody with the ids you would get by getContactPairs