### PR TITLE
Open folder button implimentation

### DIFF
--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -556,7 +556,7 @@ class ArmoryOpenProjectFolderButton(bpy.types.Operator):
         if not arm.utils.check_saved(self):
             return {"CANCELLED"}
 
-        webbrowser.open('file://' + arm.utils.get_fp())
+        arm.utils.open_folder()
         return{'FINISHED'}
 
 class ArmoryKodeStudioButton(bpy.types.Operator):

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -616,8 +616,7 @@ def kode_studio(hx_path=None):
         
 def open_folder():
     if arm.utils.get_os() is 'win':
-        print('not implimented')
-        webbrowser.open('file://' + arm.utils.get_fp())
+        subprocess.Popen('explorer /select,"' + arm.utils.get_fp() + '"')
     if arm.utils.get_os() is 'mac':
         subprocess.Popen(['open', arm.utils.get_fp()])
     if arm.utils.get_os() is 'linux':

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -613,6 +613,17 @@ def kode_studio(hx_path=None):
     else:
         fp = hx_path if hx_path != None else arm.utils.get_fp()
         webbrowser.open('file://' + fp)
+        
+def open_folder():
+    if arm.utils.get_os() is 'win':
+        print('not implimented')
+        webbrowser.open('file://' + arm.utils.get_fp())
+    if arm.utils.get_os() is 'mac':
+        subprocess.Popen(['open', arm.utils.get_fp()])
+    if arm.utils.get_os() is 'linux':
+        subprocess.Popen(['xdg-open', arm.utils.get_fp()])
+    else:
+        webbrowser.open('file://' + arm.utils.get_fp())
 
 def def_strings_to_array(strdefs):
     defs = strdefs.split('_')


### PR DESCRIPTION
Open folder button always opens in a web browser. This pull request will implement it so the default file manager is used to open the folder when open folder button is clicked.

NOTE: I am not sure about the windows implementation, could someone have a look to see if it works