### PR TITLE
Add getElements():Array<TElement> function to CanvasScript

### DIFF
--- a/Sources/armory/trait/internal/CanvasScript.hx
+++ b/Sources/armory/trait/internal/CanvasScript.hx
@@ -65,6 +65,11 @@ class CanvasScript extends Trait {
 		for (e in canvas.elements) if (e.name == name) return e;
 		return null;
 	}
+	
+	// Returns canvas array of elements
+	public function getElements():Array<TElement> {
+		return canvas.elements;
+	}
 
 	// Contains data
 	@:access(zui.Canvas)


### PR DESCRIPTION
Adding getElements() function to CanvasScript, it can be a handy method for this Trait. Sometimes we would need to iterate all elements attached to a Canvas without having to call one by one using getElement(name:String)