### PR TITLE
Allow to set custom play scene

### DIFF
--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -71,6 +71,7 @@ def init_properties():
         items=[('Scene', 'Scene', 'Scene'),
                ('Viewport', 'Viewport', 'Viewport')],
         name="Camera", description="Viewport camera", default='Scene', update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_play_scene = PointerProperty(name="Scene", description="Scene to launch", update=assets.invalidate_compiler_cache, type=bpy.types.Scene)
     bpy.types.World.arm_debug_console = BoolProperty(name="Debug Console", description="Show inspector in player and enable debug draw.\nRequires that Zui is not disabled", default=False, update=assets.invalidate_shader_cache)
     bpy.types.World.arm_verbose_output = BoolProperty(name="Verbose Output", description="Print additional information to the console during compilation", default=False)
     bpy.types.World.arm_runtime = EnumProperty(

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -272,6 +272,7 @@ class ARM_PT_ArmoryPlayerPanel(bpy.types.Panel):
         row.operator("arm.clean_menu")
         layout.prop(wrd, 'arm_runtime')
         layout.prop(wrd, 'arm_play_camera')
+        layout.prop(wrd, 'arm_play_scene')
 
         if log.num_warnings > 0:
             box = layout.box()

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -559,10 +559,12 @@ def get_project_scene_name():
     return get_active_scene().name
 
 def get_active_scene():
+    wrd = bpy.data.worlds['Arm']
     if not state.is_export:
-        return bpy.context.scene
+        if wrd.arm_play_scene == None:
+            return bpy.context.scene
+        return wrd.arm_play_scene
     else:
-        wrd = bpy.data.worlds['Arm']
         item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
         return item.arm_project_scene
 


### PR DESCRIPTION
This allows to (optionally) specify a scene to launch in player menu.  

I think it's a common workflow to load objects from other scenes into your main 'Game' scene, and pretty annoying to have to switch between scenes just for launching.