### PR TITLE
Fix camera export when multiple scenes are exported

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -713,7 +713,7 @@ class ArmoryExporter:
 
             elif type == NodeTypeCamera:
                 if 'spawn' in o and not o['spawn']:
-                    self.camera_spawned = False
+                    self.camera_spawned |= False
                 else:
                     self.camera_spawned = True
                 if objref not in self.cameraArray:


### PR DESCRIPTION
Previously, the warning `Armory Warning: No camera found in active scene` was displayed when exporting two or more scenes with different cameras.

For scenes other than the first exported scene, the attribute `o['spawn']` is set to `False` for objects not in the currently exported scene to disable them (makes sense so far):
https://github.com/armory3d/armory/blob/4c3332858ef0f397d898b3050fd86f80e47868eb/blender/arm/exporter.py#L586-L589


The issue with that was that if `spawn` was set to `False`, `camera_spawned` (states whether a camera is found and exported) was set to `False` too, thus revising that information even if a valid camera was found before:
https://github.com/armory3d/armory/blob/4c3332858ef0f397d898b3050fd86f80e47868eb/blender/arm/exporter.py#L715-L716

Just a **_very_** small fix but one that took way too long to find. The exporter is very messy, maybe someday I'll have the time to refactor some parts of it :)

Thanks to @knowledgenude for reporting this issue
