### PR TITLE
Custom Particle Node

### DIFF
--- a/Sources/armory/trait/CustomParticle.hx
+++ b/Sources/armory/trait/CustomParticle.hx
@@ -1,0 +1,40 @@
+package armory.trait;
+
+import iron.object.MeshObject;
+
+/**
+ * Trait to enable GPU instancing of Mesh objects
+ */
+class CustomParticle extends iron.Trait {
+
+	@prop
+	var ParticleCount: Int = 100;
+
+	public function new() {
+		super();
+
+		notifyOnInit(function() {
+			var partCount = ParticleCount;
+			setupSimpleInstanced(partCount);
+		});
+	}
+
+	function setupSimpleInstanced(count: Int){
+		if(object.raw.type == 'mesh_object')
+		{
+			var meshObjGeom = cast(object, MeshObject).data.geom;
+			meshObjGeom.instanced = true;
+			meshObjGeom.instanceCount = count;
+		}
+	}
+
+	public function updateParticleCount(count: Int){
+
+		if(object.raw.type == 'mesh_object')
+		{
+			var meshObjGeom = cast(object, MeshObject).data.geom;
+			meshObjGeom.instanced = true;
+			meshObjGeom.instanceCount = count;
+		}
+	}
+}

--- a/blender/arm/material/arm_nodes/Custom_particle_node.py
+++ b/blender/arm/material/arm_nodes/Custom_particle_node.py
@@ -1,0 +1,185 @@
+from bpy.props import *
+from bpy.types import Node
+
+from arm.material.arm_nodes.arm_nodes import add_node
+from arm.material.shader import Shader
+from arm.material.cycles import *
+
+
+class CustomParticleNode(Node):
+    """Input data for paricles."""
+    bl_idname = 'ArmCustomParticleNode'
+    bl_label = 'Custom Particle'
+    bl_icon = 'NONE'
+
+    posX: BoolProperty(
+        name = "",
+        description="enable translation along x",
+        default=False,
+    )
+
+    posY: BoolProperty(
+        name = "",
+        description="enable translation along y",
+        default=False,
+    )
+
+    posZ: BoolProperty(
+        name = "",
+        description="enable translation along z",
+        default=False,
+    )
+    
+    rotX: BoolProperty(
+        name = "",
+        description="enable rotation along x",
+        default=False,
+    )
+
+    rotY: BoolProperty(
+        name = "",
+        description="enable rotation along y",
+        default=False,
+    )
+
+    rotZ: BoolProperty(
+        name = "",
+        description="enable rotation along z",
+        default=False,
+    )
+
+    sclX: BoolProperty(
+        name = "",
+        description="enable scaling along x",
+        default=False,
+    )
+
+    sclY: BoolProperty(
+        name = "",
+        description="enable scaling along y",
+        default=False,
+    )
+
+    sclZ: BoolProperty(
+        name = "",
+        description="enable scaling along z",
+        default=False,
+    )
+
+    billBoard: BoolProperty(
+        name = "Bill Board",
+        description = "Enable Bill Board",
+        default = False,
+    )
+
+
+    def init(self, context):
+        self.inputs.new('NodeSocketVector', 'Position')
+        self.inputs.new('NodeSocketVector', 'Rotation')
+        self.inputs.new('NodeSocketVector', 'Scale')
+    
+    def draw_buttons(self, context, layout):
+
+        grid0 = layout.grid_flow(row_major=True, columns=4, align=False)
+
+        grid0.label(text = "")
+        grid0.label(text = " X")
+        grid0.label(text = " Y")
+        grid0.label(text = " Z")
+
+        grid0.label(text = "Pos")
+        grid0.prop(self,"posX")
+        grid0.prop(self,"posY")
+        grid0.prop(self,"posZ")
+
+        grid0.label(text = "Rot")
+        grid0.prop(self,"rotX")
+        grid0.prop(self,"rotY")
+        grid0.prop(self,"rotZ")
+
+        grid0.label(text = "Scl")
+        grid0.prop(self,"sclX")
+        grid0.prop(self,"sclY")
+        grid0.prop(self,"sclZ")
+
+        layout.prop(self,"billBoard")
+        
+        
+    def parse(self, vertshdr:Shader,part_con) -> str:
+                
+        if(self.sclX or self.sclY or self.sclZ):
+            scl = parse_vector_input(self.inputs[2])
+        
+        if(self.sclX):
+            vertshdr.write(f'spos.x *= {scl}.x;')
+
+        if(self.sclY):
+            vertshdr.write(f'spos.y *= {scl}.y;')
+
+        if(self.sclX):
+            vertshdr.write(f'spos.z *= {scl}.z;')
+
+        if(self.billBoard):
+            vertshdr.add_uniform('mat4 WV', '_worldViewMatrix')
+            vertshdr.write('spos = mat4(transpose(mat3(WV))) * spos;')
+        
+        if(self.rotX or self.rotY or self.rotZ):
+            rot = parse_vector_input(self.inputs[1])
+
+        if(self.rotX and not self.rotY and not self.rotZ):
+            vertshdr.write(f'mat3 part_rot_mat = mat3(1.0, 0.0, 0.0,') 
+            vertshdr.write(f'                       0.0, cos({rot}.x), sin({rot}.x),')
+            vertshdr.write(f'                       0.0, -sin({rot}.x), cos({rot}.x));')
+
+        if(not self.rotX and self.rotY and not self.rotZ):
+            vertshdr.write(f'mat3 part_rot_mat = mat3(cos({rot}.y), 0.0, -sin({rot}.y),') 
+            vertshdr.write(f'                       0.0, 1.0, 0.0,')
+            vertshdr.write(f'                       sin({rot}.y), 0.0, cos({rot}.y));')
+
+        if(not self.rotX and not self.rotY and self.rotZ):
+            vertshdr.write(f'mat3 part_rot_mat = mat3(cos({rot}.z), sin({rot}.z), 0.0,') 
+            vertshdr.write(f'                       -sin({rot}.z), cos({rot}.z), 0.0,')
+            vertshdr.write(f'                       0.0, 0.0, 1.0);')
+
+        if(self.rotX and self.rotY and not self.rotZ):
+            vertshdr.write(f'mat3 part_rot_mat = mat3(cos({rot}.y), 0.0, -sin({rot}.y),') 
+            vertshdr.write(f'                         sin({rot}.y) * sin({rot}.x), cos({rot}.x), cos({rot}.y) * sin({rot}.x),')
+            vertshdr.write(f'                         sin({rot}.y) * cos({rot}.x), -sin({rot}.x), cos({rot}.y) * cos({rot}.x));')
+        
+        if(self.rotX and not self.rotY and self.rotZ):
+            vertshdr.write(f'mat3 part_rot_mat = mat3(cos({rot}.z), sin({rot}.z), 0.0,') 
+            vertshdr.write(f'                         -sin({rot}.z) * cos({rot}.x), cos({rot}.z) * cos({rot}.x), sin({rot}.x),')
+            vertshdr.write(f'                         sin({rot}.z) * sin({rot}.x), -cos({rot}.z) * sin({rot}.x), cos({rot}.x));')
+        
+        if(not self.rotX and self.rotY and self.rotZ):
+            vertshdr.write(f'mat3 part_rot_mat = mat3(cos({rot}.z) * cos({rot}.y), sin({rot}.z) * cos({rot}.y), -sin({rot}.y),') 
+            vertshdr.write(f'                         -sin({rot}.z) , cos({rot}.z), 0.0,')
+            vertshdr.write(f'                         cos({rot}.z) * sin({rot}.y), sin({rot}.z) * sin({rot}.y), cos({rot}.y));')
+        
+        if(self.rotX and self.rotY and self.rotZ):
+            vertshdr.write(f'mat3 part_rot_mat = mat3(cos({rot}.z) * cos({rot}.y), sin({rot}.z) * cos({rot}.y), -sin({rot}.y),') 
+            vertshdr.write(f'                         -sin({rot}.z) * cos({rot}.x) + cos({rot}.z) * sin({rot}.y) * sin({rot}.x), cos({rot}.z) * cos({rot}.x) + sin({rot}.z) * sin({rot}.y) * sin({rot}.x), cos({rot}.y) * sin({rot}.x),')
+            vertshdr.write(f'                         sin({rot}.z) * sin({rot}.x) + cos({rot}.z) * sin({rot}.y) * cos({rot}.x), -cos({rot}.z) * sin({rot}.x) + sin({rot}.z) * sin({rot}.y) * cos({rot}.x), cos({rot}.y) * cos({rot}.x));')
+        
+        if(self.rotX or self.rotY or self.rotZ):
+            vertshdr.write('spos.xyz = part_rot_mat * spos.xyz;')
+            if((part_con.data['name'] == 'mesh' or 'translucent') and vertshdr.contains('wnormal')):
+                vertshdr.write('wnormal = transpose(inverse(part_rot_mat)) * wnormal;')
+        
+        if(self.posX or self.posY or self.posZ):
+            pos = parse_vector_input(self.inputs[0])
+        
+        if(self.posX):
+            vertshdr.write(f'spos.x += {pos}.x;')
+
+        if(self.posY):
+            vertshdr.write(f'spos.y += {pos}.y;')
+
+        if(self.posZ):
+            vertshdr.write(f'spos.z += {pos}.z;')
+                
+        if(vertshdr.contains('vec3 disp')):
+            vertshdr.write('wposition = vec4(W * spos).xyz;')
+        
+       
+add_node(CustomParticleNode, category='Armory')

--- a/blender/arm/material/arm_nodes/shader_data_node.py
+++ b/blender/arm/material/arm_nodes/shader_data_node.py
@@ -66,6 +66,7 @@ class ShaderDataNode(Node):
     def parse(self, frag: Shader, vert: Shader) -> str:
         if self.input_type == "uniform":
             frag.add_uniform(f'{self.variable_type} {self.variable_name}', link=self.variable_name)
+            vert.add_uniform(f'{self.variable_type} {self.variable_name}', link=self.variable_name)
 
             if self.variable_type == "sampler2D":
                 frag.add_uniform('vec2 screenSize', link='_screenSize')

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -35,10 +35,11 @@ curshader: Shader
 
 def parse(nodes, con, vert, frag, geom, tesc, tese, parse_surface=True, parse_opacity=True, parse_displacement=True, basecol_only=False):
     output_node = node_by_type(nodes, 'OUTPUT_MATERIAL')
+    custom_particle_node = node_by_name(nodes, 'ArmCustomParticleNode')
     if output_node != None:
-        parse_output(output_node, con, vert, frag, geom, tesc, tese, parse_surface, parse_opacity, parse_displacement, basecol_only)
+        parse_output(output_node, con, vert, frag, geom, tesc, tese, parse_surface, parse_opacity, parse_displacement, basecol_only, custom_particle_node)
 
-def parse_output(node, _con, _vert, _frag, _geom, _tesc, _tese, _parse_surface, _parse_opacity, _parse_displacement, _basecol_only):
+def parse_output(node, _con, _vert, _frag, _geom, _tesc, _tese, _parse_surface, _parse_opacity, _parse_displacement, _basecol_only, custom_particle_node):
     global parsed # Compute nodes only once
     global parents
     global normal_parsed
@@ -115,6 +116,17 @@ def parse_output(node, _con, _vert, _frag, _geom, _tesc, _tese, _parse_surface, 
             curshader = vert
         out_disp = parse_displacement_input(node.inputs[2])
         curshader.write('vec3 disp = {0};'.format(out_disp))
+    
+    if custom_particle_node != None:
+        if (not (_parse_displacement and disp_enabled() and node.inputs[2].is_linked)):
+            parsed = {}
+            parents = []
+            normal_parsed = False
+        CPNode = custom_particle_node
+        normal_parsed = False
+
+        curshader = vert
+        custom_particle_node.parse(curshader, con)
 
 def parse_group(node, socket): # Entering group
     index = socket_index(node, socket)
@@ -1674,6 +1686,11 @@ def to_vec3(v):
 def node_by_type(nodes, ntype):
     for n in nodes:
         if n.type == ntype:
+            return n
+
+def node_by_name(nodes, name):
+    for n in nodes:
+        if n.bl_idname == name:
             return n
 
 def socket_index(node, socket):

--- a/blender/arm/material/make_inst.py
+++ b/blender/arm/material/make_inst.py
@@ -14,7 +14,7 @@ def inst_pos(con, vert):
         vert.write('    croty * srotz * srotx + sroty * crotx, -crotz * srotx, -sroty * srotz * srotx + croty * crotx')
         vert.write(');')
         vert.write('spos.xyz = mirot * spos.xyz;')
-        if con.data['name'] == 'mesh':
+        if((con.data['name'] == 'mesh' or 'translucent') and vert.contains('wnormal')):
             vert.write('wnormal = transpose(inverse(mirot)) * wnormal;')
 
     if con.is_elem('iscl'):


### PR DESCRIPTION
This PR introduces a new material node; Custom Particle node.

Also requires [Iron/#101](https://github.com/armory3d/iron/pull/101#issue-488258474)

This node can be used to efficiently create arbitrarily complex GPU particle systems as a function of particle index `gl_InstanceID` and `uniform time`.

![image](https://user-images.githubusercontent.com/55564981/93395286-ea0ffd80-f875-11ea-81dd-96928c83cf71.png)

Node properties:

- Efficiently control what particle parameters are modified at run-time using `pos, rot, scl` checkbox. The code for only selected checkboxes is written to the shader. No unwanted processing.

- Built-in billboard option for spherical billboarding of particles. The local z of each particle always faces the camera.

- Since this node is a material node, multiple particle systems can be set-up in different materials. During run-time, changing material also changes the particle system.

- Dynamically control particle system parameters using Armory Shader Value/Color parameters. 

Here are a few examples created using this node as a test

[A Pattern type particle system](https://quantumcoderqc.itch.io/armory3d-dynamic-pattern-particle)
[Projectile Particle System](https://quantumcoderqc.itch.io/armory3d-dynamic-particle-parameter-control)
[Sprite Sheet Particle System](https://quantumcoderqc.itch.io/armory3d-sprite-sheet-particle-example)


Usage: A minimalist example of instanced rendering. Fragment and Vertex shader in a single material

Material Setup:
![image](https://user-images.githubusercontent.com/55564981/93397924-de730580-f87a-11ea-9039-15918043bf73.png)
 
Result:
![image](https://user-images.githubusercontent.com/55564981/93397893-cd29f900-f87a-11ea-898c-68b26f281bdc.png)


