### PR TITLE
update for navmesh generation

### DIFF
--- a/Sources/armory/trait/NavAgent.hx
+++ b/Sources/armory/trait/NavAgent.hx
@@ -57,8 +57,7 @@ class NavAgent extends Trait {
 
 		orient.subvecs(p, object.transform.loc).normalize;
 		var targetAngle = Math.atan2(orient.y, orient.x) + Math.PI / 2;
-
-		locAnim = Tween.to({ target: object.transform.loc, props: { x: p.x, y: p.y /*, z: p.z*/ }, duration: dist / speed, done: function() {
+		locAnim = Tween.to({ target: object.transform.loc, props: { x: p.x, y: p.y , z: p.z }, duration: dist / speed, done: function() {
 			index++;
 			if (index < path.length) go();
 			else removeUpdate(update);

--- a/Sources/armory/trait/NavMesh.hx
+++ b/Sources/armory/trait/NavMesh.hx
@@ -15,6 +15,20 @@ class NavMesh extends Trait {
 	public function new() { super(); }
 #else
 
+	// recast config:
+	@prop
+	public var cellSize:Float = 0.3; // voxelization cell size 
+	@prop
+	public var cellHeight:Float = 0.2; // voxelization cell height
+	@prop
+	public var agentHeight:Float = 2.0; // agent capsule height
+	@prop
+	public var agentRadius:Float = 0.4; // agent capsule radius
+	@prop
+	public var agentMaxClimb:Float = 0.9; // how high steps agents can climb, in voxels
+	@prop
+	public var agentMaxSlope:Float = 45.0; // maximum slope angle, in degrees
+
 	var recast:Recast = null;
 	var ready = false;
 
@@ -33,6 +47,17 @@ class NavMesh extends Trait {
 
 			recast = Navigation.active.recast;
 			recast.OBJDataLoader(b.toString(), function() {
+
+				var settings = [
+				'cellSize' => cellSize,
+				'cellHeight' => cellHeight,
+				'agentHeight' => agentHeight,
+				'agentRadius' => agentRadius,
+				'agentMaxClimb' => agentMaxClimb,
+				'agentMaxSlope' => agentMaxSlope,
+				];
+				recast.settings(settings);
+
 				recast.buildSolo();
 				ready = true;
 			});
@@ -43,7 +68,7 @@ class NavMesh extends Trait {
 		if (!ready) return;
 		recast.findPath(from.x, from.z, from.y, to.x, to.z, to.y, 200, function(path:Array<RecastWaypoint>) {
 			var ar:Array<Vec4> = [];
-			for (p in path) ar.push(new Vec4(p.x, p.z, -p.y));
+			for (p in path) ar.push(new Vec4(p.x, p.z, (p.y + 1.1)));
 			done(ar);
 		});
 	}

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -434,72 +434,6 @@ class ArmVirtualInputPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
 
-class ARM_PT_NavigationPanel(bpy.types.Panel):
-    bl_label = "Armory Navigation"
-    bl_space_type = "PROPERTIES"
-    bl_region_type = "WINDOW"
-    bl_context = "scene"
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-        scene = bpy.context.scene
-        if scene == None:
-            return
-
-        layout.operator("arm.generate_navmesh")
-        layout.operator("arm.remove_navmesh")
-
-class ArmoryGenerateNavmeshButton(bpy.types.Operator):
-    '''Generate navmesh from selected meshes'''
-    bl_idname = 'arm.generate_navmesh'
-    bl_label = 'Generate Navmesh'
-
-    def execute(self, context):
-        obj = context.active_object
-        if obj == None or obj.type != 'MESH':
-            return{'CANCELLED'}
-
-        # Prevent duplicates
-        for t in obj.arm_traitlist:
-            if t.class_name_prop == 'NavMesh':
-                return{'FINISHED'}
-
-        # TODO: build tilecache here
-
-        # Navmesh trait
-        obj.arm_traitlist.add()
-        obj.arm_traitlist[-1].type_prop = 'Bundled Script'
-        obj.arm_traitlist[-1].class_name_prop = 'NavMesh'
-
-        # For visualization
-        # Removed in b28
-        # bpy.ops.mesh.navmesh_make('EXEC_DEFAULT')
-        # obj = context.active_object
-        # obj.hide_render = True
-        # obj.arm_export = False
-
-        return{'FINISHED'}
-
-class ArmoryRemoveNavmeshButton(bpy.types.Operator):
-    '''Remove generated navmesh from selected mesh'''
-    bl_idname = 'arm.remove_navmesh'
-    bl_label = 'Remove Navmesh'
-
-    def execute(self, context):
-        obj = context.active_object
-        if obj == None or obj.type != 'MESH':
-            return{'CANCELLED'}
-
-        # Navmesh trait
-        for i in range(len(obj.arm_traitlist)):
-            if obj.arm_traitlist[i].class_name_prop == 'NavMesh':
-                obj.arm_traitlist.remove(i)
-                break
-
-        return{'FINISHED'}
-
 class ArmoryPlayButton(bpy.types.Operator):
     '''Launch player in new window'''
     bl_idname = 'arm.play'
@@ -1492,9 +1426,6 @@ def register():
     bpy.utils.register_class(CleanButtonMenu)
     bpy.utils.register_class(ArmoryCleanProjectButton)
     bpy.utils.register_class(ArmoryPublishProjectButton)
-    bpy.utils.register_class(ArmoryGenerateNavmeshButton)
-    bpy.utils.register_class(ArmoryRemoveNavmeshButton)
-    bpy.utils.register_class(ARM_PT_NavigationPanel)
     bpy.utils.register_class(ArmGenLodButton)
     bpy.utils.register_class(ARM_PT_LodPanel)
     bpy.utils.register_class(ArmGenTerrainButton)
@@ -1545,9 +1476,6 @@ def unregister():
     bpy.utils.unregister_class(CleanButtonMenu)
     bpy.utils.unregister_class(ArmoryCleanProjectButton)
     bpy.utils.unregister_class(ArmoryPublishProjectButton)
-    bpy.utils.unregister_class(ArmoryGenerateNavmeshButton)
-    bpy.utils.unregister_class(ArmoryRemoveNavmeshButton)
-    bpy.utils.unregister_class(ARM_PT_NavigationPanel)
     bpy.utils.unregister_class(ArmGenLodButton)
     bpy.utils.unregister_class(ARM_PT_LodPanel)
     bpy.utils.unregister_class(ArmGenTerrainButton)


### PR DESCRIPTION
What has changed:
- added back visualization of navmesh generation
- readded navagents moving in the z axis. I tested for a bit and got good results with that small modification, not really sure why it was commented out but will look at it further if the results are not consistent for now.
- added functions to change navmesh generation settings for recast, used in the interface when generating visualization and when running the project
- moved the navmesh generation button for consistency


![image](https://user-images.githubusercontent.com/42382648/62548406-1ec12100-b83d-11e9-86c5-d38afe2d4f53.png)

Depends on:
https://github.com/armory3d/armory_tools/pull/1
https://github.com/armory3d/haxerecast/pull/1

I tried to do some threading to prevent the UI to lock but I couldn't get the importing model part to work with threads so I dropped it for now.
Error catching is missing too, planning to add it in the future with a few other features.