### PR TITLE
Fix unset object prop

### DIFF
--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -536,6 +536,8 @@ def safestr(s: str) -> str:
     return ''.join([i if ord(i) < 128 else '_' for i in s])
 
 def asset_name(bdata):
+    if bdata == None:
+        return None
     s = bdata.name
     # Append library name if linked
     if bdata.library is not None:


### PR DESCRIPTION
Fix for:
```sh
File "/home/tong/sdk/armsdk//armory/blender/arm/utils.py", line 539, in asset_name
	s = bdata.name
	AttributeError: 'NoneType' object has no attribute 'name'
```
This happens on export if a trait has a **unset** prop of type `iron.object.Object`.