### PR TITLE
Improve reroute handling in logic nodes

### DIFF
--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -181,9 +181,9 @@ def build_node(node, f):
         if out.is_linked:
             out_name = ''
             for l in out.links:
-                n = l.to_node
-                out_name += '[' if len(out_name) == 0 else ', '
-                out_name += build_node(n, f)
+                for output in collect_outputs_from_link(l, f):
+                    out_name += '[' if len(out_name) == 0 else ', '
+                    out_name += output
             out_name += ']'
         # Not linked - create node with default values
         else:
@@ -192,6 +192,25 @@ def build_node(node, f):
         f.write('\t\t' + name + '.addOutputs(' + out_name + ');\n')
 
     return name
+
+# If the given link points to a reroute, the outgoings links of that reroute will be recursively checked.
+# Otherwise, the node that this link points to will be added to a list and returned.
+def collect_outputs_from_link(link, f):
+    outputs = []
+    n = link.to_node
+    if n.type == 'REROUTE':
+        # if this link points to a reroute
+        for out in n.outputs:
+            # check whether its output (it should have only one)
+            if out.is_linked:
+                # is connected to some other nodes
+                for l in out.links:
+                    # for any of the links collect the potential output nodes
+                    outputs = outputs + collect_outputs_from_link(l, f)
+    else:
+        # if we reached a "normal" node, add it
+        outputs.append(build_node(n, f))
+    return outputs
     
 def get_root_nodes(node_group):
     roots = []

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -196,8 +196,10 @@ def build_node(node, f):
 
     return name
 
-# If the given link points to a reroute, the outgoings links of that reroute will be recursively checked.
-# Otherwise, the node that this link points to will be added to a list and returned.
+# Expects an output socket
+# It first checks all outgoing links for non-reroute nodes and adds them to a list
+# Then it recursively checks all the discoverey reroute nodes
+# Returns all non reroute nodes which are directly or indirectly connected to this output.
 def collect_nodes_from_output(out, f):
     outputs = []
     reroutes = []


### PR DESCRIPTION
This PR addresses an issue with reroutes.
In the creating outputs stage of the `build_node` function, it previously checked whether an output was linked and then added the result of `build_node` to the outputs array.
While `build_node` correctly handled reroutes as inputs, this didn't seem to work when collecting the outputs.

This PR introduces a new recursive `collect_outputs_from_link` function, which takes an (outgoing) link and recursively adds all non-reroute nodes to an array, which is then returned.
The create outputs in `build_node` was modified to use these instead of the raw links.


![grafik](https://user-images.githubusercontent.com/39460066/61595860-aaf80500-abfc-11e9-8d6c-222a7180977a.png)
For testing I hooked up a keyboard node to a print node through two reroutes.
With the original exporter, this was produced:
`_Keyboard.addOutputs([_Keyboard]);`
As can be easily seen, there is no print node, but the keyboard is being added as its own output... I guess this is because of how the reroutes are being handled in the beginning of the `build_node` function:
```
if node.type == 'REROUTE':
        if len(node.inputs) > 0 and len(node.inputs[0].links) > 0:
            return build_node(node.inputs[0].links[0].from_node, f)
        else:
            return None
```
it seems to only work in the "input direction".
Thus, when the create output stage would have called `build_node` on the reroute, it would have just returned the keyboard node...

With this change, this should be produced
`_Keyboard.addOutputs([_Print]);`

Now all of this seems to be working fine:
![grafik](https://user-images.githubusercontent.com/39460066/61595875-e0045780-abfc-11e9-9ddd-5a83e63bc132.png)

There is a Keyboard with an arbitrarily large number of reroutes, some aren't even attached to anything. There is a keyboard with no reroute, a completely unconnected keyboard, and an alternate node with reroutes at one output.
In case of the alternate node, it will run "hello" and "world" at the same time, which is the desired behavior.

One last thing: currently, pressing space will result in "b", "true" and "a" in that order. Thus I assume, that in a chain of reroutes, the nodes attached to the "last" reroute (the one being the furthest away) will be executed first. If we were to invert the list in the for loop (line 184), we could probably guarantee that nodes will be executed in the exact order as they are attached to the reroute chain. While not really necessary, this could be used as an implicit sequence node, to improve readability in some cases.
However, whenever the chain "splits" (into two new chains), there would be no guarantee which of these would be executed first...