### PR TITLE
Add SpawnCollection node

### DIFF
--- a/Sources/armory/logicnode/SpawnCollectionNode.hx
+++ b/Sources/armory/logicnode/SpawnCollectionNode.hx
@@ -1,0 +1,70 @@
+package armory.logicnode;
+
+import iron.data.SceneFormat.TObj;
+import iron.math.Mat4;
+import iron.object.Object;
+
+class SpawnCollectionNode extends LogicNode {
+
+	/** Collection name **/
+	public var property0: Null<String>;
+
+	var topLevelObjects: Array<Object>;
+	var allObjects: Array<Object>;
+	var ownerObject: Null<Object>;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+
+		// Return empty arrays if not executed
+		topLevelObjects = new Array();
+		allObjects = new Array();
+	}
+
+	override function run(from: Int) {
+		var raw = iron.Scene.active.raw;
+
+		if (property0 == null) return;
+
+		// Check if the group exists
+		for (g in raw.groups) {
+			if (g.name == property0) {
+
+				var transform: Mat4 = inputs[1].get();
+				if (transform == null) transform = Mat4.identity();
+
+				// Create owner object that instantiates the group
+				var rawOwnerObject: TObj = {
+					name: property0,
+					type: "object",
+					group_ref: property0,
+					data_ref: "",
+					transform: {
+						values: transform.toFloat32Array()
+					}
+				};
+				raw.objects.push(rawOwnerObject);
+
+				iron.Scene.active.createObject(rawOwnerObject, raw, null, null,
+					(created: Object) -> {
+						ownerObject = created;
+						topLevelObjects = created.getChildren(false);
+						allObjects = created.getChildren(true);
+
+						runOutput(0);
+					}
+				);
+				return;
+			}
+		}
+	}
+
+	override function get(from: Int): Dynamic {
+		switch (from) {
+			case 1: return topLevelObjects;
+			case 2: return allObjects;
+			case 3: return ownerObject;
+		}
+		return null;
+	}
+}

--- a/blender/arm/logicnode/action_spawn_collection.py
+++ b/blender/arm/logicnode/action_spawn_collection.py
@@ -1,0 +1,28 @@
+import bpy
+from bpy.props import *
+from bpy.types import Node, NodeSocket
+from arm.logicnode.arm_nodes import *
+
+
+class SpawnCollectionNode(Node, ArmLogicTreeNode):
+    """Spawns a collection to the current scene."""
+    bl_idname = 'LNSpawnCollectionNode'
+    bl_label = 'Spawn Collection'
+    bl_icon = 'NONE'
+
+    property0: PointerProperty(name='Collection', type=bpy.types.Collection)
+
+    def init(self, context):
+        self.inputs.new('ArmNodeSocketAction', 'In')
+        self.inputs.new('NodeSocketShader', 'Transform')
+
+        self.outputs.new('ArmNodeSocketAction', 'Out')
+        self.outputs.new('ArmNodeSocketArray', 'Top-Level Objects')
+        self.outputs.new('ArmNodeSocketArray', 'All Objects')
+        self.outputs.new('ArmNodeSocketObject', 'Owner Object')
+
+    def draw_buttons(self, context, layout):
+        layout.prop_search(self, 'property0', bpy.data, 'collections', icon='NONE', text='')
+
+
+add_node(SpawnCollectionNode, category='Action')

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -159,7 +159,10 @@ def build_node(node: bpy.types.Node, f):
             elif hasattr(prop, 'name'): # PointerProperty
                 prop = '"' + str(prop.name) + '"'
             else:
-                prop = str(prop)
+                if prop is None:
+                    prop = 'null'
+                else:
+                    prop = str(prop)
             f.write('\t\t' + name + '.property' + str(i) + ' = ' + prop + ';\n')
 
     # Create inputs


### PR DESCRIPTION
Requires https://github.com/armory3d/iron/pull/100

This PR adds a new, often requested node to spawn collections to the active scene:

![SpawnCollectionNode](https://user-images.githubusercontent.com/17685000/92145055-f0cf5700-ee17-11ea-86c6-696868c5eda5.jpg)

I've also fixed a bug where `None` would be written into the generated .hx code when a property is `None` (for example when no collection was selected).

**Outputs:**
- Top-Level Objects: All objects in the collection that are direct children of the owner object of the collection's instance
- All Objects: All objects in the collection
- Owner Object: The owning object of the collection's instance (like the empty Blender uses for that purpose).