### PR TITLE
Fix building with analyzer-optimize enabled

### DIFF
--- a/Sources/armory/system/Starter.hx
+++ b/Sources/armory/system/Starter.hx
@@ -4,14 +4,14 @@ import kha.WindowOptions;
 
 class Starter {
 
-	static var tasks: Int;
-
 	#if arm_loadscreen
 	public static var drawLoading: kha.graphics2.Graphics->Int->Int->Void = null;
 	public static var numAssets: Int;
 	#end
 
 	public static function main(scene: String, mode: Int, resize: Bool, min: Bool, max: Bool, w: Int, h: Int, msaa: Int, vsync: Bool, getRenderPath: Void->iron.RenderPath) {
+
+		var tasks : Int;
 
 		function start() {
 			if (tasks > 0) return;
@@ -76,20 +76,17 @@ class Starter {
 		#if (js && arm_bullet)
 		function loadLibAmmo(name: String) {
 			kha.Assets.loadBlobFromPath(name, function(b: kha.Blob) {
-				var print = function(s:String) { trace(s); };
-				var loaded = function() { tasks--; start(); };
-				js.Syntax.code("(1, eval)({0})", b.toString());
+				js.Syntax.code("(1,eval)({0})", b.toString());
 				#if kha_krom
-				var instantiateWasm = function(imports, successCallback) {
-					var wasmbin = Krom.loadBlob("ammo.wasm.wasm");
-					var module = new js.lib.webassembly.Module(wasmbin);
-					var inst = new js.lib.webassembly.Instance(module, imports);
+				js.Syntax.code("Ammo({print:function(s){haxe.Log.trace(s);},instantiateWasm:function(imports,successCallback) {
+					var wasmbin = Krom.loadBlob('ammo.wasm.wasm');
+					var module = new WebAssembly.Module(wasmbin);
+					var inst = new WebAssembly.Instance(module,imports);
 					successCallback(inst);
 					return inst.exports;
-				};
-				js.Syntax.code("Ammo({print:print, instantiateWasm:instantiateWasm}).then(loaded)");
+				}}).then(function(){ tasks--; start();})");
 				#else
-				js.Syntax.code("Ammo({print:print}).then(loaded)");
+				js.Syntax.code("Ammo({print:function(s){haxe.Log.trace(s);}}).then(function(){ tasks--; start();})");
 				#end
 			});
 		}


### PR DESCRIPTION
Allows to build haxe project with static-analyzer (`-D analyzer-module`) enabled to improve code generation for the krom and html5 target. It's the only place where i've found such incompatibility but there might be more. Be aware that this change moves the ammo lib callbacks from haxe to untyped js, so  the compiler can't catch any errors from possible side effects, but works for me.

The generated code with analyzer enabled (without the fix) removes the callback to `print` and `instantiateWasm`:
```js
var loadLibAmmo = function(name) {
	kha_Assets.loadBlobFromPath(name,function(b) {
		(1, eval)(b.toString());
		Ammo({print:print, instantiateWasm:instantiateWasm}).then(loaded);
	},null,{ fileName : "Sources/armory/system/Starter.hx", lineNumber : 83, className : "armory.system.Starter", methodName : "main"});
};
```
So this might happening everywhere untyped js calls are used.

It would be nice to add this flag in release builds by default.  
