### PR TITLE
Fix debug console

### DIFF
--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -167,7 +167,7 @@ class DebugConsole extends Trait {
 
 						if (currentObject.children.length > 0) {
 							ui.row([1 / 13, 12 / 13]);
-							b = ui.panel(listHandle.nest(lineCounter, {selected: true}), "", true);
+							b = ui.panel(listHandle.nest(lineCounter, {selected: true}), "", true, false, false);
 							ui.text(currentObject.name);
 						}
 						else {

--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -352,8 +352,13 @@ class DebugConsole extends Trait {
 
 						if (selectedObject.name == "Scene") {
 							selectedType = "(Scene)";
-							var p = iron.Scene.active.world.probe;
-							p.raw.strength = ui.slider(Id.handle({value: p.raw.strength}), "Env Strength", 0.0, 5.0, true);
+							if (iron.Scene.active.world != null) {
+								var p = iron.Scene.active.world.probe;
+								p.raw.strength = ui.slider(Id.handle({value: p.raw.strength}), "Env Strength", 0.0, 5.0, true);
+							}
+							else {
+								ui.text("This scene has no world data to edit.");
+							}
 						}
 						else if (Std.is(selectedObject, iron.object.LightObject)) {
 							selectedType = "(Light)";


### PR DESCRIPTION
- Previously there was a null pointer exception when a scene was selected that had no world
- The outliner look was wrong since https://github.com/armory3d/zui/commit/038c6d4e40716a416583b464bd7461fc756b0a28