### PR TITLE
UI for quick Node variable access

### DIFF
--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -155,7 +155,7 @@ class ARMAddVarNode(bpy.types.Operator):
         return({'FINISHED'})
     
 class ARMAddSetVarNode(bpy.types.Operator):
-    '''Add a node to set that this ones value'''
+    '''Add a node to set this Variable'''
     bl_idname = 'arm.add_setvar_node'
     bl_label = 'Add Set'
     bl_options = {'GRAB_CURSOR', 'BLOCKING'}

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -307,7 +307,6 @@ def register():
     bpy.utils.register_class(ARM_PT_Variables)
     bpy.utils.register_class(ARMAddVarNode)
     bpy.utils.register_class(ARMAddSetVarNode)
-    bpy.types.Scene.arm_varlist_index = IntProperty(name="Index for node variables", default=0)
     register_nodes()
 
 def unregister():


### PR DESCRIPTION
Quickly add references to node-variables, and setters. Here is a  showcase:
https://youtu.be/Sx4aoxVHiPo
It is definetly more handy in more complex Node setups, just wanted an quick test to demonstrate this.

Any suggestions? Having the "Set" button spawn two nodes is a bit janky, but I don't know how to make a single node that modifies a node-variable based on its ID.