### PR TITLE
Added `CanvasScript.setUiScale` method.

### DIFF
--- a/Sources/armory/trait/internal/CanvasScript.hx
+++ b/Sources/armory/trait/internal/CanvasScript.hx
@@ -105,6 +105,14 @@ class CanvasScript extends Trait {
 	}
 
 	/**
+	 * Set UI scale factor.
+	 * @param factor Scale factor.
+	 */
+	 public function setUiScale(factor:Float) {
+		cui.setScale(factor);
+	}
+
+	/**
 	 * Set visibility of canvas
 	 * @param visible Whether canvas should be visible or not
 	*/


### PR DESCRIPTION
This exposes the `Zui.setScale` method trough `CanvasScript` to allow changing the scale factor for the UI elements.

I'm not really sure if this is the right place to put this nor if there would be another way of accessing this setting from Armory at runtime :thinking: 