### PR TITLE
Exporter: better handling of duplicate object names

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -837,7 +837,7 @@ class ArmoryExporter:
                         action_obj['name'] = aname
                         action_obj['objects'] = bones
                         arm.utils.write_arm(fp, action_obj)
-                
+
                 #clear baked actions
                 for a in baked_actions:
                         bpy.data.actions.remove( a, do_unlink=True)
@@ -1433,13 +1433,27 @@ class ArmoryExporter:
                 if has_proxy_user:
                     continue
 
+                asset_name = arm.utils.asset_name(bobject)
+
                 # Add external linked objects
-                if bobject.name not in scene_objects and collection.library is not None:
+                if collection.library is not None:
+                    # Iron differentiates objects based on their names,
+                    # so errors will happen if two objects with the
+                    # same name exists. This check is only required
+                    # when the object in question is in a library,
+                    # otherwise Blender will not allow duplicate names
+                    if asset_name in scene_objects:
+                        log.warn("skipping export of the object"
+                                 f" {bobject.name} (collection"
+                                 f" {collection.name}) because it has the same"
+                                 " export name as another object in the scene:"
+                                 f" {asset_name}")
+                        continue
+
                     self.process_bobject(bobject)
                     self.export_object(bobject, self.scene)
-                    out_collection['object_refs'].append(arm.utils.asset_name(bobject))
-                else:
-                    out_collection['object_refs'].append(bobject.name)
+
+                out_collection['object_refs'].append(asset_name)
 
         self.output['groups'].append(out_collection)
 


### PR DESCRIPTION
Fix/Workaround for https://github.com/armory3d/armory/issues/1523.

Iron does not allow duplicate names for objects but the now replaced code was still adding exporting objects to collections if their names were already "taken".

Also, objects in collections are now always exported with their full asset name, taking the collection name into account which decreases the rate of name conflicts massively.

In the very rare case that an object from a collection still has the same name as another object in the scene (that object then must be named `[collection_name]_[object_name].blend` for this problem to occur, which is very unusual), a warning is printed to the console and the collection object with the duplicate name is not exported.

---
*Just an idea for the future (off-topic):* Warnings sometimes get buried amongst all other kinds of messages in the console and tend to get overseen. I think a message at the start of the game that says that n warnings occurred during export could help here. Or a hint in the UI if it is not too annoying). Maybe I will look into that and open another PR.