### PR TITLE
Revert offset to the y value when adding a path navmesh

### DIFF
--- a/Sources/armory/trait/NavMesh.hx
+++ b/Sources/armory/trait/NavMesh.hx
@@ -68,7 +68,7 @@ class NavMesh extends Trait {
 		if (!ready) return;
 		recast.findPath(from.x, from.z, from.y, to.x, to.z, to.y, 200, function(path:Array<RecastWaypoint>) {
 			var ar:Array<Vec4> = [];
-			for (p in path) ar.push(new Vec4(p.x, p.z, (p.y + 1.1)));
+			for (p in path) ar.push(new Vec4(p.x, p.z, p.y));
 			done(ar);
 		});
 	}


### PR DESCRIPTION
This is to revert it to the original without the offset because it has inconsistent results with meshes with almost no height, something that I need to investigate why. 

So for now to keep results consistent it stays without the offset.