### PR TITLE
Implement "receive shadow" setting for mobile path + all light types

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -346,7 +346,7 @@ void main() {
 	fragColor.rgb += sampleLight(
 		p, n, v, dotNV, pointPos, pointCol, albedo, roughness, occspec.y, f0
 		#ifdef _ShadowMap
-			, 0, pointBias
+			, 0, pointBias, true
 		#endif
 		#ifdef _Spot
 		, true, spotData.x, spotData.y, spotDir
@@ -400,7 +400,7 @@ void main() {
 			occspec.y,
 			f0
 			#ifdef _ShadowMap
-				, li, lightsArray[li * 2].w // bias
+				, li, lightsArray[li * 2].w, true // bias
 			#endif
 			#ifdef _Spot
 			, li > numPoints - 1

--- a/Shaders/deferred_light_mobile/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_mobile/deferred_light.frag.glsl
@@ -182,7 +182,7 @@ void main() {
 	fragColor.rgb += sampleLight(
 		p, n, v, dotNV, pointPos, pointCol, albedo, roughness, occspec.y, f0
 		#ifdef _ShadowMap
-			, 0, pointBias
+			, 0, pointBias, true
 		#endif
 		#ifdef _Spot
 		, true, spotData.x, spotData.y, spotDir
@@ -218,7 +218,7 @@ void main() {
 			occspec.y,
 			f0
 			#ifdef _ShadowMap
-				, li, lightsArray[li * 2].w // bias
+				, li, lightsArray[li * 2].w, true // bias
 			#endif
 			#ifdef _Spot
 			, li > numPoints - 1

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -70,7 +70,7 @@ uniform sampler2D sltcMag;
 vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, const vec3 lp, const vec3 lightCol,
 	const vec3 albedo, const float rough, const float spec, const vec3 f0
 	#ifdef _ShadowMap
-		, int index, float bias
+		, int index, float bias, bool receiveShadow
 	#endif
 	#ifdef _Spot
 		, bool isSpot, float spotA, float spotB, vec3 spotDir
@@ -130,28 +130,30 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 
 	#ifdef _LTC
 	#ifdef _ShadowMap
-		#ifdef _SinglePoint
-		vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-		direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-		#endif
-		#ifdef _Clusters
-		if (index == 0) {
-			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-		}
-		else if (index == 1) {
-			vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
-			direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
-		}
-		else if (index == 2) {
-			vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
-			direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
-		}
-		else if (index == 3) {
-			vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
-			direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
-		}
-		#endif
+        if (receiveShadow) {
+    		#ifdef _SinglePoint
+    		vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+    		direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+    		#endif
+    		#ifdef _Clusters
+    		if (index == 0) {
+    			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+    			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+    		}
+    		else if (index == 1) {
+    			vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
+    			direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
+    		}
+    		else if (index == 2) {
+    			vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
+    			direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
+    		}
+    		else if (index == 3) {
+    			vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
+    			direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
+    		}
+    		#endif
+        }
 	#endif
 	return direct;
 	#endif
@@ -164,28 +166,30 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 			direct *= smoothstep(spotB, spotA, spotEffect);
 		}
 		#ifdef _ShadowMap
-			#ifdef _SinglePoint
-			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-			#endif
-			#ifdef _Clusters
-			if (index == 0) {
-				vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-			}
-			else if (index == 1) {
-				vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
-				direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
-			}
-			else if (index == 2) {
-				vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
-				direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
-			}
-			else if (index == 3) {
-				vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
-				direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
-			}
-			#endif
+            if (receiveShadow) {
+    			#ifdef _SinglePoint
+    			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+    			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+    			#endif
+    			#ifdef _Clusters
+    			if (index == 0) {
+    				vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+    				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+    			}
+    			else if (index == 1) {
+    				vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
+    				direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
+    			}
+    			else if (index == 2) {
+    				vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
+    				direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
+    			}
+    			else if (index == 3) {
+    				vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
+    				direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
+    			}
+    			#endif
+            }
 		#endif
 		return direct;
 	}
@@ -196,17 +200,19 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	#endif
 
 	#ifdef _ShadowMap
-		#ifdef _SinglePoint
-		#ifndef _Spot
-		direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
-		#endif
-		#endif
-		#ifdef _Clusters
-		if (index == 0) direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
-		else if (index == 1) direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
-		else if (index == 2) direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
-		else if (index == 3) direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
-		#endif
+        if (receiveShadow) {
+    		#ifdef _SinglePoint
+    		#ifndef _Spot
+    		direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+    		#endif
+    		#endif
+    		#ifdef _Clusters
+    		if (index == 0) direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+    		else if (index == 1) direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
+    		else if (index == 2) direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
+    		else if (index == 3) direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
+    		#endif
+        }
 	#endif
 
 	return direct;

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -130,30 +130,30 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 
 	#ifdef _LTC
 	#ifdef _ShadowMap
-        if (receiveShadow) {
-    		#ifdef _SinglePoint
-    		vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-    		direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-    		#endif
-    		#ifdef _Clusters
-    		if (index == 0) {
-    			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-    			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-    		}
-    		else if (index == 1) {
-    			vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
-    			direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
-    		}
-    		else if (index == 2) {
-    			vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
-    			direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
-    		}
-    		else if (index == 3) {
-    			vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
-    			direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
-    		}
-    		#endif
-        }
+		if (receiveShadow) {
+			#ifdef _SinglePoint
+			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+			#endif
+			#ifdef _Clusters
+			if (index == 0) {
+				vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+			}
+			else if (index == 1) {
+				vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
+				direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
+			}
+			else if (index == 2) {
+				vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
+				direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
+			}
+			else if (index == 3) {
+				vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
+				direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
+			}
+			#endif
+		}
 	#endif
 	return direct;
 	#endif
@@ -166,30 +166,30 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 			direct *= smoothstep(spotB, spotA, spotEffect);
 		}
 		#ifdef _ShadowMap
-            if (receiveShadow) {
-    			#ifdef _SinglePoint
-    			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-    			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-    			#endif
-    			#ifdef _Clusters
-    			if (index == 0) {
-    				vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-    				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-    			}
-    			else if (index == 1) {
-    				vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
-    				direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
-    			}
-    			else if (index == 2) {
-    				vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
-    				direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
-    			}
-    			else if (index == 3) {
-    				vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
-    				direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
-    			}
-    			#endif
-            }
+			if (receiveShadow) {
+				#ifdef _SinglePoint
+				vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+				#endif
+				#ifdef _Clusters
+				if (index == 0) {
+					vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+					direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+				}
+				else if (index == 1) {
+					vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
+					direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
+				}
+				else if (index == 2) {
+					vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
+					direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
+				}
+				else if (index == 3) {
+					vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
+					direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
+				}
+				#endif
+			}
 		#endif
 		return direct;
 	}
@@ -200,19 +200,19 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	#endif
 
 	#ifdef _ShadowMap
-        if (receiveShadow) {
-    		#ifdef _SinglePoint
-    		#ifndef _Spot
-    		direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
-    		#endif
-    		#endif
-    		#ifdef _Clusters
-    		if (index == 0) direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
-    		else if (index == 1) direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
-    		else if (index == 2) direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
-    		else if (index == 3) direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
-    		#endif
-        }
+		if (receiveShadow) {
+			#ifdef _SinglePoint
+			#ifndef _Spot
+			direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+			#endif
+			#endif
+			#ifdef _Clusters
+			if (index == 0) direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+			else if (index == 1) direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
+			else if (index == 2) direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
+			else if (index == 3) direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
+			#endif
+		}
 	#endif
 
 	return direct;

--- a/Shaders/std/light_mobile.glsl
+++ b/Shaders/std/light_mobile.glsl
@@ -33,7 +33,7 @@
 vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, const vec3 lp, const vec3 lightCol,
 	const vec3 albedo, const float rough, const float spec, const vec3 f0
 	#ifdef _ShadowMap
-		, int index, float bias
+		, int index, float bias, bool receiveShadow
 	#endif
 	#ifdef _Spot
 		, bool isSpot, float spotA, float spotB, vec3 spotDir
@@ -60,28 +60,30 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 			direct *= smoothstep(spotB, spotA, spotEffect);
 		}
 		#ifdef _ShadowMap
-			#ifdef _SinglePoint
-			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-			#endif
-			#ifdef _Clusters
-			if (index == 0) {
-				vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-			}
-			else if (index == 1) {
-				vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
-				direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
-			}
-			else if (index == 2) {
-				vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
-				direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
-			}
-			else if (index == 3) {
-				vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
-				direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
-			}
-			#endif
+            if (receiveShadow) {
+    			#ifdef _SinglePoint
+    			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+    			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+    			#endif
+    			#ifdef _Clusters
+    			if (index == 0) {
+    				vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+    				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+    			}
+    			else if (index == 1) {
+    				vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
+    				direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
+    			}
+    			else if (index == 2) {
+    				vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
+    				direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
+    			}
+    			else if (index == 3) {
+    				vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
+    				direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
+    			}
+    			#endif
+            }
 		#endif
 		return direct;
 	}
@@ -89,15 +91,17 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 
 	#ifdef _ShadowMap
 	#ifndef _Spot
-		#ifdef _SinglePoint
-		direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
-		#endif
-		#ifdef _Clusters
-		if (index == 0) direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
-		else if (index == 1) direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
-		else if (index == 2) direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
-		else if (index == 3) direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
-		#endif
+        if (receiveShadow) {
+    		#ifdef _SinglePoint
+    		direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+    		#endif
+    		#ifdef _Clusters
+    		if (index == 0) direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+    		else if (index == 1) direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
+    		else if (index == 2) direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
+    		else if (index == 3) direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
+    		#endif
+        }
 	#endif
 	#endif
 

--- a/Shaders/std/light_mobile.glsl
+++ b/Shaders/std/light_mobile.glsl
@@ -60,30 +60,30 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 			direct *= smoothstep(spotB, spotA, spotEffect);
 		}
 		#ifdef _ShadowMap
-            if (receiveShadow) {
-    			#ifdef _SinglePoint
-    			vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-    			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-    			#endif
-    			#ifdef _Clusters
-    			if (index == 0) {
-    				vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
-    				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-    			}
-    			else if (index == 1) {
-    				vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
-    				direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
-    			}
-    			else if (index == 2) {
-    				vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
-    				direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
-    			}
-    			else if (index == 3) {
-    				vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
-    				direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
-    			}
-    			#endif
-            }
+			if (receiveShadow) {
+				#ifdef _SinglePoint
+				vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+				#endif
+				#ifdef _Clusters
+				if (index == 0) {
+					vec4 lPos = LWVPSpot0 * vec4(p + n * bias * 10, 1.0);
+					direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+				}
+				else if (index == 1) {
+					vec4 lPos = LWVPSpot1 * vec4(p + n * bias * 10, 1.0);
+					direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
+				}
+				else if (index == 2) {
+					vec4 lPos = LWVPSpot2 * vec4(p + n * bias * 10, 1.0);
+					direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
+				}
+				else if (index == 3) {
+					vec4 lPos = LWVPSpot3 * vec4(p + n * bias * 10, 1.0);
+					direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
+				}
+				#endif
+			}
 		#endif
 		return direct;
 	}
@@ -91,17 +91,17 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 
 	#ifdef _ShadowMap
 	#ifndef _Spot
-        if (receiveShadow) {
-    		#ifdef _SinglePoint
-    		direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
-    		#endif
-    		#ifdef _Clusters
-    		if (index == 0) direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
-    		else if (index == 1) direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
-    		else if (index == 2) direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
-    		else if (index == 3) direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
-    		#endif
-        }
+		if (receiveShadow) {
+			#ifdef _SinglePoint
+			direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+			#endif
+			#ifdef _Clusters
+			if (index == 0) direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+			else if (index == 1) direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
+			else if (index == 2) direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
+			else if (index == 3) direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
+			#endif
+		}
 	#endif
 	#endif
 

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -3,13 +3,14 @@ import bpy
 def write(vert, frag):
     wrd = bpy.data.worlds['Arm']
     is_shadows = '_ShadowMap' in wrd.world_defs
-    
+
     frag.add_include('std/clusters.glsl')
     frag.add_uniform('vec2 cameraProj', link='_cameraPlaneProj')
     frag.add_uniform('vec2 cameraPlane', link='_cameraPlane')
     frag.add_uniform('vec4 lightsArray[maxLights * 2]', link='_lightsArray')
     frag.add_uniform('sampler2D clustersData', link='_clustersData')
     if is_shadows:
+        frag.add_uniform('bool receiveShadow')
         frag.add_uniform('vec2 lightProj', link='_lightPlaneProj', included=True)
         frag.add_uniform('samplerCubeShadow shadowMapPoint[4]', included=True)
     vert.add_out('vec4 wvpposition')
@@ -36,7 +37,7 @@ def write(vert, frag):
 
     frag.write('for (int i = 0; i < min(numLights, maxLightsCluster); i++) {')
     frag.write('int li = int(texelFetch(clustersData, ivec2(clusterI, i + 1), 0).r * 255);')
-    
+
     frag.write('direct += sampleLight(')
     frag.write('    wposition,')
     frag.write('    n,')
@@ -49,7 +50,7 @@ def write(vert, frag):
     frag.write('    specular,')
     frag.write('    f0')
     if is_shadows:
-        frag.write('    , li, lightsArray[li * 2].w') # bias
+        frag.write('    , li, lightsArray[li * 2].w, receiveShadow') # bias
     if '_Spot' in wrd.world_defs:
         frag.write('    , li > numPoints - 1')
         frag.write('    , lightsArray[li * 2 + 1].w') # cutoff


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1737.

The required checks were only implemented for sun lamps on full render path, now each lamp type and the mobile render path supports the `Receive Shadow` material setting (forward rendering only).