### PR TITLE
Apply tansform for RigidBody if Keep Transform

### DIFF
--- a/Sources/armory/logicnode/ClearParentNode.hx
+++ b/Sources/armory/logicnode/ClearParentNode.hx
@@ -1,6 +1,7 @@
 package armory.logicnode;
 
 import iron.object.Object;
+import armory.trait.physics.RigidBody;
 
 class ClearParentNode extends LogicNode {
 
@@ -15,6 +16,12 @@ class ClearParentNode extends LogicNode {
 		if (object == null || object.parent == null) return;
 
 		object.parent.removeChild(object, keepTransform);
+
+		#if arm_physics
+		var rigidBody = object.getTrait(RigidBody);
+		if (rigidBody != null) rigidBody.syncTransform();
+		#end
+		
 		iron.Scene.active.root.addChild(object, false);
 
 		runOutput(0);


### PR DESCRIPTION
This PR partially solves #1830 . `RigidBody` now obeys `keep Transform`. 

However, when `keep transform` is disabled, the object transform does not return to the original transforms. This must be fixed in [Iron](https://github.com/armory3d/iron.git). 