### PR TITLE
Deactivate "Debug Console" checkbox when Zui is not enabled

### DIFF
--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -71,7 +71,7 @@ def init_properties():
         items=[('Scene', 'Scene', 'Scene'),
                ('Viewport', 'Viewport', 'Viewport')],
         name="Camera", description="Viewport camera", default='Scene', update=assets.invalidate_compiler_cache)
-    bpy.types.World.arm_debug_console = BoolProperty(name="Debug Console", description="Show inspector in player and enable debug draw", default=False, update=assets.invalidate_shader_cache)
+    bpy.types.World.arm_debug_console = BoolProperty(name="Debug Console", description="Show inspector in player and enable debug draw.\nRequires that Zui is not disabled", default=False, update=assets.invalidate_shader_cache)
     bpy.types.World.arm_runtime = EnumProperty(
         items=[('Krom', 'Krom', 'Krom'),
                ('Browser', 'Browser', 'Browser')],

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -362,7 +362,9 @@ class ARM_PT_ProjectFlagsPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
         wrd = bpy.data.worlds['Arm']
-        layout.prop(wrd, 'arm_debug_console')
+        row = layout.row()
+        row.enabled = wrd.arm_ui != 'Disabled'
+        row.prop(wrd, 'arm_debug_console')
         layout.prop(wrd, 'arm_cache_build')
         layout.prop(wrd, 'arm_live_patch')
         layout.prop(wrd, 'arm_stream_scene')


### PR DESCRIPTION
Just a small improvement to prevent an error during compilation.
I've also updated the property description:
![debug_console_description](https://user-images.githubusercontent.com/17685000/75635802-3cab0480-5c19-11ea-931d-f433f3a1622b.png)
