### PR TITLE
Add Sublime Text as a supported text editor

### DIFF
--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -313,7 +313,7 @@ class ArmoryGenerateNavmeshButton(bpy.types.Operator):
     bl_label = 'Generate Navmesh'
     def execute(self, context):
         obj = context.active_object
-        
+
         if obj.type != 'MESH':
             return{'CANCELLED'}
 
@@ -329,10 +329,10 @@ class ArmoryGenerateNavmeshButton(bpy.types.Operator):
         nav_full_path = arm.utils.get_fp_build() + '/compiled/Assets/navigation'
         if not os.path.exists(nav_full_path):
             os.makedirs(nav_full_path)
-        
+
         nav_mesh_name = 'nav_' + obj.data.name
         mesh_path = nav_full_path + '/' + nav_mesh_name + '.obj'
-        
+
         with open(mesh_path, 'w') as f:
             for v in obj.data.vertices:
                 f.write("v %.4f " % (v.co[0] * obj.scale.x))
@@ -343,10 +343,10 @@ class ArmoryGenerateNavmeshButton(bpy.types.Operator):
                 for i in reversed(p.vertices): # Flipped normals
                     f.write(" %d" % (i + 1))
                 f.write("\n")
-        
+
         fp_build_name = arm.utils.get_fp_build().rsplit('/')[-1]
         nav_mesh_path = '/' + fp_build_name + '/compiled/Assets/navigation/' + nav_mesh_name
-       
+
         buildnavjs_path = arm.utils.get_sdk_path() + '/lib/haxerecast/buildnavjs'
 
         # append config values
@@ -372,7 +372,7 @@ class ArmoryGenerateNavmeshButton(bpy.types.Operator):
         navmesh.rotation_euler = (0,0,0)
         navmesh.location = (obj.location.x,obj.location.y,obj.location.z)
         navmesh.arm_export = False
-        
+
         bpy.context.view_layer.objects.active = navmesh
         bpy.ops.object.editmode_toggle()
         bpy.ops.mesh.select_all(action='SELECT')

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -252,18 +252,19 @@ class ArmEditScriptButton(bpy.types.Operator):
         arm.utils.check_default_props()
 
         if not os.path.exists(arm.utils.get_fp() + "/khafile.js"):
-            print('Generating Krom project for Kode Studio')
+            print('Generating Krom project for IDE build configuration')
             make.build('krom')
 
         if self.is_object:
             obj = bpy.context.object
         else:
             obj = bpy.context.scene
+
         item = obj.arm_traitlist[obj.arm_traitlist_index]
         pkg = arm.utils.safestr(bpy.data.worlds['Arm'].arm_project_package)
         # Replace the haxe package syntax with the os-dependent path syntax for opening
         hx_path = arm.utils.get_fp() + '/Sources/' + pkg + '/' + item.class_name_prop.replace('.', os.sep) + '.hx'
-        arm.utils.kode_studio(hx_path)
+        arm.utils.open_editor(hx_path)
         return{'FINISHED'}
 
 class ArmEditBundledScriptButton(bpy.types.Operator):

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -347,7 +347,7 @@ class ARM_PT_ArmoryProjectPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
         row = layout.row(align=True)
-        row.operator("arm.kode_studio")
+        row.operator("arm.open_editor")
         row.operator("arm.open_project_folder", icon="FILE_FOLDER")
 
 class ARM_PT_ProjectFlagsPanel(bpy.types.Panel):
@@ -559,9 +559,9 @@ class ArmoryOpenProjectFolderButton(bpy.types.Operator):
         webbrowser.open('file://' + arm.utils.get_fp())
         return{'FINISHED'}
 
-class ArmoryKodeStudioButton(bpy.types.Operator):
-    '''Launch this project in Kode Studio or VS Code'''
-    bl_idname = 'arm.kode_studio'
+class ArmoryOpenEditorButton(bpy.types.Operator):
+    '''Launch this project in the IDE'''
+    bl_idname = 'arm.open_editor'
     bl_label = 'Code Editor'
     bl_description = 'Open Project in IDE'
 
@@ -572,10 +572,10 @@ class ArmoryKodeStudioButton(bpy.types.Operator):
         arm.utils.check_default_props()
 
         if not os.path.exists(arm.utils.get_fp() + "/khafile.js"):
-            print('Generating Krom project for Kode Studio')
+            print('Generating Krom project for IDE build configuration')
             make.build('krom')
 
-        arm.utils.kode_studio()
+        arm.utils.open_editor()
         return{'FINISHED'}
 
 class CleanMenu(bpy.types.Menu):
@@ -1436,7 +1436,7 @@ def register():
     bpy.utils.register_class(ArmoryStopButton)
     bpy.utils.register_class(ArmoryBuildProjectButton)
     bpy.utils.register_class(ArmoryOpenProjectFolderButton)
-    bpy.utils.register_class(ArmoryKodeStudioButton)
+    bpy.utils.register_class(ArmoryOpenEditorButton)
     bpy.utils.register_class(CleanMenu)
     bpy.utils.register_class(CleanButtonMenu)
     bpy.utils.register_class(ArmoryCleanProjectButton)
@@ -1486,7 +1486,7 @@ def unregister():
     bpy.utils.unregister_class(ArmoryStopButton)
     bpy.utils.unregister_class(ArmoryBuildProjectButton)
     bpy.utils.unregister_class(ArmoryOpenProjectFolderButton)
-    bpy.utils.unregister_class(ArmoryKodeStudioButton)
+    bpy.utils.unregister_class(ArmoryOpenEditorButton)
     bpy.utils.unregister_class(CleanMenu)
     bpy.utils.unregister_class(CleanButtonMenu)
     bpy.utils.unregister_class(ArmoryCleanProjectButton)

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -630,8 +630,11 @@ def generate_sublime_project(subl_project_path):
     print('Generating Sublime Text project file')
 
     project_data = {
-        'folders': [
-            {'path': '.'}
+        "folders": [
+            {
+                "path": ".",
+                "file_exclude_patterns": ["*.blend*", "*.arm"]
+            },
         ],
     }
 


### PR DESCRIPTION
Linked to https://github.com/armory3d/armsdk/pull/5

**This PR adds support for Sublime Text (and other custom code editors). I have reworked the selection menu in the user preferences and the detection of the standard code editor.**

## What has changed:
- Instead of a folder path, the user must now specify the file path to the executable file in the user preferences, so that user-defined editors are also supported.
- Since Kode Studio is no longer included in armsdk, the methods for automatically searching for this editor inside the SDK folder have been removed
- If the user has defined the environment variables "VISUAL" or "EDITOR", these will be considered first when choosing the default editor.
- If Sublime Text is selected, a simple project file is created.

## What is missing so that the PR is ready to merge:
- Test if Mac ~~and Linux~~(https://github.com/armory3d/armory/pull/1381#issuecomment-534611360) still work after the changes. Unfortunately, I only have Windows, so if someone can test it, it would be great.
- Custom build system for sublime text. So far the project can only be built in Blender with F5 or in Kode Studio. @luboslenco Is there a way to build the project using an external script? Then it could be called from Sublime (and more editors in the future).
- What about the mklink methods in utils.py? Are they still needed or why were they commented out?
- Should the editor-related methods in utils.py be moved to their own script? The file becomes more and more cluttered.
- Should we write a tutorial (in the Wiki?) on how to add new editor configurations? Should the system change to make adding editors even easier?