### PR TITLE
Fix object type trait property export for linked objects

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2501,7 +2501,11 @@ class ArmoryExporter:
                             x['props'].append(trait_prop.name)
                             x['props'].append(trait_prop.type)
 
-                            value = trait_prop.get_value()
+                            if trait_prop.type.endswith("Object"):
+                                value = arm.utils.asset_name(trait_prop.value_object)
+                            else:
+                                value = trait_prop.get_value()
+
                             x['props'].append(value)
 
                 o['traits'].append(x)


### PR DESCRIPTION
Object names of trait properties are now exported by using `arm.utils.asset_name()`.