### PR TITLE
Add "armory" flag on export to differ between Armory and Kha

### DIFF
--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -51,6 +51,9 @@ let project = new Project('""" + arm.utils.safestr(wrd.arm_project_name) + """')
 project.addSources('Sources');
 """)
 
+        # Let libraries differentiate between Armory and pure Kha
+        assets.add_khafile_def('armory')
+
         # Auto-add assets located in Bundled directory
         if os.path.exists('Bundled'):
             for file in glob.glob("Bundled/**", recursive=True):


### PR DESCRIPTION
Armory's Kha is usually a bit behind the Kode/Kha version which can make it a bit complicated in some cases for libraries to support both versions. For example, Kha replaced `PipelineCache` with `SimplePipelineCache` (the first is now an interface) but Armory still uses the old version.

This PR adds an "armory" flag so it's easy to just check if Armory is used or not. This also makes it possible to check whether Iron is available.