### PR TITLE
Fix noise texture

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -529,16 +529,15 @@ def parse_vector(node, socket):
         assets_add(get_sdk_path() + '/armory/Assets/' + 'noise256.png')
         assets_add_embedded_data('noise256.png')
         curshader.add_uniform('sampler2D snoise256', link='$noise256.png')
-        curshader.add_function(c_functions.str_tex_noise)
         if node.inputs[0].is_linked:
             co = parse_vector_input(node.inputs[0])
         else:
             co = 'bposition'
-        scale = parse_value_input(node.inputs[1])
+        scale = parse_value_input(node.inputs[2])
         # detail = parse_value_input(node.inputs[2])
         # distortion = parse_value_input(node.inputs[3])
         # Slow..
-        res = 'vec3(tex_noise({0} * {1}), tex_noise({0} * {1} + 0.33), tex_noise({0} * {1} + 0.66))'.format(co, scale)
+        res = 'vec3(tex_noise({0} * {1}), tex_noise({0} * {1} + 5.0), tex_noise({0} * {1} + 8.0))'.format(co, scale)
         if sample_bump:
             write_bump(node, res, 0.1)
         return res

--- a/blender/arm/material/cycles_functions.py
+++ b/blender/arm/material/cycles_functions.py
@@ -68,7 +68,8 @@ float tex_noise_f(vec3 x) {
                mix(mix(hash(n + dot(step, vec3(0, 0, 1))), hash(n + dot(step, vec3(1, 0, 1))), u.x),
                    mix(hash(n + dot(step, vec3(0, 1, 1))), hash(n + dot(step, vec3(1, 1, 1))), u.x), u.y), u.z);
 }
-float tex_noise(vec3 p) {
+float tex_noise(vec3 k) {
+    vec3 p = vec3(k.xy, 0);
     p *= 1.25;
     float f = 0.5 * tex_noise_f(p); p *= 2.01;
     f += 0.25 * tex_noise_f(p); p *= 2.02;


### PR DESCRIPTION
The way this fix is done might be against the way the shader was intended to function. Fix # 1 will still apply though, because for some reason the scale input of the noise texture is at id "2" instead of being at id "1". Fix # 2 is not letting the shader use the Z coordinate of its input because that crashes it. I have no idea why. Also changed the shifting parameters of the G and B values because I think that it looks closer to what it looks like in Blender with that.