### PR TITLE
Fix value node when used with material params

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -1559,7 +1559,7 @@ def write_result(link: bpy.types.NodeLink) -> Optional[str]:
             res = parse_value(link.from_node, link.from_socket)
             if res is None:
                 return None
-            if link.from_node.type == "VALUE":
+            if link.from_node.type == "VALUE" and not link.from_node.arm_material_param:
                 curshader.add_const('float', res_var, res)
             else:
                 curshader.write('float {0} = {1};'.format(res_var, res))


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1674

----

@luboslenco It looks like the ID in `arm_commit` does not use the commit hash but a hash value of the file's content(https://stackoverflow.com/a/1796675/9985959). Do you have any idea on how to improve this (git hooks maybe?) I stumpled upon this because I tried to find out which version @Simonrazer had in his issue above.
https://github.com/armory3d/armory/blob/df30e9b68158265e1fa181d3c2b43c91ece01a80/blender/arm/props.py#L13-L17