### PR TITLE
Allow reading props from scripts in subfolders

### DIFF
--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -233,11 +233,11 @@ script_props = {}
 script_props_defaults = {}
 def fetch_script_props(file):
     with open(file) as f:
-        if '/' in file:
-            file = file.split('/')[-1]
-        if '\\' in file:
-            file = file.split('\\')[-1]
         name = file.rsplit('.')[0]
+        if '/' in name:
+            name = name.replace('/','.')
+        if '\\' in file:
+            name = name.replace('\\','.')
         script_props[name] = []
         script_props_defaults[name] = []
         lines = f.read().splitlines()

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -234,6 +234,8 @@ script_props_defaults = {}
 def fetch_script_props(file):
     with open(file) as f:
         name = file.rsplit('.')[0]
+        if 'Sources' in name:
+            name = name[name.index('Sources')+8:]
         if '/' in name:
             name = name.replace('/','.')
         if '\\' in file:


### PR DESCRIPTION
if a file is created with a name like "test.folder.scripts.MyTrait" in the new script window, it will be stored in script_props and script_props_defaults with that full name, instead of just "MyTrait".

fixes this: https://github.com/armory3d/armory/issues/1306