### PR TITLE
Upgrade Apply Force at location and Apply Impulse at location to include object rotation

### DIFF
--- a/Sources/armory/logicnode/ApplyForceAtLocationNode.hx
+++ b/Sources/armory/logicnode/ApplyForceAtLocationNode.hx
@@ -13,15 +13,19 @@ class ApplyForceAtLocationNode extends LogicNode {
 	override function run(from: Int) {
 		var object: Object = inputs[1].get();
 		var force: Vec4 = inputs[2].get();
-        var location: Vec4 = inputs[3].get();
-		var local: Bool = inputs.length > 3 ? inputs[3].get() : false;
+		var localForce: Bool = inputs[3].get();
+        var location: Vec4 = inputs[4].get();
+		var localLoc: Bool =  inputs[5].get();
 
 		if (object == null || force == null || location == null) return;
 
 #if arm_physics
 		var rb: RigidBody = object.getTrait(RigidBody);
-		if (!local) {
-			rb.applyForce(force, location);
+		if (localLoc) {
+			location.applyQuat(object.transform.rot);
+		}
+		if(!localForce){
+			rb.applyForce(force,location);
 		}
 		else {
 			var look = object.transform.world.look().mult(force.y);

--- a/Sources/armory/logicnode/ApplyImpulseAtLocationNode.hx
+++ b/Sources/armory/logicnode/ApplyImpulseAtLocationNode.hx
@@ -13,15 +13,20 @@ class ApplyImpulseAtLocationNode extends LogicNode {
 	override function run(from: Int) {
 		var object: Object = inputs[1].get();
 		var impulse: Vec4 = inputs[2].get();
-		var location: Vec4 = inputs[3].get();
-		var local: Bool = inputs.length > 3 ? inputs[3].get() : false;
+		var localForce: Bool = inputs[3].get();
+        var location: Vec4 = inputs[4].get();
+		var localLoc: Bool =  inputs[5].get();
 
 		if (object == null || impulse == null || location == null) return;
 
 #if arm_physics
 		var rb: RigidBody = object.getTrait(RigidBody);
-		if (!local) {
-			rb.applyImpulse(impulse, location); }
+		if (localLoc) {
+			location.applyQuat(object.transform.rot);
+		}
+		if (!localForce) {
+			rb.applyImpulse(impulse, location); 
+		}
 		else {
 			var look = object.transform.world.look().mult(impulse.y);
 			var right = object.transform.world.right().mult(impulse.x);

--- a/blender/arm/logicnode/physics_apply_force_at_location.py
+++ b/blender/arm/logicnode/physics_apply_force_at_location.py
@@ -13,8 +13,9 @@ class ApplyForceAtLocationNode(Node, ArmLogicTreeNode):
         self.inputs.new('ArmNodeSocketAction', 'In')
         self.inputs.new('ArmNodeSocketObject', 'Object')
         self.inputs.new('NodeSocketVector', 'Force')
+        self.inputs.new('NodeSocketBool', 'Force On Local Axis')
         self.inputs.new('NodeSocketVector', 'Location')
-        self.inputs.new('NodeSocketBool', 'On Local Axis')
+        self.inputs.new('NodeSocketBool', 'Location On Local Axis')
         self.outputs.new('ArmNodeSocketAction', 'Out')
 
 add_node(ApplyForceAtLocationNode, category='Physics')

--- a/blender/arm/logicnode/physics_apply_impulse_at_location.py
+++ b/blender/arm/logicnode/physics_apply_impulse_at_location.py
@@ -13,8 +13,9 @@ class ApplyImpulseAtLocationNode(Node, ArmLogicTreeNode):
         self.inputs.new('ArmNodeSocketAction', 'In')
         self.inputs.new('ArmNodeSocketObject', 'Object')
         self.inputs.new('NodeSocketVector', 'Impulse')
+        self.inputs.new('NodeSocketBool', 'Impulse On Local Axis')
         self.inputs.new('NodeSocketVector', 'Location')
-        self.inputs.new('NodeSocketBool', 'On Local Axis')
+        self.inputs.new('NodeSocketBool', 'Location On Local Axis')
         self.outputs.new('ArmNodeSocketAction', 'Out')
 
 add_node(ApplyImpulseAtLocationNode, category='Physics')


### PR DESCRIPTION
This PR intends to solve issue #1813 

With this PR,

- Location of Force/ Impulse is always defined with respect to the object location. Object rotation is not accounted for. 
- If `Location On Local Axis` is enabled, object rotation is also accounted for. 
- Force/ Impulse is defined with respect to the global axis. 
- If `Force/ Impluse On Local Axis` is enabled, Force/ Impulse will be applied with respect to object local axis. 


![Capture](https://user-images.githubusercontent.com/55564981/91510895-a5302100-e8de-11ea-8cfc-99c8392be4d4.PNG)
