### PR TITLE
A bunch of really small improvements

### DIFF
--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -175,7 +175,7 @@ class DebugConsole extends Trait {
 
 							// Draw line that shows parent relations
 							ui.g.color = ui.t.ACCENT_COL;
-							ui.g.drawLine(ui._x - 16, ui._y + ui.ELEMENT_H() / 2, ui._x, ui._y + ui.ELEMENT_H() / 2);
+							ui.g.drawLine(ui._x - 10, ui._y + ui.ELEMENT_H() / 2, ui._x, ui._y + ui.ELEMENT_H() / 2);
 							ui.g.color = 0xffffffff;
 
 							ui.text(currentObject.name);

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -356,7 +356,7 @@ class ARM_PT_ArmoryProjectPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
         row = layout.row(align=True)
-        row.operator("arm.open_editor")
+        row.operator("arm.open_editor", icon="DESKTOP")
         row.operator("arm.open_project_folder", icon="FILE_FOLDER")
 
 class ARM_PT_ProjectFlagsPanel(bpy.types.Panel):
@@ -1358,6 +1358,7 @@ class ArmProxyToggleAllButton(bpy.types.Operator):
 class ArmProxyApplyAllButton(bpy.types.Operator):
     bl_idname = 'arm.proxy_apply_all'
     bl_label = 'Apply to All'
+
     def execute(self, context):
         for obj in bpy.data.objects:
             if obj.proxy == None:

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -690,7 +690,7 @@ def open_editor(hx_path=None):
 
         # Sublime Text
         if get_code_editor() == 'sublime':
-            project_name = bpy.data.worlds['Arm'].arm_project_name
+            project_name = arm.utils.safestr(bpy.data.worlds['Arm'].arm_project_name)
             subl_project_path = arm.utils.get_fp() + f'/{project_name}.sublime-project'
 
             if not os.path.exists(subl_project_path):


### PR DESCRIPTION
- Fixed the look of the debug console outliner
- Now using `arm.utils.safestr()` for sublime text project names
- Added an icon for the "Code Editor" operator so that it is more distinguishable