### PR TITLE
Fix ArrayLoopNode socket (dynamic value) + add "Index" output

### DIFF
--- a/Sources/armory/logicnode/ArrayLoopNode.hx
+++ b/Sources/armory/logicnode/ArrayLoopNode.hx
@@ -3,6 +3,7 @@ package armory.logicnode;
 class ArrayLoopNode extends LogicNode {
 
 	var value: Dynamic;
+	var index: Int;
 
 	public function new(tree: LogicTree) {
 		super(tree);
@@ -12,8 +13,10 @@ class ArrayLoopNode extends LogicNode {
 		var ar: Array<Dynamic> = inputs[1].get();
 		if (ar == null) return;
 
+		index = -1;
 		for (val in ar) {
 			value = val;
+			index++;
 			runOutput(0);
 
 			if (tree.loopBreak) {
@@ -21,10 +24,12 @@ class ArrayLoopNode extends LogicNode {
 				break;
 			}
 		}
-		runOutput(2);
+		runOutput(3);
 	}
 
 	override function get(from: Int): Dynamic {
-		return value;
+		if (from == 1)
+			return value;
+		return index;
 	}
 }

--- a/blender/arm/logicnode/logic_array_loop.py
+++ b/blender/arm/logicnode/logic_array_loop.py
@@ -8,12 +8,13 @@ class ArrayLoopNode(Node, ArmLogicTreeNode):
     bl_idname = 'LNArrayLoopNode'
     bl_label = 'Array Loop'
     bl_icon = 'CURVE_PATH'
-    
+
     def init(self, context):
         self.inputs.new('ArmNodeSocketAction', 'In')
         self.inputs.new('ArmNodeSocketArray', 'Array')
         self.outputs.new('ArmNodeSocketAction', 'Loop')
-        self.outputs.new('NodeSocketInt', 'Value')
+        self.outputs.new('NodeSocketShader', 'Value')
+        self.outputs.new('NodeSocketInt', 'Index')
         self.outputs.new('ArmNodeSocketAction', 'Done')
 
 add_node(ArrayLoopNode, category='Logic')


### PR DESCRIPTION
The value output socket of the ArrayLoop node was mistakenly showing a dark green circle (= Integer). This is now light green (= Dynamic). Thanks to "busy guy" on Discord for reporting this.

Also, the node now has an additional `Index` output that outputs the current index of the iteration.

**Example:**
![array_loop](https://user-images.githubusercontent.com/17685000/79048350-d86a6000-7c1c-11ea-8c3e-f213d8ed6b0a.png)
**Output**
```
armory.logicnode.PrintNode:15: 0
armory.logicnode.PrintNode:15: i: 0
armory.logicnode.PrintNode:15: 2
armory.logicnode.PrintNode:15: i: 1
armory.logicnode.PrintNode:15: 45
armory.logicnode.PrintNode:15: i: 2
```