### PR TITLE
Fix irradiance export

### DIFF
--- a/blender/arm/write_probes.py
+++ b/blender/arm/write_probes.py
@@ -228,8 +228,8 @@ def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True
 
     return mip_count
 
-# Parse sh coefs produced by cmft into json array
 def sh_to_json(sh_file):
+    """Parse sh coefs produced by cmft into json array"""
     with open(sh_file + '.c') as f:
         sh_lines = f.read().splitlines()
     band0_line = sh_lines[5]
@@ -240,10 +240,9 @@ def sh_to_json(sh_file):
     parse_band_floats(irradiance_floats, band0_line)
     parse_band_floats(irradiance_floats, band1_line)
     parse_band_floats(irradiance_floats, band2_line)
-    
-    sh_json = {}
-    sh_json['irradiance'] = irradiance_floats
-    ext = '.arm' if bpy.data.worlds['Arm'].arm_minimize else '.json'
+
+    sh_json = {'irradiance': irradiance_floats}
+    ext = '.arm' if bpy.data.worlds['Arm'].arm_minimize else ''
     arm.utils.write_arm(sh_file + ext, sh_json)
     
     # Clean up .c

--- a/blender/arm/write_probes.py
+++ b/blender/arm/write_probes.py
@@ -18,12 +18,12 @@ def add_rad_assets(output_file_rad, rad_format, num_mips):
 # Generate probes from environment map
 def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True):
     envpath = arm.utils.get_fp_build() + '/compiled/Assets/envmaps'
-    
+
     if not os.path.exists(envpath):
         os.makedirs(envpath)
 
     base_name = arm.utils.extract_filename(image_filepath).rsplit('.', 1)[0]
-    
+
     # Assets to be generated
     output_file_irr = envpath + '/' + base_name + '_irradiance'
     output_file_rad = envpath + '/' + base_name + '_radiance'
@@ -37,7 +37,7 @@ def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True
             if arm_radiance:
                 add_rad_assets(output_file_rad, rad_format, cached_num_mips)
             return cached_num_mips
-    
+
     # Get paths
     sdk_path = arm.utils.get_sdk_path()
     kha_path = arm.utils.get_kha_path()
@@ -51,10 +51,10 @@ def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True
     else:
         cmft_path = '"' + sdk_path + '/lib/armory_tools/cmft/cmft-linux64"'
         kraffiti_path = '"' + kha_path + '/Kinc/Tools/kraffiti/kraffiti-linux64"'
-    
+
     output_gama_numerator = '2.2' if disable_hdr else '1.0'
     input_file = arm.utils.asset_path(image_filepath)
-    
+
     # Scale map
     rpdat = arm.utils.get_rp()
     target_w = int(rpdat.arm_radiance_size)
@@ -77,7 +77,7 @@ def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True
             ' format=' + rad_format + \
             ' width=' + str(target_w) + \
             ' height=' + str(target_h)], shell=True)
-    
+
     # Irradiance spherical harmonics
     if arm.utils.get_os() == 'win':
         subprocess.call([ \
@@ -96,7 +96,7 @@ def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True
 
     sh_to_json(output_file_irr)
     add_irr_assets(output_file_irr)
-    
+
     # Mip-mapped radiance
     if arm_radiance == False:
         return cached_num_mips
@@ -111,7 +111,7 @@ def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True
         mip_count = 8
     else:
         mip_count = 7
-    
+
     wrd = bpy.data.worlds['Arm']
     use_opencl = 'true'
 
@@ -184,7 +184,7 @@ def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True
     generated_files = []
     for i in range(0, mip_count):
         generated_files.append(output_file_rad + '_' + str(i))
-    
+
     # Convert to jpgs
     if disable_hdr is True:
         for f in generated_files:
@@ -201,7 +201,7 @@ def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True
                     ' to="' + f + '.jpg"' + \
                     ' format=jpg'], shell=True)
             os.remove(f + '.hdr')
-    
+
     # Scale from (4x2 to 1x1>
     for i in range (0, 2):
         last = generated_files[-1]
@@ -221,7 +221,7 @@ def write_probes(image_filepath, disable_hdr, cached_num_mips, arm_radiance=True
                 ' scale=0.5' + \
                 ' format=' + rad_format], shell=True)
         generated_files.append(out)
-    
+
     mip_count += 2
 
     add_rad_assets(output_file_rad, rad_format, mip_count)
@@ -244,7 +244,7 @@ def sh_to_json(sh_file):
     sh_json = {'irradiance': irradiance_floats}
     ext = '.arm' if bpy.data.worlds['Arm'].arm_minimize else ''
     arm.utils.write_arm(sh_file + ext, sh_json)
-    
+
     # Clean up .c
     os.remove(sh_file + '.c')
 
@@ -263,9 +263,9 @@ def write_sky_irradiance(base_name):
     envpath = arm.utils.get_fp_build() + '/compiled/Assets/envmaps'
     if not os.path.exists(envpath):
         os.makedirs(envpath)
-    
+
     output_file = envpath + '/' + base_name + '_irradiance'
-    
+
     sh_json = {}
     sh_json['irradiance'] = irradiance_floats
     arm.utils.write_arm(output_file + '.arm', sh_json)
@@ -277,13 +277,13 @@ def write_color_irradiance(base_name, col):
     irradiance_floats = [col[0] * 1.13, col[1] * 1.13, col[2] * 1.13] # Adjust to Cycles
     for i in range(0, 24):
         irradiance_floats.append(0.0)
-    
+
     envpath = arm.utils.get_fp_build() + '/compiled/Assets/envmaps'
     if not os.path.exists(envpath):
         os.makedirs(envpath)
-    
+
     output_file = envpath + '/' + base_name + '_irradiance'
-    
+
     sh_json = {}
     sh_json['irradiance'] = irradiance_floats
     arm.utils.write_arm(output_file + '.arm', sh_json)


### PR DESCRIPTION
When `arm_minimize` was false, exported irradiance files got the ending `.json.json` and were not found.

---

@luboslenco Is there a reason that `arm.utils.write_arm()` does not add the `.arm` extension to minimized files but the `.json` extension to not minimized ones? Currently, there are a lot of lines like
```python
ext = '.arm' if bpy.data.worlds['Arm'].arm_minimize else ''
```
all over the codebase to compensate for this.