### PR TITLE
Fixed `armory.trait.PhysicsDrag.update` for Hashlink [fixes #1730]

### DIFF
--- a/Sources/armory/trait/PhysicsDrag.hx
+++ b/Sources/armory/trait/PhysicsDrag.hx
@@ -103,7 +103,7 @@ class PhysicsDrag extends Trait {
 				dir.setZ(dir.z() * pickDist);
 				var newPivotB = new bullet.Bt.Vector3(rayFrom.x() + dir.x(), rayFrom.y() + dir.y(), rayFrom.z() + dir.z());
 
-				#if js
+				#if (js || hl)
 				pickConstraint.getFrameOffsetA().setOrigin(newPivotB);
 				#elseif cpp
 				pickConstraint.setFrameOffsetAOrigin(newPivotB);


### PR DESCRIPTION
Just enabling the same code used for JavaScript.