### PR TITLE
Big PlaySoundRawNode update

### DIFF
--- a/Sources/armory/logicnode/PlaySoundRawNode.hx
+++ b/Sources/armory/logicnode/PlaySoundRawNode.hx
@@ -50,6 +50,7 @@ class PlaySoundRawNode extends LogicNode {
 			case Stop:
 				if (channel != null) channel.stop();
 				tree.removeUpdate(this.onUpdate);
+				runOutput(2);
 		}
 	}
 

--- a/Sources/armory/logicnode/PlaySoundRawNode.hx
+++ b/Sources/armory/logicnode/PlaySoundRawNode.hx
@@ -2,15 +2,14 @@ package armory.logicnode;
 
 class PlaySoundRawNode extends LogicNode {
 
+	/** The name of the sound */
 	public var property0: String;
-	/**
-	 * Override sample rate
-	 */
+	/** Whether to loop the playback */
 	public var property1: Bool;
-	/**
-	 * Playback sample rate
-	 */
-	public var property2: Int;
+	/** Override sample rate */
+	public var property2: Bool;
+	/** Playback sample rate */
+	public var property3: Int;
 
 	public function new(tree: LogicTree) {
 		super(tree);
@@ -18,8 +17,8 @@ class PlaySoundRawNode extends LogicNode {
 
 	override function run(from: Int) {
 		iron.data.Data.getSound(property0, function(sound: kha.Sound) {
-			if (property1) sound.sampleRate = property2;
-			iron.system.Audio.play(sound, false);
+			if (property2) sound.sampleRate = property3;
+			iron.system.Audio.play(sound, property1);
 		});
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/PlaySoundRawNode.hx
+++ b/Sources/armory/logicnode/PlaySoundRawNode.hx
@@ -3,6 +3,14 @@ package armory.logicnode;
 class PlaySoundRawNode extends LogicNode {
 
 	public var property0: String;
+	/**
+	 * Override sample rate
+	 */
+	public var property1: Bool;
+	/**
+	 * Playback sample rate
+	 */
+	public var property2: Int;
 
 	public function new(tree: LogicTree) {
 		super(tree);
@@ -10,6 +18,7 @@ class PlaySoundRawNode extends LogicNode {
 
 	override function run(from: Int) {
 		iron.data.Data.getSound(property0, function(sound: kha.Sound) {
+			if (property1) sound.sampleRate = property2;
 			iron.system.Audio.play(sound, false);
 		});
 		runOutput(0);

--- a/Sources/armory/logicnode/PlaySoundRawNode.hx
+++ b/Sources/armory/logicnode/PlaySoundRawNode.hx
@@ -6,10 +6,12 @@ class PlaySoundRawNode extends LogicNode {
 	public var property0: String;
 	/** Whether to loop the playback */
 	public var property1: Bool;
-	/** Override sample rate */
+	/** Retrigger */
 	public var property2: Bool;
+	/** Override sample rate */
+	public var property3: Bool;
 	/** Playback sample rate */
-	public var property3: Int;
+	public var property4: Int;
 
 	var sound: kha.Sound = null;
 	var channel: kha.audio1.AudioChannel = null;
@@ -29,11 +31,12 @@ class PlaySoundRawNode extends LogicNode {
 
 				// Resume
 				if (channel != null) {
+					if (property2) channel.stop();
 					channel.play();
 				}
 				// Start
 				else if (sound != null) {
-					if (property2) sound.sampleRate = property3;
+					if (property3) sound.sampleRate = property4;
 					channel = iron.system.Audio.play(sound, property1);
 				}
 
@@ -41,17 +44,11 @@ class PlaySoundRawNode extends LogicNode {
 				runOutput(0);
 
 			case Pause:
-				if (channel != null) {
-					channel.pause();
-				}
-
+				if (channel != null) channel.pause();
 				tree.removeUpdate(this.onUpdate);
 
 			case Stop:
-				if (channel != null) {
-					channel.stop();
-				}
-
+				if (channel != null) channel.stop();
 				tree.removeUpdate(this.onUpdate);
 		}
 	}
@@ -64,9 +61,7 @@ class PlaySoundRawNode extends LogicNode {
 				runOutput(2);
 			}
 			// Running
-			else {
-				runOutput(1);
-			}
+			else runOutput(1);
 		}
 	}
 }

--- a/blender/arm/logicnode/sound_play_sound.py
+++ b/blender/arm/logicnode/sound_play_sound.py
@@ -15,10 +15,14 @@ class PlaySoundNode(Node, ArmLogicTreeNode):
         description='Play the sound in a loop',
         default=False)
     property2: BoolProperty(
+        name='Retrigger',
+        description='Play the sound from the beginning everytime',
+        default=False)
+    property3: BoolProperty(
         name='Use Custom Sample Rate',
         description='If enabled, override the default sample rate',
         default=False)
-    property3: IntProperty(
+    property4: IntProperty(
         name='Sample Rate',
         description='Set the sample rate used to play this sound',
         default=44100,
@@ -35,15 +39,17 @@ class PlaySoundNode(Node, ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0', bpy.data, 'sounds', icon='NONE', text='')
 
-        layout.prop(self, 'property1')
+        col = layout.column(align=True)
+        col.prop(self, 'property1')
+        col.prop(self, 'property2')
 
         layout.label(text="Overrides:")
         # Sample rate
         split = layout.split(factor=0.15, align=False)
-        split.prop(self, 'property2', text="")
+        split.prop(self, 'property3', text="")
         row = split.row()
-        if not self.property2:
+        if not self.property3:
             row.enabled = False
-        row.prop(self, 'property3')
+        row.prop(self, 'property4')
 
 add_node(PlaySoundNode, category='Sound')

--- a/blender/arm/logicnode/sound_play_sound.py
+++ b/blender/arm/logicnode/sound_play_sound.py
@@ -7,7 +7,7 @@ class PlaySoundNode(Node, ArmLogicTreeNode):
     """Play sound node"""
     bl_idname = 'LNPlaySoundRawNode'
     bl_label = 'Play Sound'
-    bl_icon = 'QUESTION'
+    bl_icon = 'PLAY_SOUND'
 
     property0: PointerProperty(name='', type=bpy.types.Sound)
     property1: BoolProperty(

--- a/blender/arm/logicnode/sound_play_sound.py
+++ b/blender/arm/logicnode/sound_play_sound.py
@@ -11,10 +11,14 @@ class PlaySoundNode(Node, ArmLogicTreeNode):
 
     property0: PointerProperty(name='', type=bpy.types.Sound)
     property1: BoolProperty(
+        name='Loop',
+        description='Play the sound in a loop',
+        default=False)
+    property2: BoolProperty(
         name='Use Custom Sample Rate',
         description='If enabled, override the default sample rate',
         default=False)
-    property2: IntProperty(
+    property3: IntProperty(
         name='Sample Rate',
         description='Set the sample rate used to play this sound',
         default=44100,
@@ -27,13 +31,15 @@ class PlaySoundNode(Node, ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0', bpy.data, 'sounds', icon='NONE', text='')
 
+        layout.prop(self, 'property1')
+
         layout.label(text="Overrides:")
         # Sample rate
         split = layout.split(factor=0.15, align=False)
-        split.prop(self, 'property1', text="")
+        split.prop(self, 'property2', text="")
         row = split.row()
-        if not self.property1:
+        if not self.property2:
             row.enabled = False
-        row.prop(self, 'property2')
+        row.prop(self, 'property3')
 
 add_node(PlaySoundNode, category='Sound')

--- a/blender/arm/logicnode/sound_play_sound.py
+++ b/blender/arm/logicnode/sound_play_sound.py
@@ -25,8 +25,12 @@ class PlaySoundNode(Node, ArmLogicTreeNode):
         min=0)
 
     def init(self, context):
-        self.inputs.new('ArmNodeSocketAction', 'In')
+        self.inputs.new('ArmNodeSocketAction', 'Play')
+        self.inputs.new('ArmNodeSocketAction', 'Pause')
+        self.inputs.new('ArmNodeSocketAction', 'Stop')
         self.outputs.new('ArmNodeSocketAction', 'Out')
+        self.outputs.new('ArmNodeSocketAction', 'Running')
+        self.outputs.new('ArmNodeSocketAction', 'Done')
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0', bpy.data, 'sounds', icon='NONE', text='')

--- a/blender/arm/logicnode/sound_play_sound.py
+++ b/blender/arm/logicnode/sound_play_sound.py
@@ -4,12 +4,21 @@ from bpy.types import Node, NodeSocket
 from arm.logicnode.arm_nodes import *
 
 class PlaySoundNode(Node, ArmLogicTreeNode):
-    '''Play sound node'''
+    """Play sound node"""
     bl_idname = 'LNPlaySoundRawNode'
     bl_label = 'Play Sound'
     bl_icon = 'QUESTION'
 
     property0: PointerProperty(name='', type=bpy.types.Sound)
+    property1: BoolProperty(
+        name='Use Custom Sample Rate',
+        description='If enabled, override the default sample rate',
+        default=False)
+    property2: IntProperty(
+        name='Sample Rate',
+        description='Set the sample rate used to play this sound',
+        default=44100,
+        min=0)
 
     def init(self, context):
         self.inputs.new('ArmNodeSocketAction', 'In')
@@ -17,5 +26,14 @@ class PlaySoundNode(Node, ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0', bpy.data, 'sounds', icon='NONE', text='')
+
+        layout.label(text="Overrides:")
+        # Sample rate
+        split = layout.split(factor=0.15, align=False)
+        split.prop(self, 'property1', text="")
+        row = split.row()
+        if not self.property1:
+            row.enabled = False
+        row.prop(self, 'property2')
 
 add_node(PlaySoundNode, category='Sound')

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -154,6 +154,8 @@ def build_node(node, f):
             prop = getattr(node, prop_name)
             if isinstance(prop, str):
                 prop = '"' + str(prop) + '"'
+            elif isinstance(prop, bool):
+                prop = str(prop).lower()
             elif hasattr(prop, 'name'): # PointerProperty
                 prop = '"' + str(prop.name) + '"'
             else:


### PR DESCRIPTION
This PR implements https://github.com/armory3d/armory/issues/1703 and adds even further functionality to the `PlaySoundRawNode`. Thanks to @knowledgenude for the proposal :)

**Screenshot**:
![Screenshot](https://user-images.githubusercontent.com/17685000/82101357-9a28fa80-970c-11ea-869a-6079668e25e7.png)

- Fixed boolean type node properties
- New inputs `Pause` and `Stop`
- New outputs `Running` and `Done`
- Setting for enabling loop playback (default `false`)
- `Retrigger` option that will play a sound from the beginning if `Play` is true but the sound is still playing (default `false`)
- Optional sample rate override to compensate for wrong playback pitch and speed (possibly a Kha issue)
- Changed the Node icon (does this even show up in the UI somewhere?)

**Example file**: (adapted from issue https://github.com/armory3d/armory/issues/1704)
[sound_node.zip](https://github.com/armory3d/armory/files/4637372/sound_node.zip)
