### PR TITLE
Fix rigid bodies continuing to move when parented

### DIFF
--- a/Sources/armory/logicnode/SetParentNode.hx
+++ b/Sources/armory/logicnode/SetParentNode.hx
@@ -1,6 +1,7 @@
 package armory.logicnode;
 
 import iron.object.Object;
+import armory.trait.physics.RigidBody;
 
 class SetParentNode extends LogicNode {
 
@@ -23,6 +24,12 @@ class SetParentNode extends LogicNode {
 		if (object == null || parent == null || object.parent == parent) return;
 
 		object.parent.removeChild(object, isUnparent); // keepTransform
+		
+		#if arm_physics
+		var rigidBody = object.getTrait(RigidBody);
+		if (rigidBody != null) rigidBody.setActivationState(0);
+		#end
+
 		parent.addChild(object, !isUnparent); // applyInverse
 
 		runOutput(0);


### PR DESCRIPTION
I used @QuantumCoderQC Clear Parent node fix and adapted here. This fixes one more bug from here: https://github.com/armory3d/armory/issues/1830

I don't know if this is a correct fix, but solved a problem for me.

One last bug that stills is the rigid body in "random" places when parented. To fix this, when the rigid body (no matter if active or passive) is parented, it must have Animated checkbox checked. I don't know how to do this. This will solve all problems related to it, except the "Keep Transform" unchecked one.

Just somethings to take in count: if the Animated checkbox is set by "Set Parent", then "Clear Parent" should unset the Animated Checkbox. But when the checkbox was not set by "Set Parent", "Clear Parent" should not touch in there. This make me think about merging this two nodes into one.