### PR TITLE
fix export with a 'zoo collection'

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1763,7 +1763,7 @@ class ArmoryExporter:
         for o in self.meshArray.items():
             self.export_mesh(o, scene)
 
-    def execute(self, context, filepath, scene=None):
+    def execute(self, context, filepath, scene=None, depsgraph=None):
         global current_output
         profile_time = time.time()
 
@@ -1799,7 +1799,7 @@ class ArmoryExporter:
         # for i in range(0, len(self.scene.view_layers)):
             # if self.scene.view_layers[i] == True:
                 # self.active_layers.append(i)
-        self.depsgraph = context.evaluated_depsgraph_get()
+        self.depsgraph = context.evaluated_depsgraph_get() if depsgraph == None else depsgraph
         self.preprocess()
 
         # scene_objects = []


### PR DESCRIPTION
Add a temporary collection to the current scene that links all the foreign objects meshes and collections with meshes from other scenes so the depsgraph can "see" it and then the collection is destroyed. Later the "charged" depsgraph is passed to the exporter.

This is done because the dependency graph requires a scene change in order to be updated with the view layer. So instead of changing scenes to update the dependency graph, the objects are brought to the dependency graph. This behavior and other solutions are discussed with more detail in the issue linked below.

"Zoo" collection only gathers MESH and EMPTY (linked collections) to keep it minimal, but it could be expanded to include other types of objects if required.

Fixes this https://github.com/armory3d/armory/issues/1466