### PR TITLE
Support for collection instance with autobaking armatures

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -838,7 +838,7 @@ class ArmoryExporter:
                                 boneo = {}
                                 self.export_bone(skelobj, bone, scene, boneo, action)
                                 bones.append(boneo)
-                        self.write_bone_matrices(scene, action)
+                        self.write_bone_matrices( bpy.context.scene, action)
                         if len(bones) > 0 and 'anim' in bones[0]:
                             self.export_pose_markers(bones[0]['anim'], action)
                         # Save action separately


### PR DESCRIPTION
I made some changes so the action autobaking feature wouldn't crash on collection instances. Here's a demo file, _main.blend_ should crash on master
[colinst-autobake.zip](https://github.com/armory3d/armory/files/4294058/colinst-autobake.zip)