### PR TITLE
add a triangulation modifier on export

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1191,6 +1191,13 @@ class ArmoryExporter:
         table = objectRef[1]["objectTable"]
         bobject = table[0]
         oid = arm.utils.safestr(objectRef[1]["structName"])
+        
+        # add a standard triangulate modifier
+        tri_mod = bobject.modifiers.new(name="exportTriangulation", type='TRIANGULATE')
+        # try not to mess with the shading
+        tri_mod.quad_method = "FIXED"
+        tri_mod.keep_custom_normals = True
+        self.depsgraph.update()
 
         wrd = bpy.data.worlds['Arm']
         if wrd.arm_single_data_file:
@@ -1316,6 +1323,8 @@ class ArmoryExporter:
 
         if hasattr(bobject, 'evaluated_get'):
             bobject_eval.to_mesh_clear()
+            
+        bobject.modifiers.remove(tri_mod)
 
     def export_light(self, objectRef):
         # This function exports a single light object

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1192,10 +1192,20 @@ class ArmoryExporter:
         bobject = table[0]
         oid = arm.utils.safestr(objectRef[1]["structName"])
         
+        # save current auto smooth values
+        option_smooth = bobject.data.use_auto_smooth
+        option_smooth_angle = bobject.data.auto_smooth_angle
+        
+        # if not yet done, turn on auto smooth with 180 degrees
+        if bobject.data.use_auto_smooth != 1:
+            bobject.data.use_auto_smooth = 1
+            bobject.data.auto_smooth_angle = math.pi
+            
         # add a standard triangulate modifier
         tri_mod = bobject.modifiers.new(name="exportTriangulation", type='TRIANGULATE')
         # try not to mess with the shading
         tri_mod.quad_method = "FIXED"
+        tri_mod.ngon_method = "CLIP"
         tri_mod.keep_custom_normals = True
         self.depsgraph.update()
 
@@ -1324,7 +1334,12 @@ class ArmoryExporter:
         if hasattr(bobject, 'evaluated_get'):
             bobject_eval.to_mesh_clear()
             
+        # remove the temporary triangulation
         bobject.modifiers.remove(tri_mod)
+        
+        # restore auto smooth
+        bobject.data.use_auto_smooth = option_smooth
+        bobject.data.auto_smooth_angle = option_smooth_angle
 
     def export_light(self, objectRef):
         # This function exports a single light object


### PR DESCRIPTION
This should fix issues related to differences in triangulation by adding a temporary triangulation modifier on export to let blender handle mesh triangulation.
Sets the triangulation method to fixed and activates the keep normals option in an attempt to not mess up shading.
I am a little unsure about the `self.depsgraph.update()`, since the ![documentation](https://docs.blender.org/api/blender2.8/bpy.types.Depsgraph.html#bpy.types.Depsgraph.update) of this method says that this `invalidates all references to evaluated data-blocks`, but this didn't seem to be an issue.

Initial idea based on the accepted answer of this ![stackexchange](https://blender.stackexchange.com/questions/71569/how-to-add-modifiers-using-python-script-and-set-parameters?rq=1) thread 

the relevant part of the blender python api https://docs.blender.org/api/current/bpy.types.ObjectModifiers.html#bpy.types.ObjectModifiers