### PR TITLE
Fix android target options

### DIFF
--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -285,9 +285,9 @@ project.addSources('Sources');
 
         if state.target.startswith('android'):
             bundle = 'org.armory3d.' + wrd.arm_project_package if wrd.arm_project_bundle == '' else wrd.arm_project_bundle
-            f.write("project.targetOptions.android.package = '{0}';\n".format(arm.utils.safestr(bundle)))
+            f.write("project.targetOptions.android_native.package = '{0}';\n".format(arm.utils.safestr(bundle)))
             if wrd.arm_winorient != 'Multi':
-                f.write("project.targetOptions.android.screenOrientation = '{0}';\n".format(wrd.arm_winorient.lower()))
+                f.write("project.targetOptions.android_native.screenOrientation = '{0}';\n".format(wrd.arm_winorient.lower()))
         elif state.target.startswith('ios'):
             bundle = 'org.armory3d.' + wrd.arm_project_package if wrd.arm_project_bundle == '' else wrd.arm_project_bundle
             f.write("project.targetOptions.ios.bundle = '{0}';\n".format(arm.utils.safestr(bundle)))

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -43,8 +43,8 @@ def write_khafilejs(is_play, export_physics, export_navigation, export_ui, is_pu
     rel_path = arm.utils.get_relative_paths() # Convert absolute paths to relative
     wrd = bpy.data.worlds['Arm']
 
-    with open('khafile.js', 'w') as f:
-        f.write(
+    with open('khafile.js', 'w') as khafile:
+        khafile.write(
 """// Auto-generated
 let project = new Project('""" + arm.utils.safestr(wrd.arm_project_name) + """');
 
@@ -62,30 +62,30 @@ project.addSources('Sources');
             if os.path.exists(arm.utils.build_dir() + '/compiled/Shaders/Project'):
                 shutil.rmtree(arm.utils.build_dir() + '/compiled/Shaders/Project', onerror=remove_readonly)
             shutil.copytree('Shaders', arm.utils.build_dir() + '/compiled/Shaders/Project')
-            f.write("project.addShaders('" + arm.utils.build_dir() + "/compiled/Shaders/Project/**');\n")
+            khafile.write("project.addShaders('" + arm.utils.build_dir() + "/compiled/Shaders/Project/**');\n")
             # for file in glob.glob("Shaders/**", recursive=True):
                 # if os.path.isfile(file):
                     # assets.add_shader(file)
 
         if not os.path.exists('Libraries/armory'):
-            f.write(add_armory_library(sdk_path, 'armory', rel_path=rel_path))
+            khafile.write(add_armory_library(sdk_path, 'armory', rel_path=rel_path))
 
         if not os.path.exists('Libraries/iron'):
-            f.write(add_armory_library(sdk_path, 'iron', rel_path=rel_path))
+            khafile.write(add_armory_library(sdk_path, 'iron', rel_path=rel_path))
 
         # Project libraries
         if os.path.exists('Libraries'):
             libs = os.listdir('Libraries')
             for lib in libs:
                 if os.path.isdir('Libraries/' + lib):
-                    f.write('project.addLibrary("{0}");\n'.format(lib.replace('//', '/')))
+                    khafile.write('project.addLibrary("{0}");\n'.format(lib.replace('//', '/')))
 
         # Subprojects, merge this with libraries
         if os.path.exists('Subprojects'):
             libs = os.listdir('Subprojects')
             for lib in libs:
                 if os.path.isdir('Subprojects/' + lib):
-                    f.write('await project.addProject("Subprojects/{0}");\n'.format(lib))
+                    khafile.write('await project.addProject("Subprojects/{0}");\n'.format(lib))
 
         if wrd.arm_audio == 'Disabled':
             assets.add_khafile_def('kha_no_ogg')
@@ -97,31 +97,31 @@ project.addSources('Sources');
             if wrd.arm_physics_engine == 'Bullet':
                 assets.add_khafile_def('arm_bullet')
                 if not os.path.exists('Libraries/haxebullet'):
-                    f.write(add_armory_library(sdk_path + '/lib/', 'haxebullet', rel_path=rel_path))
+                    khafile.write(add_armory_library(sdk_path + '/lib/', 'haxebullet', rel_path=rel_path))
                 if state.target.startswith('krom'):
                     ammojs_path = sdk_path + '/lib/haxebullet/ammo/ammo.wasm.js'
                     ammojs_path = ammojs_path.replace('\\', '/').replace('//', '/')
-                    f.write(add_assets(ammojs_path, rel_path=rel_path))
+                    khafile.write(add_assets(ammojs_path, rel_path=rel_path))
                     ammojs_wasm_path = sdk_path + '/lib/haxebullet/ammo/ammo.wasm.wasm'
                     ammojs_wasm_path = ammojs_wasm_path.replace('\\', '/').replace('//', '/')
-                    f.write(add_assets(ammojs_wasm_path, rel_path=rel_path))
+                    khafile.write(add_assets(ammojs_wasm_path, rel_path=rel_path))
                 elif state.target == 'html5' or state.target == 'node':
                     ammojs_path = sdk_path + '/lib/haxebullet/ammo/ammo.js'
                     ammojs_path = ammojs_path.replace('\\', '/').replace('//', '/')
-                    f.write(add_assets(ammojs_path, rel_path=rel_path))
+                    khafile.write(add_assets(ammojs_path, rel_path=rel_path))
             elif wrd.arm_physics_engine == 'Oimo':
                 assets.add_khafile_def('arm_oimo')
                 if not os.path.exists('Libraries/oimo'):
-                    f.write(add_armory_library(sdk_path + '/lib/', 'oimo', rel_path=rel_path))
+                    khafile.write(add_armory_library(sdk_path + '/lib/', 'oimo', rel_path=rel_path))
 
         if export_navigation:
             assets.add_khafile_def('arm_navigation')
             if not os.path.exists('Libraries/haxerecast'):
-                f.write(add_armory_library(sdk_path + '/lib/', 'haxerecast', rel_path=rel_path))
+                khafile.write(add_armory_library(sdk_path + '/lib/', 'haxerecast', rel_path=rel_path))
             if state.target.startswith('krom') or state.target == 'html5':
                 recastjs_path = sdk_path + '/lib/haxerecast/js/recast/recast.js'
                 recastjs_path = recastjs_path.replace('\\', '/').replace('//', '/')
-                f.write(add_assets(recastjs_path, rel_path=rel_path))
+                khafile.write(add_assets(recastjs_path, rel_path=rel_path))
 
         if is_publish:
             assets.add_khafile_def('arm_published')
@@ -129,25 +129,25 @@ project.addSources('Sources');
                 assets.add_khafile_def('arm_compress')
         else:
             pass
-            # f.write("""project.addParameter("--macro include('armory.trait')");\n""")
-            # f.write("""project.addParameter("--macro include('armory.trait.internal')");\n""")
+            # khafile.write("""project.addParameter("--macro include('armory.trait')");\n""")
+            # khafile.write("""project.addParameter("--macro include('armory.trait.internal')");\n""")
             # if export_physics:
-            #     f.write("""project.addParameter("--macro include('armory.trait.physics')");\n""")
+            #     khafile.write("""project.addParameter("--macro include('armory.trait.physics')");\n""")
             #     if wrd.arm_physics_engine == 'Bullet':
-            #         f.write("""project.addParameter("--macro include('armory.trait.physics.bullet')");\n""")
+            #         khafile.write("""project.addParameter("--macro include('armory.trait.physics.bullet')");\n""")
             #     else:
-            #         f.write("""project.addParameter("--macro include('armory.trait.physics.oimo')");\n""")
+            #         khafile.write("""project.addParameter("--macro include('armory.trait.physics.oimo')");\n""")
             # if export_navigation:
-            #     f.write("""project.addParameter("--macro include('armory.trait.navigation')");\n""")
+            #     khafile.write("""project.addParameter("--macro include('armory.trait.navigation')");\n""")
 
         # if import_logicnodes: # Live patching for logic nodes
-            # f.write("""project.addParameter("--macro include('armory.logicnode')");\n""")
+            # khafile.write("""project.addParameter("--macro include('armory.logicnode')");\n""")
 
         if not wrd.arm_compiler_inline:
-            f.write("project.addParameter('--no-inline');\n")
+            khafile.write("project.addParameter('--no-inline');\n")
 
         if enable_dce:
-            f.write("project.addParameter('-dce full');\n")
+            khafile.write("project.addParameter('-dce full');\n")
 
         live_patch = wrd.arm_live_patch and state.target == 'krom'
         if wrd.arm_debug_console or live_patch:
@@ -157,8 +157,8 @@ project.addSources('Sources');
 
         import_traits = list(set(import_traits))
         for i in range(0, len(import_traits)):
-            f.write("project.addParameter('" + import_traits[i] + "');\n")
-            f.write("""project.addParameter("--macro keep('""" + import_traits[i] + """')");\n""")
+            khafile.write("project.addParameter('" + import_traits[i] + "');\n")
+            khafile.write("""project.addParameter("--macro keep('""" + import_traits[i] + """')");\n""")
 
         noembed = wrd.arm_cache_build and not is_publish and state.target == 'krom'
         if noembed:
@@ -170,14 +170,14 @@ project.addSources('Sources');
         shaders_path = arm.utils.build_dir() + '/compiled/Shaders/*.glsl'
         if rel_path:
             shaders_path = os.path.relpath(shaders_path, arm.utils.get_fp()).replace('\\', '/')
-        f.write('project.addShaders("' + shaders_path + '", { noembed: ' + str(noembed).lower() + '});\n')
+        khafile.write('project.addShaders("' + shaders_path + '", { noembed: ' + str(noembed).lower() + '});\n')
 
         if arm.utils.get_gapi() == 'direct3d11':
             # noprocessing flag - gets renamed to .d3d11
             shaders_path = arm.utils.build_dir() + '/compiled/Hlsl/*.glsl'
             if rel_path:
                 shaders_path = os.path.relpath(shaders_path, arm.utils.get_fp()).replace('\\', '/')
-            f.write('project.addShaders("' + shaders_path + '", { noprocessing: true, noembed: ' + str(noembed).lower() + ' });\n')
+            khafile.write('project.addShaders("' + shaders_path + '", { noprocessing: true, noembed: ' + str(noembed).lower() + ' });\n')
 
         # Move assets for published game to /data folder
         use_data_dir = is_publish and (state.target == 'krom-windows' or state.target == 'krom-linux' or state.target == 'windows-hl' or state.target == 'linux-hl')
@@ -193,15 +193,15 @@ project.addSources('Sources');
         dest = ''
         if use_data_dir:
             dest += ', destination: "data/{name}"'
-        f.write('project.addAssets("' + assets_path + '", { notinlist: true ' + dest + '});\n')
-        f.write('project.addAssets("' + assets_path_sh + '", { notinlist: true ' + dest + '});\n')
+        khafile.write('project.addAssets("' + assets_path + '", { notinlist: true ' + dest + '});\n')
+        khafile.write('project.addAssets("' + assets_path_sh + '", { notinlist: true ' + dest + '});\n')
 
         shader_data_references = sorted(list(set(assets.shader_datas)))
         for ref in shader_data_references:
             ref = ref.replace('\\', '/').replace('//', '/')
             if '/compiled/' in ref: # Asset already included
                 continue
-            f.write(add_assets(ref, use_data_dir=use_data_dir, rel_path=rel_path))
+            khafile.write(add_assets(ref, use_data_dir=use_data_dir, rel_path=rel_path))
 
         asset_references = sorted(list(set(assets.assets)))
         for ref in asset_references:
@@ -214,7 +214,7 @@ project.addSources('Sources');
                 quality = wrd.arm_sound_quality
             elif s.endswith('.png') or s.endswith('.jpg'):
                 quality = wrd.arm_texture_quality
-            f.write(add_assets(ref, quality=quality, use_data_dir=use_data_dir, rel_path=rel_path))
+            khafile.write(add_assets(ref, quality=quality, use_data_dir=use_data_dir, rel_path=rel_path))
 
         if wrd.arm_sound_quality < 1.0 or state.target == 'html5':
             assets.add_khafile_def('arm_soundcompress')
@@ -224,17 +224,17 @@ project.addSources('Sources');
 
         if wrd.arm_debug_console:
             assets.add_khafile_def('arm_debug')
-            f.write(add_shaders(sdk_path + "/armory/Shaders/debug_draw/**", rel_path=rel_path))
+            khafile.write(add_shaders(sdk_path + "/armory/Shaders/debug_draw/**", rel_path=rel_path))
 
         if wrd.arm_verbose_output:
-            f.write("project.addParameter('--times');\n")
+            khafile.write("project.addParameter('--times');\n")
 
         if export_ui:
             if not os.path.exists('Libraries/zui'):
-                f.write(add_armory_library(sdk_path, 'lib/zui', rel_path=rel_path))
+                khafile.write(add_armory_library(sdk_path, 'lib/zui', rel_path=rel_path))
             p = sdk_path + '/armory/Assets/font_default.ttf'
             p = p.replace('//', '/')
-            f.write(add_assets(p.replace('\\', '/'), use_data_dir=use_data_dir, rel_path=rel_path))
+            khafile.write(add_assets(p.replace('\\', '/'), use_data_dir=use_data_dir, rel_path=rel_path))
             assets.add_khafile_def('arm_ui')
 
         if wrd.arm_minimize == False:
@@ -275,27 +275,27 @@ project.addSources('Sources');
             # assets.add_khafile_def('arm_degrees')
 
         for d in assets.khafile_defs:
-            f.write("project.addDefine('" + d + "');\n")
+            khafile.write("project.addDefine('" + d + "');\n")
 
         for p in assets.khafile_params:
-            f.write("project.addParameter('" + p + "');\n")
+            khafile.write("project.addParameter('" + p + "');\n")
 
         if wrd.arm_khafile != None:
-            f.write(wrd.arm_khafile.as_string())
+            khafile.write(wrd.arm_khafile.as_string())
 
         if state.target.startswith('android'):
             bundle = 'org.armory3d.' + wrd.arm_project_package if wrd.arm_project_bundle == '' else wrd.arm_project_bundle
-            f.write("project.targetOptions.android_native.package = '{0}';\n".format(arm.utils.safestr(bundle)))
+            khafile.write("project.targetOptions.android_native.package = '{0}';\n".format(arm.utils.safestr(bundle)))
             if wrd.arm_winorient != 'Multi':
-                f.write("project.targetOptions.android_native.screenOrientation = '{0}';\n".format(wrd.arm_winorient.lower()))
+                khafile.write("project.targetOptions.android_native.screenOrientation = '{0}';\n".format(wrd.arm_winorient.lower()))
         elif state.target.startswith('ios'):
             bundle = 'org.armory3d.' + wrd.arm_project_package if wrd.arm_project_bundle == '' else wrd.arm_project_bundle
-            f.write("project.targetOptions.ios.bundle = '{0}';\n".format(arm.utils.safestr(bundle)))
+            khafile.write("project.targetOptions.ios.bundle = '{0}';\n".format(arm.utils.safestr(bundle)))
 
         if wrd.arm_project_icon != '':
             shutil.copy(bpy.path.abspath(wrd.arm_project_icon), arm.utils.get_fp() + '/icon.png')
 
-        f.write("\n\nresolve(project);\n")
+        khafile.write("\n\nresolve(project);\n")
 
 def get_winmode(arm_winmode):
     if arm_winmode == 'Window':


### PR DESCRIPTION
This fixes https://github.com/armory3d/armory/issues/1815.

As Armory only supports the native android target, we can change `android` to `android_native` in the khafile (see https://github.com/Kode/kincmake/pull/11).

I've also changed `f` to `khafile` in the code for better readability.