### PR TITLE
Fix ResourceWarning for open_folder()

### DIFF
--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -719,11 +719,11 @@ def open_editor(hx_path=None):
 
 def open_folder():
     if arm.utils.get_os() == 'win':
-        subprocess.Popen(['explorer', arm.utils.get_fp()])
+        subprocess.run(['explorer', arm.utils.get_fp()])
     elif arm.utils.get_os() == 'mac':
-        subprocess.Popen(['open', arm.utils.get_fp()])
+        subprocess.run(['open', arm.utils.get_fp()])
     elif arm.utils.get_os() == 'linux':
-        subprocess.Popen(['xdg-open', arm.utils.get_fp()])
+        subprocess.run(['xdg-open', arm.utils.get_fp()])
     else:
         webbrowser.open('file://' + arm.utils.get_fp())
 


### PR DESCRIPTION
`subprocess.Popen()` led to a ResourceWarning when using the `open_project_folder()` operator:
```
C:\Program Files\Blender Foundation\Blender 2.82\2.82\python\lib\subprocess.py:858: ResourceWarning: subprocess 15904 is still running
  ResourceWarning, source=self)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

Replacing `Popen()` with `run()` (new since Python 3.5) solves the issue, calling `Popen()` with stdin, stdout, stderr = `None` would probably also work, but `run()` is recommended.