### PR TITLE
Add shader uniform support for the attribute node

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -396,11 +396,19 @@ def parse_vector(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> str:
         return 'vcolor'
 
     elif node.type == 'ATTRIBUTE':
+        # Shader uniforms
+        if node.attribute_name.startswith(('vec2 ', 'vec3 ', 'vec4 ')):
+            utype, uname = node.attribute_name.split(' ')[:2]
+            frag.add_uniform(f'{utype} {uname}', link=uname)
+            return uname
+
         if socket == node.outputs[0]: # Color
-            con.add_elem('col', 'short4norm') # Vcols only for now
+            # Vertex colors
+            con.add_elem('col', 'short4norm')
             return 'vcolor'
         else: # Vector
-            con.add_elem('tex', 'short2norm') # UVMaps only for now
+            # UV maps
+            con.add_elem('tex', 'short2norm')
             mat = mat_get_material()
             mat_users = mat_get_material_users()
             if mat_users != None and mat in mat_users:
@@ -1117,10 +1125,17 @@ def parse_value(node, socket):
         return parse_group_input(node, socket)
 
     elif node.type == 'ATTRIBUTE':
-        # Pass time till drivers are implemented
         if node.attribute_name == 'time':
             curshader.add_uniform('float time', link='_time')
             return 'time'
+
+        # Shader uniforms
+        elif node.attribute_name.startswith(('float ', 'int ')):
+            utype, uname = node.attribute_name.split(' ')[:2]
+            frag.add_uniform(f'{utype} {uname}', link=uname)
+            return uname
+
+        # Return 0.0 till drivers are implemented
         else:
             return '0.0'
 


### PR DESCRIPTION
This PR adds the possiblity to retrieve uniform values via the attribute node. The attribute node now interprets strings of the form
`uniformType uniformName` as a shader uniform. uniformType can be `vec2`, `vec3`, `vec4`, `int` and `float`, although `vec4` and `int` are not likely to be used a lot inside the node editor.

**Example**:
![uniform_nodes](https://user-images.githubusercontent.com/17685000/90551932-5d005880-e192-11ea-98d4-3ea50ca9f081.jpg)

This node setup now generates the following output in combination with an animated point lamp:
![uniforms](https://user-images.githubusercontent.com/17685000/90551555-cb90e680-e191-11ea-8ad5-5ddd7204d1f8.gif)
