### PR TITLE
Rename camera nodes (no longer duplicate names)

### DIFF
--- a/blender/arm/logicnode/action_set_camera.py
+++ b/blender/arm/logicnode/action_set_camera.py
@@ -4,14 +4,15 @@ from bpy.types import Node, NodeSocket
 from arm.logicnode.arm_nodes import *
 
 class SetCameraNode(Node, ArmLogicTreeNode):
-    '''Set camera node'''
+    """Set the active camera of the active scene."""
     bl_idname = 'LNSetCameraNode'
-    bl_label = 'Set Camera'
+    bl_label = 'Set Active Camera'
     bl_icon = 'NONE'
 
     def init(self, context):
         self.inputs.new('ArmNodeSocketAction', 'In')
         self.inputs.new('ArmNodeSocketObject', 'Object')
+
         self.outputs.new('ArmNodeSocketAction', 'Out')
 
 add_node(SetCameraNode, category='Action')

--- a/blender/arm/logicnode/postprocess_get_camera.py
+++ b/blender/arm/logicnode/postprocess_get_camera.py
@@ -4,9 +4,9 @@ from bpy.types import Node, NodeSocket
 from arm.logicnode.arm_nodes import *
 
 class CameraGetNode(Node, ArmLogicTreeNode):
-    '''Get Camera Effect'''
+    """Get postprocessing effects of the camera."""
     bl_idname = 'LNCameraGetNode'
-    bl_label = 'Get Camera'
+    bl_label = 'Get Camera Postprocessing'
     bl_icon = 'NONE'
 
     def init(self, context):

--- a/blender/arm/logicnode/postprocess_set_camera.py
+++ b/blender/arm/logicnode/postprocess_set_camera.py
@@ -11,28 +11,17 @@ class CameraSetNode(Node, ArmLogicTreeNode):
 
     def init(self, context):
         self.inputs.new('ArmNodeSocketAction', 'In')
-        self.inputs.new('NodeSocketFloat', 'F-stop')
-        self.inputs[-1].default_value = 2.0
-        self.inputs.new('NodeSocketFloat', 'Shutter Time')
-        self.inputs[-1].default_value = 1.0
-        self.inputs.new('NodeSocketFloat', 'ISO')
-        self.inputs[-1].default_value = 100.0
-        self.inputs.new('NodeSocketFloat', 'Exposure Compensation')
-        self.inputs[-1].default_value = 0.0
-        self.inputs.new('NodeSocketFloat', 'Fisheye Distortion')
-        self.inputs[-1].default_value = 0.01
-        self.inputs.new('NodeSocketBool', 'Auto Focus')
-        self.inputs[-1].default_value = True
-        self.inputs.new('NodeSocketFloat', 'DoF Distance')
-        self.inputs[-1].default_value = 10.0
-        self.inputs.new('NodeSocketFloat', 'DoF Length')
-        self.inputs[-1].default_value = 160.0
-        self.inputs.new('NodeSocketFloat', 'DoF F-Stop')
-        self.inputs[-1].default_value = 128.0
-        self.inputs.new('NodeSocketInt', 'Tonemapper')
-        self.inputs[-1].default_value = 0.0
-        self.inputs.new('NodeSocketFloat', 'Film Grain')
-        self.inputs[-1].default_value = 2.0
+        self.inputs.new('NodeSocketFloat', 'F-stop').default_value = 2.0
+        self.inputs.new('NodeSocketFloat', 'Shutter Time').default_value = 1.0
+        self.inputs.new('NodeSocketFloat', 'ISO').default_value = 100.0
+        self.inputs.new('NodeSocketFloat', 'Exposure Compensation').default_value = 0.0
+        self.inputs.new('NodeSocketFloat', 'Fisheye Distortion').default_value = 0.01
+        self.inputs.new('NodeSocketBool', 'Auto Focus').default_value = True
+        self.inputs.new('NodeSocketFloat', 'DoF Distance').default_value = 10.0
+        self.inputs.new('NodeSocketFloat', 'DoF Length').default_value = 160.0
+        self.inputs.new('NodeSocketFloat', 'DoF F-Stop').default_value = 128.0
+        self.inputs.new('NodeSocketInt', 'Tonemapper').default_value = 0.0
+        self.inputs.new('NodeSocketFloat', 'Film Grain').default_value = 2.0
         self.outputs.new('ArmNodeSocketAction', 'Out')
 
 add_node(CameraSetNode, category='Postprocess')

--- a/blender/arm/logicnode/postprocess_set_camera.py
+++ b/blender/arm/logicnode/postprocess_set_camera.py
@@ -4,9 +4,9 @@ from bpy.types import Node, NodeSocket
 from arm.logicnode.arm_nodes import *
 
 class CameraSetNode(Node, ArmLogicTreeNode):
-    '''Set Camera Effect'''
+    """Set postprocessing effects of the camera."""
     bl_idname = 'LNCameraSetNode'
-    bl_label = 'Set Camera'
+    bl_label = 'Set Camera Postprocessing'
     bl_icon = 'NONE'
 
     def init(self, context):

--- a/blender/arm/logicnode/value_active_camera.py
+++ b/blender/arm/logicnode/value_active_camera.py
@@ -4,11 +4,11 @@ from bpy.types import Node, NodeSocket
 from arm.logicnode.arm_nodes import *
 
 class ActiveCameraNode(Node, ArmLogicTreeNode):
-    '''Active camera node'''
+    """Get the active camera of the active scene."""
     bl_idname = 'LNActiveCameraNode'
-    bl_label = 'Active Camera'
+    bl_label = 'Get Active Camera'
     bl_icon = 'NONE'
-    
+
     def init(self, context):
         self.outputs.new('ArmNodeSocketObject', 'Object')
 


### PR DESCRIPTION
Previously there were two nodes equally named `Set Camera` which are now renamed to `Set Active Camera` and `Set Camera Postprocessing` (their get-parts were also renamed to reflect that change). I didn't rename the classes, idnames and files to keep compatibility but in the future they should be renamed too.