### PR TITLE
Fix initialize var to null

### DIFF
--- a/Sources/armory/system/Starter.hx
+++ b/Sources/armory/system/Starter.hx
@@ -11,7 +11,7 @@ class Starter {
 
 	public static function main(scene: String, mode: Int, resize: Bool, min: Bool, max: Bool, w: Int, h: Int, msaa: Int, vsync: Bool, getRenderPath: Void->iron.RenderPath) {
 
-		var tasks : Int;
+		var tasks : Int = null;
 
 		function start() {
 			if (tasks > 0) return;

--- a/Sources/armory/system/Starter.hx
+++ b/Sources/armory/system/Starter.hx
@@ -11,7 +11,7 @@ class Starter {
 
 	public static function main(scene: String, mode: Int, resize: Bool, min: Bool, max: Bool, w: Int, h: Int, msaa: Int, vsync: Bool, getRenderPath: Void->iron.RenderPath) {
 
-		var tasks : Int = null;
+		var tasks = 0;
 
 		function start() {
 			if (tasks > 0) return;


### PR DESCRIPTION
Static targets and doc-generation are complaining:
```sh
../armory/Sources/armory/system/Starter.hx:17: characters 8-13 : Warning : Local variable tasks might be used before being initialized
```