### PR TITLE
hotfix, no length property on map

### DIFF
--- a/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
+++ b/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
@@ -227,7 +227,6 @@ class PhysicsWorld extends Trait {
 	}
 	
 	public function findBody(id:Int):RigidBody{
-		if (rbMap.length == 0) return null;
 		var rb = rbMap.get(id);
 		return rb;
 	}


### PR DESCRIPTION
Sorry I added that length check last minute to be sure but didn't test, it seems it doesn't have length prop, but without that check should be fine.