### PR TITLE
fixed a backwards compatibility problem with a node from before armory 2020.09

### DIFF
--- a/Sources/armory/logicnode/RotateObjectNode.hx
+++ b/Sources/armory/logicnode/RotateObjectNode.hx
@@ -7,7 +7,7 @@ import armory.trait.physics.RigidBody;
 
 class RotateObjectNode extends LogicNode {
 
-	public var property0 = "uninitialized";
+	public var property0 = "Euler Angles";
 	var q = new Quat();
 
 	public function new(tree: LogicTree) {
@@ -17,23 +17,18 @@ class RotateObjectNode extends LogicNode {
 	override function run(from: Int) {
 		var object: Object = inputs[1].get();
 		var vec: Vec4 = inputs[2].get();
-		var w: Float = 0;
 		
-		// the next if/else block exist to ensure backwards compatibility with nodes that were created before armory 2020.09.
-		// delete it when the "old version" of this node will be considered removed from armory.
-		if (property0=="uninitialized") {
-			property0="Euler Angles";
-		}
-		else{
-			w = inputs[3].get();
-		}
+		// note: here, the next line is disabled because old versions of the node don't have a third input.
+		// when those old versions will be considered remove, feel free to uncomment that, and replace the other `inputs[3].get()` by `w` in this file.
+		//var w: Float = inputs[3].get();
+
 		if (object == null || vec == null) return;
 
 		switch (property0) {
 			case "Euler Angles":
 				q.fromEuler(vec.x, vec.y, vec.z);
 			case "Angle Axies (Degrees)" | "Angle Axies (Radians)":
-				var angle: Float = w;
+				var angle: Float = inputs[3].get();
 				if (property0 == "Angle Axies (Degrees)") {
 					angle = angle * (Math.PI / 180);
 				}
@@ -42,7 +37,7 @@ class RotateObjectNode extends LogicNode {
 				var angleCos = Math.cos(angle / 2);
 				q = new Quat(vec.x * angleSin, vec.y * angleSin, vec.z * angleSin, angleCos);
 			case "Quaternion":
-				q = new Quat(vec.x, vec.y, vec.z, w);
+				q = new Quat(vec.x, vec.y, vec.z, inputs[3].get());
 				q.normalize();
 		}
 


### PR DESCRIPTION
(compatibility with RotateObject nodes created with armory pre-17daabeb29dfb0a5cc8b4bef840b02b9f83f409d to be exact)
I just kinda derped the compatibility with already-instanced nodes when I wrote that previous commit. Fixing it now.