### PR TITLE
Add option for exclusive Fullscreen (WindowMode 2)

### DIFF
--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -87,7 +87,8 @@ def init_properties():
     bpy.types.World.arm_compiler_inline = BoolProperty(name="Compiler Inline", description="Favor speed over size", default=True, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_winmode = EnumProperty(
         items = [('Window', 'Window', 'Window'),
-                 ('Fullscreen', 'Fullscreen', 'Fullscreen')],
+                 ('Fullscreen', 'Fullscreen', 'Borderless Fullscreen Window'),
+                 ('Exclusive Fullscreen', 'Exclusive Fullscreen', 'Exclusive Fullscreen')],
         name="Mode", default='Window', description='Window mode to start in', update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_winorient = EnumProperty(
         items = [('Multi', 'Multi', 'Multi'),

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -298,8 +298,10 @@ project.addSources('Sources');
 def get_winmode(arm_winmode):
     if arm_winmode == 'Window':
         return 0
-    else: # Fullscreen
+    elif arm_winmode == 'Fullscreen': # Fullscreen
         return 1
+    else:   # Exclusive Fullscreen
+        return 2
 
 def write_config(resx, resy):
     wrd = bpy.data.worlds['Arm']


### PR DESCRIPTION
I am having issues with using Vsync in WindowMode 1, while it works fine in WindowMode 2. This is why I added this option to the UI. The original Fullscreen option still does the same thing (WindowMode 1).