### PR TITLE
Fix annoying error message at first Armory2D start from Blender

### DIFF
--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -664,4 +664,4 @@ def write_canvasjson(canvas_name):
         os.makedirs(canvas_path)
     with open(canvas_path + '/' + canvas_name + '.json', 'w') as f:
         f.write(
-"""{ "name": "untitled", "x": 0.0, "y": 0.0, "width": 1280, "height": 720, "elements": [], "assets": [] }""")
+"""{ "name": "untitled", "x": 0.0, "y": 0.0, "width": 1280, "height": 720, "theme": "Default Light", "elements": [], "assets": [] }""")


### PR DESCRIPTION
Previously, new canvases weren't initialized with a theme, so an error was displayed.

Linked to https://github.com/armory3d/armory2d/pull/49
Thanks to hreez on discord for the report :)