### PR TITLE
Fix bool type trait properties

### DIFF
--- a/blender/arm/props_traits_props.py
+++ b/blender/arm/props_traits_props.py
@@ -82,7 +82,7 @@ class ArmTraitPropListItem(bpy.types.PropertyGroup):
         elif self.type == "Float":
             self.value_float = float(val)
         elif self.type == "Bool":
-            self.value_bool = bool(val)
+            self.value_bool = val == "true"
         elif self.type in ("Vec2", "Vec3", "Vec4"):
             if isinstance(val, str):
                 dimensions = int(self.type[-1])

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -479,7 +479,8 @@ def fetch_prop(o):
                 prop = item.arm_traitpropslist[found_prop.name]
 
                 # Default value added and current value is blank (no override)
-                if (not found_prop.get_value() and defaults[index]):
+                if (found_prop.get_value() is None
+                        or found_prop.get_value() == "") and defaults[index]:
                     prop.set_value(defaults[index])
                 # Type has changed, update displayed name
                 if (len(found_prop.name) == 1 or (len(found_prop.name) > 1 and found_prop.name[1] != p[1])):


### PR DESCRIPTION
Trait properties of boolean type were incorrectly interpreted as blank/undefined when they defaulted to `true`.