### PR TITLE
Fix NodeItem import

### DIFF
--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -2,7 +2,7 @@ import bpy
 from bpy.types import NodeTree
 from bpy.props import *
 import nodeitems_utils
-from nodeitems_utils import NodeCategory
+from nodeitems_utils import NodeCategory, NodeItem
 from arm.logicnode import *
 import webbrowser
 


### PR DESCRIPTION
Not sure why nobody is complaining but wuthout this import i get:
```sh
Traceback (most recent call last):
  File "/home/tong/.config/blender/2.83/scripts/addons/armory.py", line 260, in execute
    start.register(local_sdk=local_sdk)
  File "/home/tong/sdk/armsdk//armory/blender/start.py", line 33, in register
    arm.nodes_logic.register()
  File "/home/tong/sdk/armsdk//armory/blender/arm/nodes_logic.py", line 196, in register
    register_nodes()
  File "/home/tong/sdk/armsdk//armory/blender/arm/nodes_logic.py", line 52, in register_nodes
    layout_items += [NodeItem('NodeReroute'), NodeItem('NodeFrame')]
NameError: name 'NodeItem' is not defined
```