### PR TITLE
Fix for faulty "missing uv maps"

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -957,7 +957,7 @@ class ArmoryExporter:
         num_verts = len(loops)
         num_uv_layers = len(exportMesh.uv_layers)
         is_baked = self.has_baked_material(bobject, exportMesh.materials)
-        has_tex = (self.get_export_uvs(exportMesh) and num_uv_layers > 0) or is_baked
+        has_tex = (self.get_export_uvs(bobject.data) and num_uv_layers > 0) or is_baked
         has_tex1 = has_tex and num_uv_layers > 1
         num_colors = len(exportMesh.vertex_colors)
         has_col = self.get_export_vcols(exportMesh) and num_colors > 0


### PR DESCRIPTION
Ask for `export_uvs` to the original object instead of the evaluated copy. 

Fixes this annoying issue: https://github.com/armory3d/armory/issues/1378.

Reason is, it seems the dependency graph fails to update whenever custom properties are set. 
So for that I think asking the original object in this case could be sufficient to fix it seeing it doesn't seem to be necessary to use the evaluated copy info I think.

> The same could be applied to the other functions that are there in that chunk of code if they don't really require asking the evaluated copy.

Before:

![](https://s5.gifyu.com/images/ezgif-2-43c1796005c7.gif)

Notice how in the end I change to different workspaces to trigger the dependency graph to update.

After:
![](https://s5.gifyu.com/images/ezgif-2-9a95bba0111c.gif)

