### PR TITLE
Add "Fake User" setting for traits + reorder trait UI

### DIFF
--- a/Sources/armory/logicnode/TraitNode.hx
+++ b/Sources/armory/logicnode/TraitNode.hx
@@ -14,6 +14,7 @@ class TraitNode extends LogicNode {
 
 		var cname = Type.resolveClass(Main.projectPackage + "." + property0);
 		if (cname == null) cname = Type.resolveClass(Main.projectPackage + ".node." + property0);
+		if (cname == null) throw 'No trait with the name "$property0" found, make sure that the trait is exported!';
 		value = Type.createInstance(cname, []);
 		return value;
 	}

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2467,8 +2467,12 @@ class ArmoryExporter:
     def export_traits(self, bobject, o):
         if hasattr(bobject, 'arm_traitlist'):
             for t in bobject.arm_traitlist:
-                if t.enabled_prop == False:
+                # Don't export disabled traits but still export those
+                # with fake user enabled so that nodes like `TraitNode`
+                # still work
+                if not t.enabled_prop and not t.fake_user:
                     continue
+
                 x = {}
                 if t.type_prop == 'Logic Nodes' and t.node_tree_prop != None and t.node_tree_prop.name != '':
                     x['type'] = 'Script'

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -567,33 +567,8 @@ def draw_traits(layout, obj, is_object):
 
     if obj.arm_traitlist_index >= 0 and len(obj.arm_traitlist) > 0:
         item = obj.arm_traitlist[obj.arm_traitlist_index]
-        # Default props
+
         if item.type_prop == 'Haxe Script' or item.type_prop == 'Bundled Script':
-            item.name = item.class_name_prop
-            row = layout.row()
-            if item.type_prop == 'Haxe Script':
-                row.prop_search(item, "class_name_prop", bpy.data.worlds['Arm'], "arm_scripts_list", text="Class")
-            else:
-                # Bundled scripts not yet fetched
-                if not bpy.data.worlds['Arm'].arm_bundled_scripts_list:
-                    arm.utils.fetch_bundled_script_names()
-                row.prop_search(item, "class_name_prop", bpy.data.worlds['Arm'], "arm_bundled_scripts_list", text="Class")
-
-            # Props
-            if item.arm_traitpropslist:
-                layout.label(text="Trait Properties:")
-                if item.arm_traitpropswarnings:
-                    box = layout.box()
-                    box.label(text=f"Warnings ({len(item.arm_traitpropswarnings)}):", icon="ERROR")
-
-                    for warning in item.arm_traitpropswarnings:
-                        box.label(text=warning.warning)
-
-                propsrow = layout.row()
-                propsrows = max(len(item.arm_traitpropslist), 6)
-                row = layout.row()
-                row.template_list("ARM_UL_PropList", "The_List", item, "arm_traitpropslist", item, "arm_traitpropslist_index", rows=propsrows)
-
             if item.type_prop == 'Haxe Script':
                 row = layout.row(align=True)
                 row.alignment = 'EXPAND'
@@ -620,6 +595,17 @@ def draw_traits(layout, obj, is_object):
                     op.is_object = is_object
                 op = row.operator("arm.refresh_scripts")
 
+            # Default props
+            item.name = item.class_name_prop
+            row = layout.row()
+            if item.type_prop == 'Haxe Script':
+                row.prop_search(item, "class_name_prop", bpy.data.worlds['Arm'], "arm_scripts_list", text="Class")
+            else:
+                # Bundled scripts not yet fetched
+                if not bpy.data.worlds['Arm'].arm_bundled_scripts_list:
+                    arm.utils.fetch_bundled_script_names()
+                row.prop_search(item, "class_name_prop", bpy.data.worlds['Arm'], "arm_bundled_scripts_list", text="Class")
+
         elif item.type_prop == 'WebAssembly':
             item.name = item.webassembly_prop
             row = layout.row()
@@ -638,8 +624,6 @@ def draw_traits(layout, obj, is_object):
 
         elif item.type_prop == 'UI Canvas':
             item.name = item.canvas_name_prop
-            row = layout.row()
-            row.prop_search(item, "canvas_name_prop", bpy.data.worlds['Arm'], "arm_canvas_list", text="Canvas")
 
             row = layout.row(align=True)
             row.alignment = 'EXPAND'
@@ -653,9 +637,28 @@ def draw_traits(layout, obj, is_object):
             op.is_object = is_object
             op = row.operator("arm.refresh_canvas_list")
 
+            row = layout.row()
+            row.prop_search(item, "canvas_name_prop", bpy.data.worlds['Arm'], "arm_canvas_list", text="Canvas")
+
         elif item.type_prop == 'Logic Nodes':
             row = layout.row()
             row.prop_search(item, "node_tree_prop", bpy.data, "node_groups", text="Tree")
+
+        if item.type_prop == 'Haxe Script' or item.type_prop == 'Bundled Script':
+            # Props
+            if item.arm_traitpropslist:
+                layout.label(text="Trait Properties:")
+                if item.arm_traitpropswarnings:
+                    box = layout.box()
+                    box.label(text=f"Warnings ({len(item.arm_traitpropswarnings)}):", icon="ERROR")
+
+                    for warning in item.arm_traitpropswarnings:
+                        box.label(text=warning.warning)
+
+                propsrow = layout.row()
+                propsrows = max(len(item.arm_traitpropslist), 6)
+                row = layout.row()
+                row.template_list("ARM_UL_PropList", "The_List", item, "arm_traitpropslist", item, "arm_traitpropslist_index", rows=propsrows)
 
 def register():
     global icons_dict

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -54,6 +54,7 @@ class ArmTraitListItem(bpy.types.PropertyGroup):
     name: StringProperty(name="Name", description="A name for this item", default="")
     enabled_prop: BoolProperty(name="", description="A name for this item", default=True, update=trigger_recompile)
     is_object: BoolProperty(name="", default=True)
+    fake_user: BoolProperty(name="Fake User", description="Export this trait even if it is deactivated", default=False)
     type_prop: EnumProperty(
         items = [('Haxe Script', 'Haxe', 'Haxe Script'),
                  ('WebAssembly', 'Wasm', 'WebAssembly'),
@@ -88,11 +89,15 @@ class ARM_UL_TraitList(bpy.types.UIList):
         # Make sure your code supports all 3 layout types
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
             layout.prop(item, "enabled_prop")
-            layout.label(text=item.name, icon=custom_icon, icon_value=custom_icon_value)
+            # Display " " for props without a name to right-align the
+            # fake_user button
+            layout.label(text=item.name if item.name != "" else " ", icon=custom_icon, icon_value=custom_icon_value)
 
         elif self.layout_type in {'GRID'}:
             layout.alignment = 'CENTER'
             layout.label(text="", icon=custom_icon, icon_value=custom_icon_value)
+
+        layout.prop(item, "fake_user", text="", icon="FAKE_USER_ON" if item.fake_user else "FAKE_USER_OFF")
 
 class ArmTraitListNewItem(bpy.types.Operator):
     # Add a new item to the list


### PR DESCRIPTION
Traits now have a `Fake User` setting. If set to `true`, the trait will be exported even if it is deactivated. This fixes https://github.com/armory3d/armory/issues/1529.

![Screenshot of the "Fake User" option](https://user-images.githubusercontent.com/17685000/79015439-02fce000-7b6d-11ea-8de5-0f04ca0e639b.png)


I've also slightly changed the trait UI:
**Before**:
![traits_before](https://user-images.githubusercontent.com/17685000/79015485-1f991800-7b6d-11ea-968e-9e91131af9c5.png)

**After**:
![traits_after](https://user-images.githubusercontent.com/17685000/79015489-20ca4500-7b6d-11ea-8f2c-059a0d2e231b.png)