### PR TITLE
Make procd textures 3d again, fix broken Z coord in bposition

### DIFF
--- a/blender/arm/material/make_finalize.py
+++ b/blender/arm/material/make_finalize.py
@@ -69,6 +69,8 @@ def make(con_mesh):
         vert.add_uniform('float posUnpack', link='_posUnpack')
         vert.write_attrib('bposition = (spos.xyz * posUnpack + hdim) / dim;')
         vert.write_attrib('if (dim.z == 0) bposition.z = 0;')
+        vert.write_attrib('if (dim.y == 0) bposition.y = 0;')
+        vert.write_attrib('if (dim.x == 0) bposition.x = 0;')
     
     if tese != None:
         if frag_bpos:

--- a/blender/arm/material/make_finalize.py
+++ b/blender/arm/material/make_finalize.py
@@ -68,6 +68,7 @@ def make(con_mesh):
         vert.add_uniform('vec3 hdim', link='_halfDim')
         vert.add_uniform('float posUnpack', link='_posUnpack')
         vert.write_attrib('bposition = (spos.xyz * posUnpack + hdim) / dim;')
+        vert.write_attrib('if (dim.z == 0) bposition.z = 0;')
     
     if tese != None:
         if frag_bpos:


### PR DESCRIPTION
I finally found out why the Z coordinate of 'bposition' was broken, a div by 0 occurred in the vertex shader if the mesh is flat. Fixed that and made the textures 3d again so they don't look stretched on not-flat objects.