### PR TITLE
Fix and refactor the colorramp node (+ more)

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -1060,18 +1060,20 @@ def parse_normal_map_color_input(inp, strength_input=None):
         con.add_elem('tang', 'short4norm')
     frag.write_normal -= 1
 
-def parse_value_input(inp):
+def parse_value_input(inp) -> str:
     if inp.is_linked:
-        l = inp.links[0]
+        link = inp.links[0]
 
-        if l.from_node.type == 'REROUTE':
-            return parse_value_input(l.from_node.inputs[0])
+        if link.from_node.type == 'REROUTE':
+            return parse_value_input(link.from_node.inputs[0])
 
-        res_var = write_result(l)
-        st = l.from_socket.type
-        if st == 'RGB' or st == 'RGBA' or st == 'VECTOR':
-            return '{0}.x'.format(res_var)
-        else: # VALUE
+        res_var = write_result(link)
+        socket_type = link.from_socket.type
+        if socket_type == 'RGB' or socket_type == 'RGBA' or socket_type == 'VECTOR':
+            # RGB to BW
+            return f'((({res_var}.r * 0.3 + {res_var}.g * 0.59 + {res_var}.b * 0.11) / 3.0) * 2.5)'
+        # VALUE
+        else:
             return res_var
     else:
         if mat_batch() and inp.is_uniform:

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -27,6 +27,8 @@ import arm.log
 import arm.material.mat_state as mat_state
 import arm.material.cycles_functions as c_functions
 
+from typing import Optional
+
 emission_found = False
 particle_info = None # Particle info export
 

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -1519,28 +1519,28 @@ def is_parsed(s):
     global parsed
     return s in parsed
 
-def res_var_name(node, socket):
+def res_var_name(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> str:
     return node_name(node.name) + '_' + safesrc(socket.name) + '_res'
 
-def write_result(l):
+def write_result(link: bpy.types.NodeLink) -> Optional[str]:
     global parsed
-    res_var = res_var_name(l.from_node, l.from_socket)
+    res_var = res_var_name(link.from_node, link.from_socket)
     # Unparsed node
     if not is_parsed(res_var):
         parsed[res_var] = True
-        st = l.from_socket.type
+        st = link.from_socket.type
         if st == 'RGB' or st == 'RGBA' or st == 'VECTOR':
-            res = parse_vector(l.from_node, l.from_socket)
-            if res == None:
+            res = parse_vector(link.from_node, link.from_socket)
+            if res is None:
                 return None
             curshader.write('vec3 {0} = {1};'.format(res_var, res))
         elif st == 'VALUE':
-            res = parse_value(l.from_node, l.from_socket)
-            if res == None:
+            res = parse_value(link.from_node, link.from_socket)
+            if res is None:
                 return None
             curshader.write('float {0} = {1};'.format(res_var, res))
     # Normal map already parsed, return
-    elif l.from_node.type == 'NORMAL_MAP':
+    elif link.from_node.type == 'NORMAL_MAP':
         return None
     return res_var
 

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -1538,7 +1538,10 @@ def write_result(link: bpy.types.NodeLink) -> Optional[str]:
             res = parse_value(link.from_node, link.from_socket)
             if res is None:
                 return None
-            curshader.write('float {0} = {1};'.format(res_var, res))
+            if link.from_node.type == "VALUE":
+                curshader.add_const('float', res_var, res)
+            else:
+                curshader.write('float {0} = {1};'.format(res_var, res))
     # Normal map already parsed, return
     elif link.from_node.type == 'NORMAL_MAP':
         return None

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -157,6 +157,7 @@ class Shader:
         self.ins = []
         self.outs = []
         self.uniforms = []
+        self.constants = []
         self.functions = {}
         self.main = ''
         self.main_init = ''
@@ -209,8 +210,30 @@ class Shader:
                 ar[0] = 'floats'
                 ar[1] = ar[1].split('[', 1)[0]
             self.context.add_constant(ar[0], ar[1], link=link)
-        if included == False and s not in self.uniforms:
+        if not included and s not in self.uniforms:
             self.uniforms.append(s)
+
+    def add_const(self, type_str: str, name: str, value_str: str, array_size: int = 0):
+        """
+        Add a global constant to the shader.
+
+        Parameters
+        ----------
+        type_str: : str
+            The name of the type, like 'float' or 'vec3'. If the
+            constant is an array, there is no need to add `[]` to the
+            type
+        name: str
+            The name of the variable
+        value_str: str
+            The value of the constant as a string
+        array_size: int
+            If not 0 (default value), create an array with the given size
+        """
+        if array_size == 0:
+            self.constants.append(f'{type_str} {name} = {value_str}')
+        elif array_size > 0:
+            self.constants.append(f'{type_str} {name}[{array_size}] = {type_str}[]({value_str})')
 
     def add_function(self, s):
         fname = s.split('(', 1)[0]
@@ -335,6 +358,8 @@ class Shader:
                 s += 'out {0}{1};\n'.format(a, out_ext)
         for a in self.uniforms:
             s += 'uniform ' + a + ';\n'
+        for c in self.constants:
+            s += 'const ' + c + ';\n'
         for f in self.functions:
             s += self.functions[f]
         s += 'void main() {\n'

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -219,7 +219,7 @@ class Shader:
 
         Parameters
         ----------
-        type_str: : str
+        type_str: str
             The name of the type, like 'float' or 'vec3'. If the
             constant is an array, there is no need to add `[]` to the
             type


### PR DESCRIPTION
- Colorramps now use the "factor" value if the input socket is not connected
- Fixed an issue when the factor value was larger than the largest element's value, this fixes https://github.com/armory3d/armory/issues/905 (the output from the test file in that issue still looks off but it is not related to the colorramp anymore)
- Fixed an issue when a color output socket was connected to a float input socket. Now, there is proper automatic rgb to bw conversion copied over from the `RGB to BW` node (this fixes https://github.com/armory3d/armory/issues/1404)
- There were `#todo` comments in the code mentioning `const` for the colorramp element vectors, so they are constant now :)
- Value node outputs are also constant now as value nodes don't have any inputs
- New `Shader.add_const()` method to add global constants
- Added some type annotations (+ a little bit of code cleanup again)

**Before:**
![colorramp_pre](https://user-images.githubusercontent.com/17685000/79670179-6caa6900-81c1-11ea-8589-9c8d6bd0adb3.jpg)

**After:**
![colorramp_post](https://user-images.githubusercontent.com/17685000/79670187-7764fe00-81c1-11ea-8358-cdb37a14c893.jpg)