### PR TITLE
Logic node that loads url

### DIFF
--- a/Sources/armory/logicnode/LoadUrlNode.hx
+++ b/Sources/armory/logicnode/LoadUrlNode.hx
@@ -1,0 +1,16 @@
+// This node does not work with Krom. "Browser compilation only" node.
+
+package armory.logicnode;
+
+import kha.System;
+
+class LoadUrlNode extends LogicNode {
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function run(from:Int) {
+		System.loadUrl(inputs[1].get());
+	}
+}

--- a/blender/arm/logicnode/native_loadUrl.py
+++ b/blender/arm/logicnode/native_loadUrl.py
@@ -13,4 +13,4 @@ class LoadUrlNode(Node, ArmLogicTreeNode):
         self.inputs.new('ArmNodeSocketAction', 'In')
         self.inputs.new('NodeSocketString', 'URL')
 
-add_node(LoadUrlNode, category='extension')
+add_node(LoadUrlNode, category='native')

--- a/blender/arm/logicnode/native_loadUrl.py
+++ b/blender/arm/logicnode/native_loadUrl.py
@@ -1,0 +1,16 @@
+import bpy
+from bpy.props import *
+from bpy.types import Node, NodeSocket
+from arm.logicnode.arm_nodes import *
+
+class LoadUrlNode(Node, ArmLogicTreeNode):
+    '''Load Url'''
+    bl_idname = 'LNLoadUrlNode'
+    bl_label = 'Load Url (Browser only)'
+    bl_icon = 'QUESTION'
+
+    def init(self, context):
+        self.inputs.new('ArmNodeSocketAction', 'In')
+        self.inputs.new('NodeSocketString', 'URL')
+
+add_node(LoadUrlNode, category='extension')


### PR DESCRIPTION
This node is dedicated to browser (HTML5) compilation.
Python : native_loadUrl.py
Haxe : LoadUrlNode.hx
Example : LoadUrl.blend

A logic node created with reference to the Haxe code on this page.
http://forums.armory3d.org/t/solved-open-web-browser-showing-url/3499