### PR TITLE
nav update 3

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2418,12 +2418,18 @@ class ArmoryExporter:
                                 # face.v.reverse()
                             # bpy.ops.export_scene.obj(override, use_selection=True, filepath=nav_filepath, check_existing=False, use_normals=False, use_uvs=False, use_materials=False)
                             # bobject.scale.y *= -1
+                            armature = bobject.find_armature()
+                            apply_modifiers = not armature
+
+                            bobject_eval = bobject.evaluated_get(self.depsgraph) if apply_modifiers else bobject
+                            exportMesh = bobject_eval.to_mesh()
+                            
                             with open(nav_filepath, 'w') as f:
-                                for v in bobject.data.vertices:
-                                    f.write("v %.4f " % (v.co[0] * bobject.scale.x))
-                                    f.write("%.4f " % (v.co[2] * bobject.scale.z))
-                                    f.write("%.4f\n" % (v.co[1] * bobject.scale.y)) # Flipped
-                                for p in bobject.data.polygons:
+                                for v in exportMesh.vertices:
+                                    f.write("v %.4f " % (v.co[0] * bobject_eval.scale.x))
+                                    f.write("%.4f " % (v.co[2] * bobject_eval.scale.z))
+                                    f.write("%.4f\n" % (v.co[1] * bobject_eval.scale.y)) # Flipped
+                                for p in exportMesh.polygons:
                                     f.write("f")
                                     for i in reversed(p.vertices): # Flipped normals
                                         f.write(" %d" % (i + 1))


### PR DESCRIPTION
added support for modifiers for navigation meshes in visualization and when playing, 

removed the need to restart blender when creating visualization by calling node directly into the subfolder and fixes https://github.com/armory3d/armory/issues/1377

Depends on this https://github.com/armory3d/haxerecast/pull/4

Example, mesh with multires and boolean modifiers (boolean may allow for less manually obstacle generation)
![](https://media.giphy.com/media/ZFuEXEipnZdBMEiWvY/giphy.gif)
![](https://media.giphy.com/media/U2AY54X4aHna6FGTdU/giphy.gif)
