### PR TITLE
Fix canvas nodes for invalid element names

### DIFF
--- a/Sources/armory/logicnode/CanvasGetLocationNode.hx
+++ b/Sources/armory/logicnode/CanvasGetLocationNode.hx
@@ -19,8 +19,11 @@ class CanvasGetLocationNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		x = canvas.getElement(element).x;
-        y = canvas.getElement(element).y;
+		var e = canvas.getElement(element);
+		if (e == null) return;
+
+		x = e.x;
+		y = e.y;
 		runOutput(0);
 	}
 

--- a/Sources/armory/logicnode/CanvasGetPBNode.hx
+++ b/Sources/armory/logicnode/CanvasGetPBNode.hx
@@ -19,6 +19,9 @@ class CanvasGetPBNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
+		var e = canvas.getElement(element);
+		if (e == null) return;
+
 		at = canvas.getElement(element).progress_at;
         max = canvas.getElement(element).progress_total;
 		runOutput(0);

--- a/Sources/armory/logicnode/CanvasGetRotationNode.hx
+++ b/Sources/armory/logicnode/CanvasGetRotationNode.hx
@@ -18,8 +18,10 @@ class CanvasGetRotationNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		rad = canvas.getElement(element).rotation;
+		var e = canvas.getElement(element);
+		if (e == null) return;
 
+		rad = e.rotation;
 		runOutput(0);
 	}
 

--- a/Sources/armory/logicnode/CanvasGetScaleNode.hx
+++ b/Sources/armory/logicnode/CanvasGetScaleNode.hx
@@ -19,8 +19,11 @@ class CanvasGetScaleNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		height = canvas.getElement(element).height;
-        width = canvas.getElement(element).width;
+		var e = canvas.getElement(element);
+		if (e == null) return;
+
+		height = e.height;
+        width = e.width;
 		runOutput(0);
 	}
 

--- a/Sources/armory/logicnode/CanvasGetScaleNode.hx
+++ b/Sources/armory/logicnode/CanvasGetScaleNode.hx
@@ -23,7 +23,7 @@ class CanvasGetScaleNode extends LogicNode {
 		if (e == null) return;
 
 		height = e.height;
-        width = e.width;
+		width = e.width;
 		runOutput(0);
 	}
 
@@ -36,7 +36,7 @@ class CanvasGetScaleNode extends LogicNode {
 		tree.notifyOnUpdate(update);
 		update();
 	}
-    override function get(from: Int): Dynamic {
+	override function get(from: Int): Dynamic {
 		if (from == 1) return height;
 		else if (from == 2) return width;
 		else return 0;

--- a/Sources/armory/logicnode/CanvasSetAssetNode.hx
+++ b/Sources/armory/logicnode/CanvasSetAssetNode.hx
@@ -18,7 +18,8 @@ class CanvasSetAssetNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		canvas.getElement(element).asset = asset;
+		var e = canvas.getElement(element);
+		if (e != null) e.asset = asset;
 		runOutput(0);
 	}
 

--- a/Sources/armory/logicnode/CanvasSetLocationNode.hx
+++ b/Sources/armory/logicnode/CanvasSetLocationNode.hx
@@ -19,8 +19,11 @@ class CanvasSetLocationNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		canvas.getElement(element).x = newX;
-		canvas.getElement(element).y = newY;
+		var e = canvas.getElement(element);
+		if (e != null) {
+			e.x = newX;
+			e.y = newY;
+		}
 		runOutput(0);
 	}
 

--- a/Sources/armory/logicnode/CanvasSetPBNode.hx
+++ b/Sources/armory/logicnode/CanvasSetPBNode.hx
@@ -19,9 +19,11 @@ class CanvasSetPBNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		canvas.getElement(element).progress_at = newAt;
-        canvas.getElement(element).progress_total = newMax;
-
+		var e = canvas.getElement(element);
+		if (e != null) {
+			e.progress_at = newAt;
+			e.progress_total = newMax;
+		}
 		runOutput(0);
 	}
 

--- a/Sources/armory/logicnode/CanvasSetRotationNode.hx
+++ b/Sources/armory/logicnode/CanvasSetRotationNode.hx
@@ -18,7 +18,8 @@ class CanvasSetRotationNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		canvas.getElement(element).rotation = rad;
+		var e = canvas.getElement(element);
+		if (e != null) e.rotation = rad;
 		runOutput(0);
 	}
 

--- a/Sources/armory/logicnode/CanvasSetScaleNode.hx
+++ b/Sources/armory/logicnode/CanvasSetScaleNode.hx
@@ -19,8 +19,11 @@ class CanvasSetScaleNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		canvas.getElement(element).height = height;
-        canvas.getElement(element).width = width;
+		var e = canvas.getElement(element);
+		if (e != null) {
+			e.height = height;
+			e.width = width;
+		}
 		runOutput(0);
 	}
 

--- a/Sources/armory/logicnode/CanvasSetTextColorNode.hx
+++ b/Sources/armory/logicnode/CanvasSetTextColorNode.hx
@@ -22,7 +22,8 @@ class CanvasSetTextColorNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		canvas.getElement(element).color_text = Color.fromFloats(r, g, b, a);
+		var e = canvas.getElement(element);
+		if (e != null) e.color_text = Color.fromFloats(r, g, b, a);
 		runOutput(0);
 	}
 

--- a/Sources/armory/logicnode/CanvasSetTextNode.hx
+++ b/Sources/armory/logicnode/CanvasSetTextNode.hx
@@ -18,7 +18,8 @@ class CanvasSetTextNode extends LogicNode {
 		if (!canvas.ready) return;
 		tree.removeUpdate(update);
 
-		canvas.getElement(element).text = text;
+		var e = canvas.getElement(element);
+		if (e != null) e.text = text;
 		runOutput(0);
 	}
 


### PR DESCRIPTION
This fixes https://github.com/armory3d/armory/issues/1842.

If the element socket of some canvas nodes had an empty name or the element doesn't exist, the game would show a black screen. Now, if an element doesn't exist for a `Set` node, the output is still run but nothing happens. For `Get` nodes, the output is not run at all if the element doesn't exist to prevent the usage of wrong values left over by old elements.