### PR TITLE
Fixed memory problem in `ArmoryExporter.execute` [fixes #1604]

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1923,7 +1923,7 @@ class ArmoryExporter:
         # scene_objects = []
         # for lay in self.scene.view_layers:
             # scene_objects += lay.objects
-        scene_objects = self.scene.collection.all_objects
+        scene_objects = self.scene.collection.all_objects.values()
 
         for bobject in scene_objects:
             # Map objects to game objects


### PR DESCRIPTION
The Blender crash referenced in the issue happened always when starting 2nd iteration of the loop in line 2041 ( https://github.com/armory3d/armory/blob/master/blender/arm/exporter.py#L2041 ). I'm not really sure, but I bet it had to do with `export_object` modifying `bpy.context.collection.objects` (line 818 — https://github.com/armory3d/armory/blob/master/blender/arm/exporter.py#L818 ), wich in turn could invalidate the reference obtained in line 1926 ( https://github.com/armory3d/armory/blob/master/blender/arm/exporter.py#L1926 ), if I understand a bit of Blender internals — wich I didn't some days ago, so this could be completely wrong :sweat_smile:  .

It no longer happens with this change.