### PR TITLE
Action autobaking

### DIFF
--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -139,6 +139,7 @@ def init_properties():
     bpy.types.MetaBall.arm_dynamic_usage = BoolProperty(name="Dynamic Data Usage", description="Metaball data can change at runtime", default=False)
     # For armature
     bpy.types.Armature.arm_cached = BoolProperty(name="Armature Cached", description="No need to reexport armature data", default=False)
+    bpy.types.Armature.arm_autobake = BoolProperty(name="Auto Bake", description="Bake constraints automatically", default=True)
     # For camera
     bpy.types.Camera.arm_frustum_culling = BoolProperty(name="Frustum Culling", description="Perform frustum culling for this camera", default=True)
 

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -142,6 +142,7 @@ class ARM_PT_DataPropsPanel(bpy.types.Panel):
             layout.prop(obj.data, 'arm_loop')
             layout.prop(obj.data, 'arm_stream')
         elif obj.type == 'ARMATURE':
+            layout.prop(obj.data, 'arm_autobake')
             pass
 
 class ARM_PT_ScenePropsPanel(bpy.types.Panel):


### PR DESCRIPTION
Hey Lubos, can you check this out?

I've always had trouble animating characters for armory because I like to work with bone constraints. Usually what I did was export to fbx and then import back into blender. That workflow is a mess, so I made this little modification to bake constraints automatically.

It introduces a new property arm_autobake for the Armature type, and it displays it in the object data properties panel. If enabled, it doesn't export any bone constraint at all, but instead bakes all actions.

Now I dont need to do blender -> fbx -> blender in order to tweak animations. Hopefully this will help someone else too :)