### PR TITLE
De-clutter console output and show warnings

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -182,7 +182,9 @@ class ArmoryExporter:
             self.export_pose_markers(oanim, action)
 
             if True: #action.arm_cached == False or not os.path.exists(fp):
-                print('Exporting object action ' + aname)
+                wrd = bpy.data.worlds['Arm']
+                if wrd.arm_verbose_output:
+                    print('Exporting object action ' + aname)
                 actionf = {}
                 actionf['objects'] = []
                 actionf['objects'].append(oaction)
@@ -285,7 +287,7 @@ class ArmoryExporter:
 
                     except KeyError:
                         if data_path not in target_names:
-                            print(f"Action {action_name}: The data path '{data_path}' is not supported (yet)!")
+                            log.warn(f"Action {action_name}: The data path '{data_path}' is not supported (yet)!")
                             continue
 
                         # Missing target entry for array_index or something else
@@ -295,7 +297,9 @@ class ArmoryExporter:
                     oanim['tracks'].append(data_ttrack)
 
                 if True:  #action.arm_cached == False or not os.path.exists(fp):
-                    print('Exporting object action ' + action_name)
+                    wrd = bpy.data.worlds['Arm']
+                    if wrd.arm_verbose_output:
+                        print('Exporting object action ' + action_name)
                     actionf = {}
                     actionf['objects'] = []
                     actionf['objects'].append(oaction)
@@ -814,14 +818,16 @@ class ArmoryExporter:
                             sel = bpy.context.selected_objects[:]
                             for _o in sel: _o.select_set(False)
                             bobject.select_set(True)
-                            print('Baking action '+aname)
+                            if wrd.arm_verbose_output:
+                                print('Baking action '+aname)
                             bpy.ops.nla.bake(frame_start = action.frame_range[0], frame_end=action.frame_range[1], step=1, only_selected=False, visual_keying=True)
                             action = bobject.animation_data.action
                             bobject.select_set(False)
                             for _o in sel: _o.select_set(True)
                             baked_actions.append(action)
 
-                        print('Exporting armature action ' + aname)
+                        if wrd.arm_verbose_output:
+                            print('Exporting armature action ' + aname)
                         bones = []
                         self.bone_tracks = []
                         for bone in bdata.bones:
@@ -1235,7 +1241,8 @@ class ArmoryExporter:
                 log.warn('{0} users {1} and {2} differ in modifier stack - use Make Single User - Object & Data for now'.format(oid, bobject.name, table[i].name))
                 break
 
-        print('Exporting mesh ' + arm.utils.asset_name(bobject.data))
+        if wrd.arm_verbose_output:
+            print('Exporting mesh ' + arm.utils.asset_name(bobject.data))
 
         o = {}
         o['name'] = oid

--- a/blender/arm/log.py
+++ b/blender/arm/log.py
@@ -1,12 +1,14 @@
-
 info_text = ''
+num_warnings = 0
 
-def clear():
-    global info_text
+def clear(clear_warnings=False):
+    global info_text, num_warnings
     info_text = ''
+    if clear_warnings:
+        num_warnings = 0
 
 def format_text(text):
-    return (text[:80] + '..') if len(text) > 80 else text # Limit str size    
+    return (text[:80] + '..') if len(text) > 80 else text # Limit str size
 
 def print_info(text):
     global info_text
@@ -14,4 +16,6 @@ def print_info(text):
     info_text = format_text(text)
 
 def warn(text):
+    global num_warnings
+    num_warnings += 1
     print('Armory Warning: ' + text)

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -315,7 +315,7 @@ def build(target, is_play=False, is_publish=False, is_export=False):
     if arm.utils.get_save_on_build():
         bpy.ops.wm.save_mainfile()
 
-    log.clear()
+    log.clear(clear_warnings=True)
 
     # Set camera in active scene
     active_scene = arm.utils.get_active_scene()
@@ -409,7 +409,9 @@ def compilation_server_done():
 
 def build_done():
     print('Finished in ' + str(time.time() - profile_time))
-    if state.proc_build == None:
+    if log.num_warnings > 0:
+        print(f'{log.num_warnings} warnings occurred during compilation!')
+    if state.proc_build is None:
         return
     result = state.proc_build.poll()
     state.proc_build = None
@@ -475,8 +477,6 @@ def get_khajs_path(target):
 def play():
     global scripts_mtime
     wrd = bpy.data.worlds['Arm']
-
-    log.clear()
 
     build(target=runtime_to_target(), is_play=True)
 

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -295,7 +295,7 @@ def compile(assets_only=False):
         cmd.append('--noproject')
 
     if not wrd.arm_verbose_output:
-        cmd.append("--silent")
+        cmd.append("--quiet")
     else:
         print("Using project from " + arm.utils.get_fp())
         print("Running: ", cmd)

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -72,6 +72,7 @@ def init_properties():
                ('Viewport', 'Viewport', 'Viewport')],
         name="Camera", description="Viewport camera", default='Scene', update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_debug_console = BoolProperty(name="Debug Console", description="Show inspector in player and enable debug draw.\nRequires that Zui is not disabled", default=False, update=assets.invalidate_shader_cache)
+    bpy.types.World.arm_verbose_output = BoolProperty(name="Verbose Output", description="Print additional information to the console during compilation", default=False)
     bpy.types.World.arm_runtime = EnumProperty(
         items=[('Krom', 'Krom', 'Krom'),
                ('Browser', 'Browser', 'Browser')],

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -366,6 +366,7 @@ class ARM_PT_ProjectFlagsPanel(bpy.types.Panel):
         row = layout.row()
         row.enabled = wrd.arm_ui != 'Disabled'
         row.prop(wrd, 'arm_debug_console')
+        layout.prop(wrd, 'arm_verbose_output')
         layout.prop(wrd, 'arm_cache_build')
         layout.prop(wrd, 'arm_live_patch')
         layout.prop(wrd, 'arm_stream_scene')

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -265,13 +265,21 @@ class ARM_PT_ArmoryPlayerPanel(bpy.types.Panel):
         wrd = bpy.data.worlds['Arm']
         row = layout.row(align=True)
         row.alignment = 'EXPAND'
-        if state.proc_play == None and state.proc_build == None:
+        if state.proc_play is None and state.proc_build is None:
             row.operator("arm.play", icon="PLAY")
         else:
             row.operator("arm.stop", icon="MESH_PLANE")
         row.operator("arm.clean_menu")
         layout.prop(wrd, 'arm_runtime')
         layout.prop(wrd, 'arm_play_camera')
+
+        if log.num_warnings > 0:
+            box = layout.box()
+            # Less spacing between lines
+            col = box.column(align=True)
+            col.label(text=f'{log.num_warnings} warnings occurred during compilation!', icon='ERROR')
+            # Blank icon to achieve the same indentation as the line before
+            col.label(text='Please open the console to get more information.', icon='BLANK1')
 
 class ARM_PT_ArmoryExporterPanel(bpy.types.Panel):
     bl_label = "Armory Exporter"
@@ -612,7 +620,7 @@ class ArmoryCleanProjectButton(bpy.types.Operator):
         return{'FINISHED'}
 
 def draw_view3d_header(self, context):
-    if state.proc_build != None:
+    if state.proc_build is not None:
         self.layout.label(text='Compiling..')
     elif log.info_text != '':
         self.layout.label(text=log.info_text)


### PR DESCRIPTION
Requires https://github.com/Kode/khamake/pull/227 (already merged in the upstream repo).

This PR adds a new `Verbose Output` option to the UI that, when turned off, shows only some basic compile information, warnings and error messages. Most of the time you don't need messages about each asset that get's exported, it just distracts from warnings. When turned on, it shows the same content as before (so `true` is the old default and `false` the new one).

![Verbose output option](https://user-images.githubusercontent.com/17685000/76128887-e9182c80-6005-11ea-8ec1-e2b3a2465331.png)

In the best case, the new console output looks like this now:
![Export screenshot](https://user-images.githubusercontent.com/17685000/76129046-6e9bdc80-6006-11ea-928f-73fe1fbf9678.png)

Also, warnings are now counted during export and a message is displayed both in the console and the UI to inform about warnings.

Console:
![Warnings in the console](https://user-images.githubusercontent.com/17685000/76129071-7d828f00-6006-11ea-8437-4d06ad3ef5c3.png)

UI:
![Warnings in the UI](https://user-images.githubusercontent.com/17685000/76129132-b1f64b00-6006-11ea-969b-9c4cd89dc78b.png)
