### PR TITLE
Fixed `armory.trait.physics.bullet.PhysicsWorld.rayCast` for Hashlink.

### DIFF
--- a/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
+++ b/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
@@ -327,7 +327,7 @@ class PhysicsWorld extends Trait {
 		#if js
 		rayCallback.set_m_collisionFilterGroup(group);
 		rayCallback.set_m_collisionFilterMask(mask);
-		#elseif cpp
+		#elseif (cpp || hl)
 		rayCallback.m_collisionFilterGroup = group;
 		rayCallback.m_collisionFilterMask = mask;
 		#end
@@ -348,7 +348,7 @@ class PhysicsWorld extends Trait {
 			hitNormalWorld.set(norm.x(), norm.y(), norm.z());
 			rb = rbMap.get(untyped body.userIndex);
 			hitInfo = new Hit(rb, hitPointWorld, hitNormalWorld);
-			#elseif cpp
+			#elseif (cpp || hl)
 			var hit = rayCallback.m_hitPointWorld;
 			hitPointWorld.set(hit.x(), hit.y(), hit.z());
 			var norm = rayCallback.m_hitNormalWorld;


### PR DESCRIPTION
Just enabling the same code used for C++.

This fix for example https://github.com/armory3d/armory_examples/tree/master/physics_raycast not working in C targets — and I think it should fix (or at least improve the situation with) #1706.