### PR TITLE
Fix Vertex Color and Tangent not exporting sometimes

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -969,8 +969,8 @@ class ArmoryExporter:
         has_tex = (self.get_export_uvs(bobject.data) and num_uv_layers > 0) or is_baked
         has_tex1 = has_tex and num_uv_layers > 1
         num_colors = len(exportMesh.vertex_colors)
-        has_col = self.get_export_vcols(exportMesh) and num_colors > 0
-        has_tang = self.has_tangents(exportMesh)
+        has_col = self.get_export_vcols(bobject.data) and num_colors > 0
+        has_tang = self.has_tangents(bobject.data)
 
         pdata = np.empty(num_verts * 4, dtype='<f4') # p.xyz, n.z
         ndata = np.empty(num_verts * 2, dtype='<f4') # n.xy

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -383,6 +383,10 @@ def parse_vector(node, socket):
     elif node.type == 'GROUP_INPUT':
         return parse_group_input(node, socket)
 
+    elif node.type == 'VERTEX_COLOR':
+        con.add_elem('col', 'short4norm') # Vcols only for now
+        return 'vcolor'
+
     elif node.type == 'ATTRIBUTE':
         if socket == node.outputs[0]: # Color
             con.add_elem('col', 'short4norm') # Vcols only for now


### PR DESCRIPTION
Applied the same fix that is used for uvs, since it seems to solve the issue of not updating correctly for exporting of vertex colors and tangents too, until it's fixed on Blender's part.
Also added support for the Vertex Color node.