### PR TITLE
log.py fixes

### DIFF
--- a/blender/arm/log.py
+++ b/blender/arm/log.py
@@ -13,9 +13,17 @@ if platform.system() == "Windows":
         # evaluated correctly for the first colored print statement.
         import ctypes
         kernel32 = ctypes.windll.kernel32
-        # -11: stdout, 7 (0b111): ENABLE_PROCESSED_OUTPUT, ENABLE_WRAP_AT_EOL_OUTPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING
+
+        # -11: stdout
+        handle_out = kernel32.GetStdHandle(-11)
+
+        console_mode = ctypes.c_long()
+        kernel32.GetConsoleMode(handle_out, ctypes.byref(console_mode))
+
+        # 0b100: ENABLE_VIRTUAL_TERMINAL_PROCESSING, enables ANSI codes
         # see https://docs.microsoft.com/en-us/windows/console/setconsolemode
-        kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+        console_mode.value |= 0b100
+        kernel32.SetConsoleMode(handle_out, console_mode)
 else:
     HAS_COLOR_SUPPORT = True
 

--- a/blender/arm/log.py
+++ b/blender/arm/log.py
@@ -7,6 +7,15 @@ ERROR = 31
 
 if platform.system() == "Windows":
     HAS_COLOR_SUPPORT = platform.release() == "10"
+
+    if HAS_COLOR_SUPPORT:
+        # Enable ANSI codes. Otherwise, the ANSI sequences might not be
+        # evaluated correctly for the first colored print statement.
+        import ctypes
+        kernel32 = ctypes.windll.kernel32
+        # -11: stdout, 7 (0b111): ENABLE_PROCESSED_OUTPUT, ENABLE_WRAP_AT_EOL_OUTPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        # see https://docs.microsoft.com/en-us/windows/console/setconsolemode
+        kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
 else:
     HAS_COLOR_SUPPORT = True
 

--- a/blender/arm/log.py
+++ b/blender/arm/log.py
@@ -31,22 +31,22 @@ def clear(clear_warnings=False):
 def format_text(text):
     return (text[:80] + '..') if len(text) > 80 else text # Limit str size
 
-def log(text,color=None):
+def log(text, color=None):
     if HAS_COLOR_SUPPORT and color is not None:
         csi = '\033['
-        text = csi + str(color) + 'm' + text + csi + '0m';
+        text = csi + str(color) + 'm' + text + csi + '0m'
     print(text)
 
 def debug(text):
-    log(text,DEBUG)
+    log(text, DEBUG)
 
 def info(text):
     global info_text
-    log(text,INFO)
+    log(text, INFO)
     info_text = format_text(text)
 
 def print_warn(text):
-    log('Warning: ' + text,WARN)
+    log('Warning: ' + text, WARN)
 
 def warn(text):
     global num_warnings
@@ -54,4 +54,4 @@ def warn(text):
     print_warn(text)
 
 def error(text):
-    log('ERROR: ' + text,ERROR)
+    log('ERROR: ' + text, ERROR)

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -598,7 +598,7 @@ def get_cascade_size(rpdat):
 def check_saved(self):
     if bpy.data.filepath == "":
         msg = "Save blend file first"
-        self.report({"ERROR"}, msg) if self != None else log.print_info(msg)
+        self.report({"ERROR"}, msg) if self is not None else log.warn(msg)
         return False
     return True
 
@@ -613,18 +613,18 @@ def check_path(s):
 
 def check_sdkpath(self):
     s = get_sdk_path()
-    if check_path(s) == False:
-        msg = "SDK path '{0}' contains special characters. Please move SDK to different path for now.".format(s)
-        self.report({"ERROR"}, msg) if self != None else log.print_info(msg)
+    if not check_path(s):
+        msg = f"SDK path '{s}' contains special characters. Please move SDK to different path for now."
+        self.report({"ERROR"}, msg) if self is not None else log.warn(msg)
         return False
     else:
         return True
 
 def check_projectpath(self):
     s = get_fp()
-    if check_path(s) == False:
-        msg = "Project path '{0}' contains special characters, build process may fail.".format(s)
-        self.report({"ERROR"}, msg) if self != None else log.print_info(msg)
+    if not check_path(s):
+        msg = f"Project path '{s}' contains special characters, build process may fail."
+        self.report({"ERROR"}, msg) if self is not None else log.warn(msg)
         return False
     else:
         return True


### PR DESCRIPTION
- Fixed a bug where colored log output was only working on Windows on subsequent logger calls but not on the first one. This was due to disabled `ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag for the windows console. It can be set via registry but I found a way to enable it for the current session [here](https://github.com/microsoft/WSL/issues/1173#issuecomment-459934080). I improved it further by only setting the required flag instead of overriding the whole user configuration.
  The used console API functions are documented [here](https://docs.microsoft.com/en-us/windows/console/getconsolemode), [here](https://docs.microsoft.com/en-us/windows/console/setconsolemode) and [here](https://docs.microsoft.com/en-us/windows/console/getstdhandle).

- Fixed outdated log calls in utils.py. This fixes https://github.com/armory3d/armory/issues/1761