### PR TITLE
Implement custom default values for custom node sockets

### DIFF
--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -33,6 +33,10 @@ class ArmCustomSocket(bpy.types.NodeSocket):
     bl_idname = 'ArmCustomSocket'
     bl_label = 'Custom Socket'
 
+    def get_default_value(self):
+        """Override this for values of unconnected input sockets."""
+        return None
+
 class ArmArraySocket(bpy.types.NodeSocket):
     bl_idname = 'ArmNodeSocketArray'
     bl_label = 'Array Socket'

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -241,10 +241,21 @@ def get_root_nodes(node_group):
             roots.append(node)
     return roots
 
-def build_default_node(inp):
+def build_default_node(inp: bpy.types.NodeSocket):
+    """Creates a new node to give a not connected input socket a value"""
     inp_name = 'new armory.logicnode.NullNode(this)'
+
     if isinstance(inp, arm.logicnode.arm_nodes.ArmCustomSocket):
-        return inp_name
+        # ArmCustomSockets need to implement get_default_value()
+        default_value = inp.get_default_value()
+
+        if default_value is None:
+            return inp_name
+        if isinstance(default_value, str):
+            default_value = f'"{default_value}"'
+
+        return f'new armory.logicnode.DynamicNode(this, {default_value})'
+
     if inp.bl_idname == 'ArmNodeSocketAction' or inp.bl_idname == 'ArmNodeSocketArray':
         return inp_name
     if inp.bl_idname == 'ArmNodeSocketObject':

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -243,39 +243,40 @@ def get_root_nodes(node_group):
 
 def build_default_node(inp: bpy.types.NodeSocket):
     """Creates a new node to give a not connected input socket a value"""
-    inp_name = 'new armory.logicnode.NullNode(this)'
+    null_node = 'new armory.logicnode.NullNode(this)'
 
     if isinstance(inp, arm.logicnode.arm_nodes.ArmCustomSocket):
         # ArmCustomSockets need to implement get_default_value()
         default_value = inp.get_default_value()
-
         if default_value is None:
-            return inp_name
+            return null_node
         if isinstance(default_value, str):
             default_value = f'"{default_value}"'
 
         return f'new armory.logicnode.DynamicNode(this, {default_value})'
 
     if inp.bl_idname == 'ArmNodeSocketAction' or inp.bl_idname == 'ArmNodeSocketArray':
-        return inp_name
+        return null_node
     if inp.bl_idname == 'ArmNodeSocketObject':
-        inp_name = 'new armory.logicnode.ObjectNode(this, "' + str(inp.get_default_value()) + '")'
-        return inp_name
+        return f'new armory.logicnode.ObjectNode(this, "{inp.get_default_value()}")'
     if inp.bl_idname == 'ArmNodeSocketAnimAction':
-        inp_name = 'new armory.logicnode.StringNode(this, "' + str(inp.get_default_value()).replace("\"", "\\\"") + '")'
-        return inp_name
+        # Backslashes are not allowed in f-strings so we need this variable
+        default_value = inp.get_default_value().replace("\"", "\\\"")
+        return f'new armory.logicnode.StringNode(this, "{default_value}")'
     if inp.type == 'VECTOR':
-        inp_name = 'new armory.logicnode.VectorNode(this, ' + str(inp.default_value[0]) + ', ' + str(inp.default_value[1]) + ', ' + str(inp.default_value[2]) + ')'
+        return f'new armory.logicnode.VectorNode(this, {inp.default_value[0]}, {inp.default_value[1]}, {inp.default_value[2]})'
     elif inp.type == 'RGBA':
-        inp_name = 'new armory.logicnode.ColorNode(this, ' + str(inp.default_value[0]) + ', ' + str(inp.default_value[1]) + ', ' + str(inp.default_value[2]) + ', ' + str(inp.default_value[3]) + ')'
+        return f'new armory.logicnode.ColorNode(this, {inp.default_value[0]}, {inp.default_value[1]}, {inp.default_value[2]}, {inp.default_value[3]})'
     elif inp.type == 'RGB':
-        inp_name = 'new armory.logicnode.ColorNode(this, ' + str(inp.default_value[0]) + ', ' + str(inp.default_value[1]) + ', ' + str(inp.default_value[2]) + ')'
+        return f'new armory.logicnode.ColorNode(this, {inp.default_value[0]}, {inp.default_value[1]}, {inp.default_value[2]})'
     elif inp.type == 'VALUE':
-        inp_name = 'new armory.logicnode.FloatNode(this, ' + str(inp.default_value) + ')'
+        return f'new armory.logicnode.FloatNode(this, {inp.default_value})'
     elif inp.type == 'INT':
-        inp_name = 'new armory.logicnode.IntegerNode(this, ' + str(inp.default_value) + ')'
+        return f'new armory.logicnode.IntegerNode(this, {inp.default_value})'
     elif inp.type == 'BOOLEAN':
-        inp_name = 'new armory.logicnode.BooleanNode(this, ' + str(inp.default_value).lower() + ')'
+        return f'new armory.logicnode.BooleanNode(this, {inp.default_value.lower()})'
     elif inp.type == 'STRING':
-        inp_name = 'new armory.logicnode.StringNode(this, "' + str(inp.default_value).replace("\"", "\\\"") + '")'
-    return inp_name
+        default_value = inp.default_value.replace("\"", "\\\"")
+        return f'new armory.logicnode.StringNode(this, "{default_value}")'
+
+    return null_node


### PR DESCRIPTION
Not connected custom input sockets now can have arbitrary default values (as long as they can be represented in Haxe syntax), previously they would just have the value `null`.