### PR TITLE
Proper debug console log output formatting

### DIFF
--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -118,7 +118,7 @@ class DebugConsole extends Trait {
 	static var haxeTrace: Dynamic->haxe.PosInfos->Void = null;
 	static var lastTraces: Array<String> = [""];
 	static function consoleTrace(v: Dynamic, ?inf: haxe.PosInfos) {
-		lastTraces.unshift(Std.string(v));
+		lastTraces.unshift(haxe.Log.formatOutput(v,inf));
 		if (lastTraces.length > 10) lastTraces.pop();
 		haxeTrace(v, inf);
 	}


### PR DESCRIPTION
Print the position and customParams passed to trace in the DebugConsole log.   

```haxe
trace("A","B","C");
```

Prints:
`my.Class.hx:23: A, B, C`

Instead of just:
`A`
