### PR TITLE
Add a restart check in navmesh vis generation

### DIFF
--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -308,12 +308,15 @@ class ArmEditBundledScriptButton(bpy.types.Operator):
 
         return{'FINISHED'}
 
+restart_required = False
+
 class ArmoryGenerateNavmeshButton(bpy.types.Operator):
     '''Generate navmesh from selected meshes'''
     bl_idname = 'arm.generate_navmesh'
     bl_label = 'Generate Navmesh'
     def execute(self, context):
         obj = context.active_object
+        global restart_required
 
         if obj.type != 'MESH':
             return{'CANCELLED'}
@@ -330,6 +333,12 @@ class ArmoryGenerateNavmeshButton(bpy.types.Operator):
         nav_full_path = arm.utils.get_fp_build() + '/compiled/Assets/navigation'
         if not os.path.exists(nav_full_path):
             os.makedirs(nav_full_path)
+            restart_required = True
+        
+        if restart_required:
+            self.report({'ERROR'}, 'Please restart Blender to generate a mesh representation.')
+            print("Failed visualization generation, please restart Blender")
+            return {"CANCELLED"}
 
         nav_mesh_name = 'nav_' + obj.data.name
         mesh_path = nav_full_path + '/' + nav_mesh_name + '.obj'

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -334,6 +334,7 @@ class ArmoryGenerateNavmeshButton(bpy.types.Operator):
         if not os.path.exists(nav_full_path):
             os.makedirs(nav_full_path)
             restart_required = True
+            bpy.ops.wm.save_mainfile()
         
         if restart_required:
             self.report({'ERROR'}, 'Please restart Blender to generate a mesh representation.')


### PR DESCRIPTION
This is for now to prevent the "vertical generation" issue that happens when generating a navmesh representation the first time and failing because of #1377. Not liking the "require a restart" thing as a solution but I didn't find one that is not a workaround yet, so for now this helps...