### PR TITLE
Colored terminal output

### DIFF
--- a/blender/arm/log.py
+++ b/blender/arm/log.py
@@ -1,3 +1,9 @@
+DEBUG = 36
+INFO = 37
+WARN = 35
+ERROR = 31
+
+no_colors = False
 info_text = ''
 num_warnings = 0
 
@@ -10,12 +16,27 @@ def clear(clear_warnings=False):
 def format_text(text):
     return (text[:80] + '..') if len(text) > 80 else text # Limit str size
 
-def print_info(text):
-    global info_text
+def log(text,color=None):
+    if not no_colors and color is not None:
+        csi = '\033['
+        text = csi + str(color) + 'm' + text + csi + '0m';
     print(text)
+
+def debug(text):
+    log(text,DEBUG)
+
+def info(text):
+    global info_text
+    log(text,INFO)
     info_text = format_text(text)
+
+def print_warn(text):
+    log('Warning: ' + text,WARN)
 
 def warn(text):
     global num_warnings
     num_warnings += 1
-    print('Armory Warning: ' + text)
+    print_warn(text)
+
+def error(text):
+    log('ERROR: ' + text,ERROR)

--- a/blender/arm/log.py
+++ b/blender/arm/log.py
@@ -1,9 +1,15 @@
+import platform
+
 DEBUG = 36
 INFO = 37
 WARN = 35
 ERROR = 31
 
-no_colors = False
+if platform.system() == "Windows":
+    HAS_COLOR_SUPPORT = platform.release() == "10"
+else:
+    HAS_COLOR_SUPPORT = True
+
 info_text = ''
 num_warnings = 0
 
@@ -17,7 +23,7 @@ def format_text(text):
     return (text[:80] + '..') if len(text) > 80 else text # Limit str size
 
 def log(text,color=None):
-    if not no_colors and color is not None:
+    if HAS_COLOR_SUPPORT and color is not None:
         csi = '\033['
         text = csi + str(color) + 'm' + text + csi + '0m';
     print(text)

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -388,7 +388,7 @@ def assets_done():
     else:
         state.proc_build = None
         state.redraw_ui = True
-        log.print_info('Build failed, check console')
+        log.error('Build failed, check console')
 
 def compilation_server_done():
     if state.proc_build == None:
@@ -403,12 +403,12 @@ def compilation_server_done():
     else:
         state.proc_build = None
         state.redraw_ui = True
-        log.print_info('Build failed, check console')
+        log.error('Build failed, check console')
 
 def build_done():
     print('Finished in ' + str(time.time() - profile_time))
     if log.num_warnings > 0:
-        print(f'{log.num_warnings} warnings occurred during compilation!')
+        log.print_warn(f'{log.num_warnings} warnings occurred during compilation')
     if state.proc_build is None:
         return
     result = state.proc_build.poll()
@@ -418,7 +418,7 @@ def build_done():
         bpy.data.worlds['Arm'].arm_recompile = False
         build_success()
     else:
-        log.print_info('Build failed, check console')
+        log.error('Build failed, check console')
 
 def patch():
     if state.proc_build != None:


### PR DESCRIPTION
Adds colored terminal output using ansi escape codes.  
There might be some more places to use it, currently added to warnings and errors.   
I've only tested on linux but afaik this should be fine with macos, windows.

![Screenshot_2020-06-08_12-29-42](https://user-images.githubusercontent.com/203646/84020850-ce967c00-a983-11ea-9df5-c19ce69d0f30.png)
