### PR TITLE
Upgrade noise texture

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -534,10 +534,9 @@ def parse_vector(node, socket):
         else:
             co = 'bposition'
         scale = parse_value_input(node.inputs[2])
-        # detail = parse_value_input(node.inputs[2])
-        # distortion = parse_value_input(node.inputs[3])
-        # Slow..
-        res = 'vec3(tex_noise({0} * {1}), tex_noise({0} * {1} + 5.0), tex_noise({0} * {1} + 8.0))'.format(co, scale)
+        detail = parse_value_input(node.inputs[3])
+        distortion = parse_value_input(node.inputs[4])
+        res = 'vec3(tex_noise({0} * {1},{2},{3}), tex_noise({0} * {1} + 120.0,{2},{3}), tex_noise({0} * {1} + 168.0,{2},{3}))'.format(co, scale, detail, distortion)
         if sample_bump:
             write_bump(node, res, 0.1)
         return res
@@ -1275,9 +1274,9 @@ def parse_value(node, socket):
         else:
             co = 'bposition'
         scale = parse_value_input(node.inputs[2])
-        # detail = parse_value_input(node.inputs[2])
-        # distortion = parse_value_input(node.inputs[3])
-        res = 'tex_noise({0} * {1})'.format(co, scale)
+        detail = parse_value_input(node.inputs[3])
+        distortion = parse_value_input(node.inputs[4])
+        res = 'tex_noise({0} * {1},{2},{3})'.format(co, scale, detail, distortion)
         if sample_bump:
             write_bump(node, res, 0.1)
         return res

--- a/blender/arm/material/cycles_functions.py
+++ b/blender/arm/material/cycles_functions.py
@@ -56,26 +56,66 @@ vec4 tex_voronoi(const vec3 x) {
 # By Morgan McGuire @morgan3d, http://graphicscodex.com Reuse permitted under the BSD license.
 # https://www.shadertoy.com/view/4dS3Wd
 str_tex_noise = """
-float hash(float n) { return fract(sin(n) * 1e4); }
-float tex_noise_f(vec3 x) {
-    const vec3 step = vec3(110, 241, 171);
-    vec3 i = floor(x);
-    vec3 f = fract(x);
-    float n = dot(i, step);
-    vec3 u = f * f * (3.0 - 2.0 * f);
-    return mix(mix(mix(hash(n + dot(step, vec3(0, 0, 0))), hash(n + dot(step, vec3(1, 0, 0))), u.x),
-                   mix(hash(n + dot(step, vec3(0, 1, 0))), hash(n + dot(step, vec3(1, 1, 0))), u.x), u.y),
-               mix(mix(hash(n + dot(step, vec3(0, 0, 1))), hash(n + dot(step, vec3(1, 0, 1))), u.x),
-                   mix(hash(n + dot(step, vec3(0, 1, 1))), hash(n + dot(step, vec3(1, 1, 1))), u.x), u.y), u.z);
+//	<https://www.shadertoy.com/view/4dS3Wd>
+//	By Morgan McGuire @morgan3d, http://graphicscodex.com
+float hash(vec2 p) { return fract(1e4 * sin(17.0 * p.x + p.y * 0.1) * (0.1 + abs(sin(p.y * 13.0 + p.x)))); }
+
+float noise(vec2 x) {
+	vec2 i = floor(x);
+	vec2 f = fract(x);
+
+	// Four corners in 2D of a tile
+	float a = hash(i);
+	float b = hash(i + vec2(1.0, 0.0));
+	float c = hash(i + vec2(0.0, 1.0));
+	float d = hash(i + vec2(1.0, 1.0));
+
+	// Simple 2D lerp using smoothstep envelope between the values.
+	// return vec3(mix(mix(a, b, smoothstep(0.0, 1.0, f.x)),
+	//			mix(c, d, smoothstep(0.0, 1.0, f.x)),
+	//			smoothstep(0.0, 1.0, f.y)));
+
+	// Same code, with the clamps in smoothstep and common subexpressions
+	// optimized away.
+	vec2 u = f * f * (3.0 - 2.0 * f);
+	return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
 }
-float tex_noise(vec3 k) {
-    vec3 p = vec3(k.xy, 0);
-    p *= 1.25;
-    float f = 0.5 * tex_noise_f(p); p *= 2.01;
-    f += 0.25 * tex_noise_f(p); p *= 2.02;
-    f += 0.125 * tex_noise_f(p); p *= 2.03;
-    f += 0.0625 * tex_noise_f(p);
-    return 1.0 - f;
+
+//  Shader-code from adapted from Blender
+//  https://github.com/sobotka/blender/blob/master/source/blender/gpu/shaders/material/gpu_shader_material_tex_wave.glsl & /gpu_shader_material_fractal_noise.glsl
+float fractal_noise(vec2 p, float octaves)
+{
+  float fscale = 1.0;
+  float amp = 1.0;
+  float sum = 0.0;
+  octaves = clamp(octaves, 0.0, 16.0);
+  int n = int(octaves);
+  for (int i = 0; i <= n; i++) {
+    float t = noise(fscale * p);
+    sum += t * amp;
+    amp *= 0.5;
+    fscale *= 2.0;
+  }
+  float rmd = octaves - floor(octaves);
+  if (rmd != 0.0) {
+    float t = noise(fscale * p);
+    float sum2 = sum + t * amp;
+    sum *= float(pow(2, n)) / float(pow(2, n + 1) - 1.0);
+    sum2 *= float(pow(2, n + 1)) / float(pow(2, n + 2) - 1);
+    return (1.0 - rmd) * sum + rmd * sum2;
+  }
+  else {
+    sum *= float(pow(2, n)) / float(pow(2, n + 1) - 1); 
+    return sum;
+  }
+}
+
+float tex_noise(vec3 co, float detail, float distortion) {
+    vec2 p = co.xy * 2;
+    if (distortion != 0.0) {
+    p += vec2(noise(p) * distortion,noise(p) * distortion);
+  }
+  return fractal_noise(p, detail);
 }
 """
 


### PR DESCRIPTION
Noise texture takes all inputs in Blender into account. Seems to be just as fast as the old method when detail is set to 0 while still not ignoring distortion. Upping the detail reduces performance, but only slightly if you only push it as far as you can see a difference.