### PR TITLE
Fix support for box/triplanar mapping

### DIFF
--- a/Shaders/std/mapping.glsl
+++ b/Shaders/std/mapping.glsl
@@ -1,0 +1,41 @@
+/*
+https://github.com/JonasFolletete/glsl-triplanar-mapping
+
+MIT License
+
+Copyright (c) 2018 Jonas Folletête
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+vec3 blendNormal(vec3 normal) {
+	vec3 blending = abs(normal);
+	blending = normalize(max(blending, 0.00001));
+	blending /= vec3(blending.x + blending.y + blending.z);
+	return blending;
+}
+
+vec3 triplanarMapping (sampler2D ImageTexture, vec3 normal, vec3 position) {
+  	vec3 normalBlend = blendNormal(normal);
+	vec3 xColor = texture(ImageTexture, position.yz).rgb;
+	vec3 yColor = texture(ImageTexture, position.xz).rgb;
+	vec3 zColor = texture(ImageTexture, position.xy).rgb;
+
+  return (xColor * normalBlend.x + yColor * normalBlend.y + zColor * normalBlend.z);
+}

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -80,7 +80,7 @@ class ShaderContext:
     def sort_vs(self):
         vs = []
         ar = ['pos', 'nor', 'tex', 'tex1', 'col', 'tang', 'bone', 'weight', 'ipos', 'irot', 'iscl']
-        for ename in ar:  
+        for ename in ar:
             elem = self.get_elem(ename)
             if elem != None:
                 vs.append(elem)
@@ -125,7 +125,7 @@ class ShaderContext:
 
     def make_vert(self):
         self.data['vertex_shader'] = self.matname + '_' + self.data['name'] + '.vert'
-        self.vert = Shader(self, 'vert')        
+        self.vert = Shader(self, 'vert')
         return self.vert
 
     def make_frag(self):
@@ -173,6 +173,9 @@ class Shader:
         self.geom_passthrough = False
         self.is_linked = False # Use already generated shader
         self.noprocessing = False
+
+    def has_include(self, s):
+        return s in self.includes
 
     def add_include(self, s):
         self.includes.append(s)
@@ -295,7 +298,7 @@ class Shader:
 
         if self.shader_type == 'vert':
             self.vstruct_to_vsin()
-        
+
         elif self.shader_type == 'tesc':
             in_ext = '[]'
             out_ext = '[]'


### PR DESCRIPTION
I modified the shader parser so that triplanar mapping of textures is supported.
Currently tested and working with Armory PBR and Principled BSDF.
Normals are supported.

Fixes this https://github.com/armory3d/armory/issues/1292

![image](https://user-images.githubusercontent.com/42382648/76686888-d8674800-65fd-11ea-8461-c3a7bf929e7c.png)

![image](https://user-images.githubusercontent.com/42382648/76686983-a3a7c080-65fe-11ea-8534-59e8bad02405.png)

