### PR TITLE
 expand the info raycast returns

### DIFF
--- a/Sources/armory/logicnode/CastPhysicsRayNode.hx
+++ b/Sources/armory/logicnode/CastPhysicsRayNode.hx
@@ -18,7 +18,8 @@ class CastPhysicsRayNode extends LogicNode {
 
 #if arm_physics
 		var physics = armory.trait.physics.PhysicsWorld.active;
-		var rb = physics.rayCast(vfrom, vto);
+		var hit = physics.rayCast(vfrom, vto);
+		var rb = (hit != null) ? hit.rb : null;
 
 		if (from == 0) { // Object
 			if (rb != null) return rb.object;


### PR DESCRIPTION
This change will allow to get the position of a hit with raycast, the normal and the body, some extra info that otherwise you couldn't obtain because raycast only returns a body, this may break some compat but I think is better than having multiple functions that do the same logic only for obtaining each piece of information separated (to keep compatibility).