### PR TITLE
Same-file collection instance bug

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1435,8 +1435,13 @@ class ArmoryExporter:
 
                 asset_name = arm.utils.asset_name(bobject)
 
-                # Add external linked objects
-                if collection.library is not None:
+                if collection.library is None:
+                    #collection is in the same file, but (likely) on another scene
+                    if asset_name not in scene_objects:
+                        self.process_bobject(bobject)
+                        self.export_object(bobject, self.scene)
+                else:
+                    # Add external linked objects
                     # Iron differentiates objects based on their names,
                     # so errors will happen if two objects with the
                     # same name exists. This check is only required


### PR DESCRIPTION
Instances from collections of different scenes in the same file were not getting exported. I think this fixes the issue.
[same-file instance bug.blend.zip](https://github.com/armory3d/armory/files/4284816/same-file.instance.bug.blend.zip)
The file should crash on the master branch.
