### PR TITLE
Add CopyTraitsFromActive operator

### DIFF
--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -48,7 +48,13 @@ def update_trait_group(self, context):
                     col = bpy.data.collections.new('Trait|' + t.name)
                 else:
                     col = bpy.data.collections['Trait|' + t.name]
-                col.objects.link(o)
+                try:
+                    col.objects.link(o)
+                except RuntimeError:
+                    # Object is already in that collection. This can
+                    # happen when multiple same traits are copied with
+                    # bpy.ops.arm.copy_traits_to_active
+                    pass
 
 class ArmTraitListItem(bpy.types.PropertyGroup):
     name: StringProperty(name="Name", description="A name for this item", default="")

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -1,16 +1,17 @@
-import shutil
-import bpy
-import subprocess
+import json
 import os
+import shutil
+import subprocess
 import webbrowser
+
+from bpy.types import NodeTree
 import bpy.utils.previews
-from bpy.types import Menu, Panel, UIList, NodeTree
-from bpy.props import *
+
+import arm.make as make
 from arm.props_traits_props import *
 import arm.utils
 import arm.write_data as write_data
-import arm.make as make
-import json
+
 
 def trigger_recompile(self, context):
     wrd = bpy.data.worlds['Arm']

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -9,6 +9,7 @@ import bpy.utils.previews
 
 import arm.make as make
 from arm.props_traits_props import *
+import arm.proxy as proxy
 import arm.utils
 import arm.write_data as write_data
 
@@ -559,6 +560,82 @@ class ARM_PT_SceneTraitPanel(bpy.types.Panel):
         obj = bpy.context.scene
         draw_traits(layout, obj, is_object=False)
 
+
+class ARM_OT_CopyTraitsFromActive(bpy.types.Operator):
+    bl_label = 'Copy Traits from Active Object'
+    bl_idname = 'arm.copy_traits_to_active'
+    bl_description = 'Copies the traits of the active object to all other selected objects'
+
+    overwrite: BoolProperty(name="Overwrite", default=True)
+
+    @classmethod
+    def poll(cls, context):
+        return context.active_object is not None and len(context.selected_objects) > 1
+
+    def draw_message_box(self, context):
+        layout = self.layout
+        layout = layout.column(align=True)
+        layout.alignment = 'EXPAND'
+
+        layout.label(text=f'Warning: At least one target object already has', icon='ERROR')
+        layout.label(text='traits assigned to it!', icon='BLANK1')
+        layout.separator()
+        layout.label(text='Do you want to overwrite the already existing traits', icon='BLANK1')
+        layout.label(text='or append to them?', icon='BLANK1')
+        layout.separator()
+
+        row = layout.row(align=True)
+        row.active_default = True
+        row.operator('arm.copy_traits_to_active', text='Overwrite').overwrite = True
+        row.active_default = False
+        row.operator('arm.copy_traits_to_active', text='Append').overwrite = False
+        row.operator('arm.discard_popup', text='Cancel')
+
+    def execute(self, context):
+        source_obj = bpy.context.active_object
+
+        for target_obj in bpy.context.selected_objects:
+            if source_obj == target_obj:
+                continue
+
+            # Offset for trait iteration when appending traits
+            offset = 0
+            if not self.overwrite:
+                offset = len(target_obj.arm_traitlist)
+
+            # Make use of proxy functions here
+            proxy.sync_collection(
+                source_obj.arm_traitlist, target_obj.arm_traitlist, clear_dst=self.overwrite)
+
+            for i in range(len(source_obj.arm_traitlist)):
+                proxy.sync_collection(
+                    source_obj.arm_traitlist[i].arm_traitpropslist,
+                    target_obj.arm_traitlist[i + offset].arm_traitpropslist
+                )
+
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        show_dialog = False
+
+        # Test if there is a target object which has traits that would
+        # get overwritten
+        source_obj = bpy.context.active_object
+        for target_object in bpy.context.selected_objects:
+            if source_obj == target_object:
+                continue
+            else:
+                if target_object.arm_traitlist:
+                    show_dialog = True
+
+        if show_dialog:
+            context.window_manager.popover(self.__class__.draw_message_box, ui_units_x=16)
+        else:
+            bpy.ops.arm.copy_traits_to_active()
+
+        return {'INTERFACE'}
+
+
 def draw_traits(layout, obj, is_object):
     rows = 2
     if len(obj.arm_traitlist) > 1:
@@ -699,10 +776,13 @@ def register():
     bpy.utils.register_class(ArmRefreshCanvasListButton)
     bpy.utils.register_class(ARM_PT_TraitPanel)
     bpy.utils.register_class(ARM_PT_SceneTraitPanel)
+    bpy.utils.register_class(ARM_OT_CopyTraitsFromActive)
+
     bpy.types.Object.arm_traitlist = CollectionProperty(type=ArmTraitListItem)
     bpy.types.Object.arm_traitlist_index = IntProperty(name="Index for arm_traitlist", default=0)
     bpy.types.Scene.arm_traitlist = CollectionProperty(type=ArmTraitListItem)
     bpy.types.Scene.arm_traitlist_index = IntProperty(name="Index for arm_traitlist", default=0)
+
     icons_dict = bpy.utils.previews.new()
     icons_dir = os.path.join(os.path.dirname(__file__), "custom_icons")
     icons_dict.load("haxe", os.path.join(icons_dir, "haxe.png"), 'IMAGE')
@@ -710,6 +790,7 @@ def register():
 
 def unregister():
     global icons_dict
+    bpy.utils.unregister_class(ARM_OT_CopyTraitsFromActive)
     bpy.utils.unregister_class(ArmTraitListItem)
     bpy.utils.unregister_class(ARM_UL_TraitList)
     bpy.utils.unregister_class(ArmTraitListNewItem)

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -577,7 +577,7 @@ class ARM_OT_CopyTraitsFromActive(bpy.types.Operator):
         layout = layout.column(align=True)
         layout.alignment = 'EXPAND'
 
-        layout.label(text=f'Warning: At least one target object already has', icon='ERROR')
+        layout.label(text='Warning: At least one target object already has', icon='ERROR')
         layout.label(text='traits assigned to it!', icon='BLANK1')
         layout.separator()
         layout.label(text='Do you want to overwrite the already existing traits', icon='BLANK1')

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -650,6 +650,13 @@ def draw_view3d_header(self, context):
     elif log.info_text != '':
         self.layout.label(text=log.info_text)
 
+
+def draw_view3d_object_menu(self, context):
+    self.layout.separator()
+    self.layout.operator_context = 'INVOKE_DEFAULT'
+    self.layout.operator('arm.copy_traits_to_active')
+
+
 class ARM_PT_RenderPathPanel(bpy.types.Panel):
     bl_label = "Armory Render Path"
     bl_space_type = "PROPERTIES"

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1442,6 +1442,18 @@ class ARM_PT_MaterialNodePanel(bpy.types.Panel):
         if n != None and (n.bl_idname == 'ShaderNodeRGB' or n.bl_idname == 'ShaderNodeValue' or n.bl_idname == 'ShaderNodeTexImage'):
             layout.prop(context.active_node, 'arm_material_param')
 
+
+class ARM_OT_DiscardPopup(bpy.types.Operator):
+    """Empty operator for discarding dialogs."""
+    bl_idname = 'arm.discard_popup'
+    bl_label = 'OK'
+    bl_description = 'Discard'
+    bl_options = {'INTERNAL'}
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
 def register():
     bpy.utils.register_class(ARM_PT_ObjectPropsPanel)
     bpy.utils.register_class(ARM_PT_ModifiersPropsPanel)
@@ -1490,10 +1502,17 @@ def register():
     bpy.utils.register_class(ArmSyncProxyButton)
     bpy.utils.register_class(ArmPrintTraitsButton)
     bpy.utils.register_class(ARM_PT_MaterialNodePanel)
+    bpy.utils.register_class(ARM_OT_DiscardPopup)
+
     bpy.types.VIEW3D_HT_header.append(draw_view3d_header)
+    bpy.types.VIEW3D_MT_object.append(draw_view3d_object_menu)
+
 
 def unregister():
+    bpy.types.VIEW3D_MT_object.remove(draw_view3d_object_menu)
     bpy.types.VIEW3D_HT_header.remove(draw_view3d_header)
+
+    bpy.utils.unregister_class(ARM_OT_DiscardPopup)
     bpy.utils.unregister_class(ARM_PT_ObjectPropsPanel)
     bpy.utils.unregister_class(ARM_PT_ModifiersPropsPanel)
     bpy.utils.unregister_class(ARM_PT_ParticlesPropsPanel)

--- a/blender/arm/proxy.py
+++ b/blender/arm/proxy.py
@@ -94,20 +94,22 @@ def sync_modifiers(obj):
         for prop in properties:
             setattr(mDst, prop, getattr(mSrc, prop))
 
-def sync_collection(cSrc, cDst):
-    cDst.clear()
-    for mSrc in cSrc:
-        mDst = cDst.get(mSrc.name, None)
-        if not mDst:
-            mDst = cDst.add()
+def sync_collection(col_src, col_dst, clear_dst=True):
+    """Synchronizes collection properties. If `clear_dst` is False, the
+    destination collection is not cleared before syncing."""
+    if clear_dst:
+        col_dst.clear()
+
+    for m_src in col_src:
+        m_dst = col_dst.add()
 
         # collect names of writable properties
-        properties = [p.identifier for p in mSrc.bl_rna.properties
+        properties = [p.identifier for p in m_src.bl_rna.properties
                       if not p.is_readonly]
 
         # copy those properties
         for prop in properties:
-            setattr(mDst, prop, getattr(mSrc, prop))
+            setattr(m_dst, prop, getattr(m_src, prop))
 
 def sync_traits(obj: bpy.types.Object):
     """Synchronizes the traits of the given object with the traits of


### PR DESCRIPTION
Implements https://github.com/armory3d/armory/issues/1783.

This PR adds a new operator to `3DView > Object > Copy Traits from Active Object` and to the search menu that copies all traits and their properties from the last selected object to all other selected objects.

![menu](https://user-images.githubusercontent.com/17685000/89779288-45c8c780-db0f-11ea-8cf6-b641ff54474d.png)

If there are traits on one of the target objects (= a conflict exists), a dialog is displayed that asks if the traits should be overwritten or if they should be kept and the new traits get appended to the end of the trait list:

![dialog](https://user-images.githubusercontent.com/17685000/89779304-50835c80-db0f-11ea-8953-a34030d8e225.png)

Additional changes:
- Fixed a bug in `update_trait_group()` that would happen if an object gets reassigned the same trait again
- Fixed a bug/missing feature in `proxy.sync_collection()` that would not take multiple same traits into account
- Cleaned up some imports
