### PR TITLE
Major refactor of trait properties

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2493,19 +2493,16 @@ class ArmoryExporter:
                             print('Armory Error: Scene "' + self.scene.name + '" - Object "' + bobject.name + '" : Referenced trait file "' + hxfile + '" not found')
 
                     x['class_name'] = trait_prefix + t.class_name_prop
-                    if len(t.arm_traitpropslist) > 0:
+
+                    # Export trait properties
+                    if t.arm_traitpropslist:
                         x['props'] = []
-                        for pt in t.arm_traitpropslist: # Append props
-                            prop = pt.name.replace(')', '').split('(')
-                            x['props'].append(prop[0])
-                            if(len(prop) > 1):
-                                if prop[1] == 'String':
-                                    value = "'" + pt.value + "'"
-                                else:
-                                    value = pt.value
-                            else:
-                                value = pt.value
+                        for trait_prop in t.arm_traitpropslist:
+                            x['props'].append(trait_prop.name)
+
+                            value = trait_prop.get_value()
                             x['props'].append(value)
+
                 o['traits'].append(x)
 
     def export_canvas_themes(self):

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2499,6 +2499,7 @@ class ArmoryExporter:
                         x['props'] = []
                         for trait_prop in t.arm_traitpropslist:
                             x['props'].append(trait_prop.name)
+                            x['props'].append(trait_prop.type)
 
                             value = trait_prop.get_value()
                             x['props'].append(value)

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -68,6 +68,7 @@ class ArmTraitListItem(bpy.types.PropertyGroup):
     node_tree_prop: PointerProperty(type=NodeTree, update=update_trait_group)
     arm_traitpropslist: CollectionProperty(type=ArmTraitPropListItem)
     arm_traitpropslist_index: IntProperty(name="Index for my_list", default=0)
+    arm_traitpropswarnings: CollectionProperty(type=ArmTraitPropWarning)
 
 class ARM_UL_TraitList(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
@@ -575,6 +576,13 @@ def draw_traits(layout, obj, is_object):
 
             # Props
             if item.arm_traitpropslist:
+                if item.arm_traitpropswarnings:
+                    box = layout.box()
+                    box.label(text=f"Warnings ({len(item.arm_traitpropswarnings)}):", icon="ERROR")
+
+                    for warning in item.arm_traitpropswarnings:
+                        box.label(text=warning.warning)
+
                 propsrow = layout.row()
                 propsrows = max(len(item.arm_traitpropslist), 6)
                 row = layout.row()

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -576,6 +576,7 @@ def draw_traits(layout, obj, is_object):
 
             # Props
             if item.arm_traitpropslist:
+                layout.label(text="Trait Properties:")
                 if item.arm_traitpropswarnings:
                     box = layout.box()
                     box.label(text=f"Warnings ({len(item.arm_traitpropswarnings)}):", icon="ERROR")

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -569,16 +569,14 @@ def draw_traits(layout, obj, is_object):
                 row.prop_search(item, "class_name_prop", bpy.data.worlds['Arm'], "arm_scripts_list", text="Class")
             else:
                 # Bundled scripts not yet fetched
-                if len(bpy.data.worlds['Arm'].arm_bundled_scripts_list) == 0:
+                if not bpy.data.worlds['Arm'].arm_bundled_scripts_list:
                     arm.utils.fetch_bundled_script_names()
                 row.prop_search(item, "class_name_prop", bpy.data.worlds['Arm'], "arm_bundled_scripts_list", text="Class")
 
             # Props
-            if len(item.arm_traitpropslist) > 0:
+            if item.arm_traitpropslist:
                 propsrow = layout.row()
-                propsrows = 2
-                if len(item.arm_traitpropslist) > 2:
-                    propsrows = 4
+                propsrows = max(len(item.arm_traitpropslist), 6)
                 row = layout.row()
                 row.template_list("ARM_UL_PropList", "The_List", item, "arm_traitpropslist", item, "arm_traitpropslist_index", rows=propsrows)
 

--- a/blender/arm/props_traits_props.py
+++ b/blender/arm/props_traits_props.py
@@ -6,6 +6,9 @@ PROP_TYPE_ICONS = {
     "Int": "CHECKBOX_DEHLT",
     "Float": "RADIOBUT_OFF",
     "Bool": "CHECKMARK",
+    "Vec2": "ORIENTATION_VIEW",
+    "Vec3": "ORIENTATION_GLOBAL",
+    "Vec4": "MESH_ICOSPHERE",
 }
 
 
@@ -26,7 +29,10 @@ class ArmTraitPropListItem(bpy.types.PropertyGroup):
             ("String", "String", "String Type"),
             ("Int", "Integer", "Integer Type"),
             ("Float", "Float", "Float Type"),
-            ("Bool", "Boolean", "Boolean Type")),
+            ("Bool", "Boolean", "Boolean Type"),
+            ("Vec2", "Vec2", "2D Vector Type"),
+            ("Vec3", "Vec3", "3D Vector Type"),
+            ("Vec4", "Vec4", "4D Vector Type")),
         name="Type",
         description="The type of this property",
         default="String")
@@ -51,6 +57,21 @@ class ArmTraitPropListItem(bpy.types.PropertyGroup):
         description="The value of this property",
         default=False)
 
+    value_vec2: FloatVectorProperty(
+        name="Value",
+        description="The value of this property",
+        size=2)
+
+    value_vec3: FloatVectorProperty(
+        name="Value",
+        description="The value of this property",
+        size=3)
+
+    value_vec4: FloatVectorProperty(
+        name="Value",
+        description="The value of this property",
+        size=4)
+
     def set_value(self, val):
         if self.type == "Int":
             self.value_int = int(val)
@@ -58,6 +79,26 @@ class ArmTraitPropListItem(bpy.types.PropertyGroup):
             self.value_float = float(val)
         elif self.type == "Bool":
             self.value_bool = bool(val)
+        elif self.type in ("Vec2", "Vec3", "Vec4"):
+            if isinstance(val, str):
+                dimensions = int(self.type[-1])
+
+                # Parse "new VecX(...)"
+                val = val.split("(")[1].split(")")[0].split(",")
+                val = [value.strip() for value in val]
+
+                # new VecX() without parameters
+                if len(val) == 1 and val[0] == "":
+                    # Use default value
+                    return
+
+                # new VecX() with less parameters than its dimensions
+                while len(val) < dimensions:
+                    val.append(0.0)
+
+                val = [float(value) for value in val]
+
+            setattr(self, "value_" + self.type.lower(), val)
         else:
             self.value_string = str(val)
 
@@ -68,6 +109,8 @@ class ArmTraitPropListItem(bpy.types.PropertyGroup):
             return self.value_float
         if self.type == "Bool":
             return self.value_bool
+        if self.type in ("Vec2", "Vec3", "Vec4"):
+            return list(getattr(self, "value_" + self.type.lower()))
         return self.value_string
 
 

--- a/blender/arm/props_traits_props.py
+++ b/blender/arm/props_traits_props.py
@@ -9,6 +9,10 @@ PROP_TYPE_ICONS = {
 }
 
 
+class ArmTraitPropWarning(bpy.types.PropertyGroup):
+    warning: StringProperty(name="Warning")
+
+
 class ArmTraitPropListItem(bpy.types.PropertyGroup):
     """Group of properties representing an item in the list."""
     name: StringProperty(
@@ -87,10 +91,12 @@ class ARM_UL_PropList(bpy.types.UIList):
 
 
 def register():
+    bpy.utils.register_class(ArmTraitPropWarning)
     bpy.utils.register_class(ArmTraitPropListItem)
     bpy.utils.register_class(ARM_UL_PropList)
 
 
 def unregister():
-    bpy.utils.unregister_class(ArmTraitPropListItem)
     bpy.utils.unregister_class(ARM_UL_PropList)
+    bpy.utils.unregister_class(ArmTraitPropListItem)
+    bpy.utils.unregister_class(ArmTraitPropWarning)

--- a/blender/arm/props_traits_props.py
+++ b/blender/arm/props_traits_props.py
@@ -9,6 +9,7 @@ PROP_TYPE_ICONS = {
     "Vec2": "ORIENTATION_VIEW",
     "Vec3": "ORIENTATION_GLOBAL",
     "Vec4": "MESH_ICOSPHERE",
+    "Object": "OBJECT_DATA"
 }
 
 
@@ -32,7 +33,8 @@ class ArmTraitPropListItem(bpy.types.PropertyGroup):
             ("Bool", "Boolean", "Boolean Type"),
             ("Vec2", "Vec2", "2D Vector Type"),
             ("Vec3", "Vec3", "3D Vector Type"),
-            ("Vec4", "Vec4", "4D Vector Type")),
+            ("Vec4", "Vec4", "4D Vector Type"),
+            ("Object", "Object", "Object Type")),
         name="Type",
         description="The type of this property",
         default="String")
@@ -73,6 +75,10 @@ class ArmTraitPropListItem(bpy.types.PropertyGroup):
         size=4)
 
     def set_value(self, val):
+        # Would require way too much effort, so it's out of scope here.
+        if self.type == "Object":
+            return
+
         if self.type == "Int":
             self.value_int = int(val)
         elif self.type == "Float":
@@ -111,6 +117,7 @@ class ArmTraitPropListItem(bpy.types.PropertyGroup):
             return self.value_bool
         if self.type in ("Vec2", "Vec3", "Vec4"):
             return list(getattr(self, "value_" + self.type.lower()))
+
         return self.value_string
 
 
@@ -126,8 +133,11 @@ class ARM_UL_PropList(bpy.types.UIList):
 
         # Make sure your code supports all 3 layout types
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
-            use_emboss = item.type == "Bool"
-            sp.prop(item, item_value_ref, text="", emboss=use_emboss)
+            if item.type == "Object":
+                sp.prop_search(item, "value_string", context.scene, "objects", text="")
+            else:
+                use_emboss = item.type == "Bool"
+                sp.prop(item, item_value_ref, text="", emboss=use_emboss)
 
         elif self.layout_type in {'GRID'}:
             layout.alignment = 'CENTER'

--- a/blender/arm/props_traits_props.py
+++ b/blender/arm/props_traits_props.py
@@ -128,7 +128,7 @@ class ARM_UL_PropList(bpy.types.UIList):
         item_value_ref = "value_" + item.type.lower()
         custom_icon = PROP_TYPE_ICONS[item.type]
 
-        sp = layout.split(factor=0.2)
+        sp = layout.split(factor=0.3)
         sp.label(text=item.type, icon=custom_icon)
         sp = sp.split(factor=0.6)
         sp.label(text=item.name)
@@ -138,7 +138,7 @@ class ARM_UL_PropList(bpy.types.UIList):
             if item.type.endswith("Object"):
                 sp.prop_search(item, "value_object", context.scene, "objects", text="", icon=custom_icon)
             else:
-                use_emboss = item.type == "Bool"
+                use_emboss = item.type in ("Bool", "String")
                 sp.prop(item, item_value_ref, text="", emboss=use_emboss)
 
         elif self.layout_type in {'GRID'}:

--- a/blender/arm/props_traits_props.py
+++ b/blender/arm/props_traits_props.py
@@ -39,40 +39,14 @@ class ArmTraitPropListItem(bpy.types.PropertyGroup):
         description="The type of this property",
         default="String")
 
-    value_string: StringProperty(
-        name="Value",
-        description="The value of this property",
-        default="")
-
-    value_int: IntProperty(
-        name="Value",
-        description="The value of this property",
-        default=0)
-
-    value_float: FloatProperty(
-        name="Value",
-        description="The value of this property",
-        default=0.0)
-
-    value_bool: BoolProperty(
-        name="Value",
-        description="The value of this property",
-        default=False)
-
-    value_vec2: FloatVectorProperty(
-        name="Value",
-        description="The value of this property",
-        size=2)
-
-    value_vec3: FloatVectorProperty(
-        name="Value",
-        description="The value of this property",
-        size=3)
-
-    value_vec4: FloatVectorProperty(
-        name="Value",
-        description="The value of this property",
-        size=4)
+    # === VALUES ===
+    value_string: StringProperty(name="Value", default="")
+    value_int: IntProperty(name="Value", default=0)
+    value_float: FloatProperty(name="Value", default=0.0)
+    value_bool: BoolProperty(name="Value", default=False)
+    value_vec2: FloatVectorProperty(name="Value", size=2)
+    value_vec3: FloatVectorProperty(name="Value", size=3)
+    value_vec4: FloatVectorProperty(name="Value", size=4)
 
     def set_value(self, val):
         # Would require way too much effort, so it's out of scope here.

--- a/blender/arm/props_traits_props.py
+++ b/blender/arm/props_traits_props.py
@@ -1,34 +1,95 @@
 import bpy
 from bpy.props import *
 
-class ArmTraitPropListItem(bpy.types.PropertyGroup):
-    # Group of properties representing an item in the list
-    name: StringProperty(
-           name="Name",
-           description="A name for this item",
-           default="Untitled")
+PROP_TYPE_ICONS = {
+    "String": "SORTALPHA",
+    "Int": "CHECKBOX_DEHLT",
+    "Float": "RADIOBUT_OFF",
+    "Bool": "CHECKMARK",
+}
 
-    value: StringProperty(
-           name="Value",
-           description="A name for this item",
-           default="")
+
+class ArmTraitPropListItem(bpy.types.PropertyGroup):
+    """Group of properties representing an item in the list."""
+    name: StringProperty(
+        name="Name",
+        description="The name of this property",
+        default="Untitled")
+
+    type: EnumProperty(
+        items=(
+            # (Haxe Type, Display Name, Description)
+            ("String", "String", "String Type"),
+            ("Int", "Integer", "Integer Type"),
+            ("Float", "Float", "Float Type"),
+            ("Bool", "Boolean", "Boolean Type")),
+        name="Type",
+        description="The type of this property",
+        default="String")
+
+    value_string: StringProperty(
+        name="Value",
+        description="The value of this property",
+        default="")
+
+    value_int: IntProperty(
+        name="Value",
+        description="The value of this property",
+        default=0)
+
+    value_float: FloatProperty(
+        name="Value",
+        description="The value of this property",
+        default=0.0)
+
+    value_bool: BoolProperty(
+        name="Value",
+        description="The value of this property",
+        default=False)
+
+    def set_value(self, val):
+        if self.type == "Int":
+            self.value_int = int(val)
+        elif self.type == "Float":
+            self.value_float = float(val)
+        elif self.type == "Bool":
+            self.value_bool = bool(val)
+        else:
+            self.value_string = str(val)
+
+    def get_value(self):
+        if self.type == "Int":
+            return self.value_int
+        if self.type == "Float":
+            return self.value_float
+        if self.type == "Bool":
+            return self.value_bool
+        return self.value_string
+
 
 class ARM_UL_PropList(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
-        # We could write some code to decide which icon to use here...
-        custom_icon = 'OBJECT_DATAMODE'
+        item_value_ref = "value_" + item.type.lower()
+
+        sp = layout.split(factor=0.2)
+        # Some properties don't support icons
+        sp.label(text=item.type, icon=PROP_TYPE_ICONS[item.type])
+        sp = sp.split(factor=0.6)
+        sp.label(text=item.name)
 
         # Make sure your code supports all 3 layout types
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
-            layout.prop(item, "value", text=item.name, emboss=False, icon=custom_icon)
+            use_emboss = item.type == "Bool"
+            sp.prop(item, item_value_ref, text="", emboss=use_emboss)
 
         elif self.layout_type in {'GRID'}:
             layout.alignment = 'CENTER'
-            layout.label(text="", icon=custom_icon)
+
 
 def register():
     bpy.utils.register_class(ArmTraitPropListItem)
     bpy.utils.register_class(ARM_UL_PropList)
+
 
 def unregister():
     bpy.utils.unregister_class(ArmTraitPropListItem)

--- a/blender/arm/props_traits_props.py
+++ b/blender/arm/props_traits_props.py
@@ -1,10 +1,5 @@
-import shutil
 import bpy
-import os
-import json
-from bpy.types import Menu, Panel, UIList
 from bpy.props import *
-from arm.utils import to_hex
 
 class ArmTraitPropListItem(bpy.types.PropertyGroup):
     # Group of properties representing an item in the list

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -277,8 +277,8 @@ def fetch_script_props(file):
                 # (= declaration has two parts)
                 if len(decl_sides) > 1:
                     prop_type = decl_sides[1].strip()
-                    if prop_type == "iron.object.Object":
-                        prop_type = "Object"
+                    if prop_type.startswith("iron.object."):
+                        prop_type = prop_type[12:]
 
                     # Default value exists
                     if len(var_sides) > 1 and var_sides[1].strip() != "":
@@ -367,7 +367,8 @@ def get_type_default_value(prop_type: str):
         return 0
     if prop_type == "Float":
         return 0.0
-    if prop_type in ("String", "Object"):
+    if prop_type == "String" or prop_type in (
+            "Object", "CameraObject", "LightObject", "MeshObject", "SpeakerObject"):
         return ""
     if prop_type == "Bool":
         return False

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -283,6 +283,8 @@ def fetch_script_props(file):
                     prop_type = decl_sides[1].strip()
                     if prop_type.startswith("iron.object."):
                         prop_type = prop_type[12:]
+                    elif prop_type.startswith("iron.math."):
+                        prop_type = prop_type[10:]
 
                     # Default value exists
                     if len(var_sides) > 1 and var_sides[1].strip() != "":
@@ -358,6 +360,8 @@ def get_prop_type_from_value(value: str):
                 value = value.split()[1].split("(")[0]
                 if value.startswith("Vec"):
                     return value
+                if value.startswith("iron.math.Vec"):
+                    return value[10:]
 
     return None
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -349,9 +349,9 @@ def get_prop_type_from_value(value: str):
             if value in ("true", "false"):
                 return "Bool"
             if value.startswith("new "):
-                if value[4:7] == "Vec":
-                    # Vec2, Vec3, Vec4
-                    return value[4:8]
+                value = value.split()[1].split("(")[0]
+                if value.startswith("Vec"):
+                    return value
 
     return None
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -329,7 +329,8 @@ def get_prop_type_from_value(value: str):
             float(value)
             return "Float"
         except ValueError:
-            if value.startswith("\"") and value.endswith("\""):
+            # "" is required, " alone will not work
+            if len(value) > 1 and value.startswith(("\"", "'")) and value.endswith(("\"", "'")):
                 return "String"
             if value in ("true", "false"):
                 return "Bool"

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -424,7 +424,10 @@ def fetch_prop(o):
             found_prop = False
             for i_prop in item.arm_traitpropslist:
                 if i_prop.name == p[0]:
-                    found_prop = i_prop
+                    if i_prop.type == p[1]:
+                        found_prop = i_prop
+                    else:
+                        item.arm_traitpropslist.remove(item.arm_traitpropslist.find(i_prop.name))
                     break
 
             # Not in list

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -238,9 +238,13 @@ def fetch_script_props(file):
             name = name.replace('/', '.')
         if '\\' in file:
             name = name.replace('\\', '.')
+
         script_props[name] = []
         script_props_defaults[name] = []
+
         lines = f.read().splitlines()
+
+        # Read next line
         read_prop = False
         for line in lines:
             if not read_prop:
@@ -249,39 +253,105 @@ def fetch_script_props(file):
 
             if read_prop:
                 if 'var ' in line:
-                    p = line.split('var ')[1]
-                elif 'final ' in line:
-                    p = line.split('final ')[1]
+                    # Line of code
+                    code_ref = line.split('var ')[1].split(';')[0]
                 else:
                     break
 
                 valid_prop = False
-                # Has type
-                if ':' in p:
-                    # Fetch default value
-                    if '=' in p:
-                        s = p.split('=')
-                        ps = s[0].split(':')
-                        prop = (ps[0].strip(), ps[1].split(';')[0].strip())
-                        prop_value = s[1].split(';')[0].replace('\'', '').replace('"', '').strip()
-                        valid_prop = True
+
+                # Declaration = Assignment;
+                var_sides = code_ref.split('=')
+                # DeclarationName: DeclarationType
+                decl_sides = var_sides[0].split(':')
+
+                prop_name = decl_sides[0].strip()
+
+                # If the prop type is annotated in the code
+                # (= declaration has two parts)
+                if len(decl_sides) > 1:
+                    prop_type = decl_sides[1].strip()
+
+                    # Default value exists
+                    if len(var_sides) > 1 and var_sides[1].strip() != "":
+                        # Type is not supported
+                        if get_type_default_value(prop_type) is None:
+                            read_prop = False
+                            continue
+
+                        prop_value = var_sides[1].replace('\'', '').replace('"', '').strip()
+
                     else:
-                        ps = p.split(':')
-                        prop = (ps[0].strip(), ps[1].split(';')[0].strip())
-                        prop_value = ''
-                        valid_prop = True
-                # Fetch default value
-                elif '=' in p:
-                    s = p.split('=')
-                    prop = (s[0].strip(), None)
-                    prop_value = s[1].split(';')[0].replace('\'', '').replace('"', '').strip()
+                        prop_value = get_type_default_value(prop_type)
+
+                        # Type is not supported
+                        if prop_value is None:
+                            read_prop = False
+                            continue
+
                     valid_prop = True
+
+                # Default value exists
+                elif len(var_sides) > 1 and var_sides[1].strip() != "":
+                    prop_value = var_sides[1].strip()
+                    prop_type = get_prop_type_from_value(prop_value)
+
+                    # Type is not supported
+                    if prop_type is None:
+                        read_prop = False
+                        continue
+                    if prop_type == "String":
+                        prop_value = prop_value.replace('\'', '').replace('"', '')
+
+                    valid_prop = True
+
+                prop = (prop_name, prop_type)
+
                 # Register prop
                 if valid_prop:
                     script_props[name].append(prop)
                     script_props_defaults[name].append(prop_value)
 
                 read_prop = False
+
+def get_prop_type_from_value(value: str):
+    """
+    Returns the property type based on its representation in the code.
+
+    If the type is not supported, `None` is returned.
+    """
+    # Maybe ast.literal_eval() is better here?
+    try:
+        int(value)
+        return "Int"
+    except ValueError:
+        try:
+            float(value)
+            return "Float"
+        except ValueError:
+            if value.startswith("\"") and value.endswith("\""):
+                return "String"
+            if value in ("true", "false"):
+                return "Bool"
+
+    return None
+
+def get_type_default_value(prop_type: str):
+    """
+    Returns the default value of the given Haxe type.
+
+    If the type is not supported, `None` is returned:
+    """
+    if prop_type == "Int":
+        return 0
+    if prop_type == "Float":
+        return 0.0
+    if prop_type == "String":
+        return ""
+    if prop_type == "Bool":
+        return False
+
+    return None
 
 def fetch_script_names():
     if bpy.data.filepath == "":
@@ -341,36 +411,38 @@ def fetch_prop(o):
             continue
         props = script_props[name]
         defaults = script_props_defaults[name]
+
         # Remove old props
         for i in range(len(item.arm_traitpropslist) - 1, -1, -1):
             ip = item.arm_traitpropslist[i]
-            # if ip.name not in props:
-            if ip.name.split('(')[0] not in [p[0] for p in props]:
+            if ip.name not in [p[0] for p in props]:
                 item.arm_traitpropslist.remove(i)
-        # Add new props
-        for i in range(0, len(props)):
-            p = props[i]
-            found = False
-            for ip in item.arm_traitpropslist:
-                if ip.name.replace(')', '').split('(')[0] == p[0]:
-                    found = ip
-                    break
-            # Not in list
-            if not found:
-                prop = item.arm_traitpropslist.add()
-                prop.name = p[0] + ('(' + p[1] + ')' if p[1] else '')
-                prop.value = defaults[i]
 
-            if found:
-                prop = item.arm_traitpropslist[found.name]
-                f = found.name.replace(')', '').split('(')
+        # Add new props
+        for index, p in enumerate(props):
+            found_prop = False
+            for i_prop in item.arm_traitpropslist:
+                if i_prop.name == p[0]:
+                    found_prop = i_prop
+                    break
+
+            # Not in list
+            if not found_prop:
+                prop = item.arm_traitpropslist.add()
+                prop.name = p[0]
+                prop.type = p[1]
+                prop.set_value(defaults[index])
+
+            if found_prop:
+                prop = item.arm_traitpropslist[found_prop.name]
 
                 # Default value added and current value is blank (no override)
-                if (not found.value and defaults[i]):
-                    prop.value = defaults[i]
+                if (not found_prop.get_value() and defaults[index]):
+                    prop.set_value(defaults[index])
                 # Type has changed, update displayed name
-                if (len(f) == 1 or (len(f) > 1 and f[1] != p[1])):
-                    prop.name = p[0] + ('(' + p[1] + ')' if p[1] else '')
+                if (len(found_prop.name) == 1 or (len(found_prop.name) > 1 and found_prop.name[1] != p[1])):
+                    prop.name = p[0]
+                    prop.type = p[1]
 
 def fetch_bundled_trait_props():
     # Bundled script props

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -1,15 +1,18 @@
-import bpy
+import glob
 import json
 import os
-import glob
 import platform
-import re
 import subprocess
 import webbrowser
+
 import numpy as np
+
+import bpy
+
 import arm.lib.armpack
-import arm.make_state as state
 import arm.log as log
+import arm.make_state as state
+
 
 class NumpyEncoder(json.JSONEncoder):
     def default(self, obj):

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -266,7 +266,8 @@ def fetch_script_props(file):
                     code_ref = line.split('var ')[1].split(';')[0]
                 else:
                     script_warnings[name].append(f"Line {lineno - 1}: Unused @prop")
-                    break
+                    read_prop = line.lstrip().startswith('@prop')
+                    continue
 
                 valid_prop = False
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -277,6 +277,8 @@ def fetch_script_props(file):
                 # (= declaration has two parts)
                 if len(decl_sides) > 1:
                     prop_type = decl_sides[1].strip()
+                    if prop_type == "iron.object.Object":
+                        prop_type = "Object"
 
                     # Default value exists
                     if len(var_sides) > 1 and var_sides[1].strip() != "":
@@ -365,7 +367,7 @@ def get_type_default_value(prop_type: str):
         return 0
     if prop_type == "Float":
         return 0.0
-    if prop_type == "String":
+    if prop_type in ("String", "Object"):
         return ""
     if prop_type == "Bool":
         return False

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -348,6 +348,10 @@ def get_prop_type_from_value(value: str):
                 return "String"
             if value in ("true", "false"):
                 return "Bool"
+            if value.startswith("new "):
+                if value[4:7] == "Vec":
+                    # Vec2, Vec3, Vec4
+                    return value[4:8]
 
     return None
 
@@ -365,6 +369,12 @@ def get_type_default_value(prop_type: str):
         return ""
     if prop_type == "Bool":
         return False
+    if prop_type == "Vec2":
+        return [0.0, 0.0]
+    if prop_type == "Vec3":
+        return [0.0, 0.0, 0.0]
+    if prop_type == "Vec4":
+        return [0.0, 0.0, 0.0, 0.0]
 
     return None
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -258,6 +258,10 @@ def fetch_script_props(file):
 
             if read_prop:
                 if 'var ' in line:
+                    if 'static ' in line:
+                        # Static properties can be overwritten multiple times
+                        # from multiple property lists
+                        script_warnings[name].append(f"Line {lineno}: Static properties may result in undefined behaviours!")
                     # Line of code
                     code_ref = line.split('var ')[1].split(';')[0]
                 else:

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -258,10 +258,6 @@ def fetch_script_props(file):
 
             if read_prop:
                 if 'var ' in line:
-                    if 'static ' in line:
-                        # Static properties can be overwritten multiple times
-                        # from multiple property lists
-                        script_warnings[name].append(f"Line {lineno}: Static properties may result in undefined behaviours!")
                     # Line of code
                     code_ref = line.split('var ')[1].split(';')[0]
                 else:
@@ -278,6 +274,11 @@ def fetch_script_props(file):
 
                 prop_name = decl_sides[0].strip()
 
+                if 'static ' in line:
+                    # Static properties can be overwritten multiple times
+                    # from multiple property lists
+                    script_warnings[name].append(f"Line {lineno} (\"{prop_name}\"): Static properties may result in undefined behaviours!")
+
                 # If the prop type is annotated in the code
                 # (= declaration has two parts)
                 if len(decl_sides) > 1:
@@ -291,7 +292,7 @@ def fetch_script_props(file):
                     if len(var_sides) > 1 and var_sides[1].strip() != "":
                         # Type is not supported
                         if get_type_default_value(prop_type) is None:
-                            script_warnings[name].append(f"Line {lineno}: {prop_name}: Type {prop_type} is not supported!")
+                            script_warnings[name].append(f"Line {lineno} (\"{prop_name}\"): Type {prop_type} is not supported!")
                             read_prop = False
                             continue
 
@@ -302,7 +303,7 @@ def fetch_script_props(file):
 
                         # Type is not supported
                         if prop_value is None:
-                            script_warnings[name].append(f"Line {lineno}: {prop_name}: Type {prop_type} is not supported!")
+                            script_warnings[name].append(f"Line {lineno} (\"{prop_name}\"): Type {prop_type} is not supported!")
                             read_prop = False
                             continue
 
@@ -315,7 +316,7 @@ def fetch_script_props(file):
 
                     # Type is not recognized
                     if prop_type is None:
-                        script_warnings[name].append(f"Line {lineno}: Property type not recognized!")
+                        script_warnings[name].append(f"Line {lineno} (\"{prop_name}\"): Property type not recognized!")
                         read_prop = False
                         continue
                     if prop_type == "String":
@@ -324,7 +325,7 @@ def fetch_script_props(file):
                     valid_prop = True
 
                 else:
-                    script_warnings[name].append(f"Line {lineno}: {prop_name}: Not a valid property!")
+                    script_warnings[name].append(f"Line {lineno} (\"{prop_name}\"): Not a valid property!")
                     read_prop = False
                     continue
 


### PR DESCRIPTION
Requires https://github.com/armory3d/iron/pull/79

- Trait property code simplified and is hopefully more readable now
- Support for different property types, not strings only
- UI shows proper UI elements for different types
- Added support for Object and Vector properties (also certain object sub-types). Default values of vector types are also allowed
- Show warnings in the UI if a prop type is not supported or the property is invalid
- Removed property support for `final` values again. Found out that this didn't really work, haxe just didn't throw an error
- UI refactor
- Different icons for different types. Might not be the best icons, feel free to change everything from this PR :)
- Properties are also refreshed when their type changes

Screenshots:
![ArmoryTraitProps](https://user-images.githubusercontent.com/17685000/71992721-29da0c00-3236-11ea-8007-041c933b1d3e.png)
![ArmoryTraitWarnings](https://user-images.githubusercontent.com/17685000/71995414-d4542e00-323a-11ea-8630-1b4b7987ea2e.png)


@luboslenco If you agree on merging this, could you please upload these screenshots (or other ones) to the `img` folder on the Armory wiki repository? I would like to write the documentation about the new features and unfortunately, GitHub doesn't allow non-members to upload or change pictures. Thank you :)

And a question: should all value widgets be embossed? Otherwise its a little bit hard to see that they're changeable. As both variants are used for different prop types, the UI currently looks a little bit irresolute.

Linked issues:
- https://github.com/armory3d/armory/issues/550 (Coming soon)
- https://github.com/armory3d/armory/issues/244 (Done: referencing objects, arrays (Vecs), native UI for different types)