### PR TITLE
Keep Canvas dimensions the same as the game dimensions

### DIFF
--- a/Sources/armory/trait/internal/CanvasScript.hx
+++ b/Sources/armory/trait/internal/CanvasScript.hx
@@ -60,7 +60,8 @@ class CanvasScript extends Trait {
 
 		notifyOnRender2D(function(g: kha.graphics2.Graphics) {
 			if (canvas == null) return;
-
+			
+			setCanvasDimensions(kha.System.windowWidth(), kha.System.windowHeight());
 			var events = Canvas.draw(cui, canvas, g);
 
 			for (e in events) {
@@ -110,7 +111,16 @@ class CanvasScript extends Trait {
 	public function setCanvasVisibility(visible: Bool){
 		for (e in canvas.elements) e.visible = visible;
 	}
-
+	
+	/**
+	 * Set dimensions of canvas
+	 * @param x Width
+	 * @param y Height
+	 */
+	public function setCanvasDimensions(x: Int, y: Int){
+		canvas.width = x;
+		canvas.height = y;
+	}
 	/**
 	 * Set font size of the canvas
 	 * @param fontSize Size of font to be setted


### PR DESCRIPTION
I had to make a new PR because I couldn't figure out how to add  a new commit since I didn't push the first PR from a my fork. 
Armory would now set the canvas dimensions every frame to the game's dimensions, so the anchors are where they should be even if the windows gets resized.