### PR TITLE
Print compositor flags on export

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -155,9 +155,10 @@ def export_data(fp, sdk_path):
     cdefs = arm.utils.def_strings_to_array(wrd.compo_defs)
 
     if wrd.arm_verbose_output:
-        print('Exported modules: ' + str(modules))
-        print('Shader flags: ' + str(defs))
-        print('Khafile flags: ' + str(assets.khafile_defs))
+        print('Exported modules:', modules)
+        print('Shader flags:', defs)
+        print('Compositor flags:', cdefs)
+        print('Khafile flags:', assets.khafile_defs)
 
     # Render path is configurable at runtime
     has_config = wrd.arm_write_config or os.path.exists(arm.utils.get_fp() + '/Bundled/config.arm')


### PR DESCRIPTION
@luboslenco Off-topic, but also regarding the verbose mode: there was a bug in Khamake that didn't show shader errors when verbose mode was disabled. It was fixed a few months ago, but is not yet included in Armory's version of Kha/Khamake. Could you please update that? Thanks :)