### PR TITLE
Fix SetSceneNode when using json export

### DIFF
--- a/Sources/armory/logicnode/SetSceneNode.hx
+++ b/Sources/armory/logicnode/SetSceneNode.hx
@@ -13,6 +13,10 @@ class SetSceneNode extends LogicNode {
 	override function run(from: Int) {
 		var sceneName: String = inputs[1].get();
 
+		#if arm_json
+		sceneName += ".json";
+		#end
+
 		iron.Scene.setActive(sceneName, function(o: iron.object.Object) {
 			root = o;
 			runOutput(0);


### PR DESCRIPTION
@luboslenco Should Iron print more informative error messages than the usual cannot read hxbytes thing or is it bad because of the overhead of try/catch statements? Also, should the game stop with such error messages (does not work on every target)? Currently it just prints out errors every frame if such bugs as the now fixed one occur.