### PR TITLE
Logic nodes improvements

### DIFF
--- a/Sources/armory/logicnode/GetCursorLocationNode.hx
+++ b/Sources/armory/logicnode/GetCursorLocationNode.hx
@@ -1,0 +1,24 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+
+class GetCursorLocationNode extends LogicNode {
+
+	var coords = new Vec4();
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var mouse = iron.system.Input.getMouse();
+
+		return switch (from) {
+			case 0: mouse.x;
+			case 1: mouse.y;
+			case 2: mouse.x * -1;
+			case 3: mouse.y * -1;
+		default: null;
+		}
+	}
+}

--- a/Sources/armory/logicnode/GetCursorStateNode.hx
+++ b/Sources/armory/logicnode/GetCursorStateNode.hx
@@ -1,0 +1,24 @@
+package armory.logicnode;
+
+import iron.system.Input;
+
+class GetCursorStateNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var mouse = iron.system.Input.getMouse();
+
+		return switch (from) {
+		case 0:
+		if (mouse.hidden == true && mouse.locked == true) return true;
+		return false;
+
+		case 1: mouse.hidden;
+		case 2: mouse.locked;
+    default: null;
+    }
+	}
+}

--- a/Sources/armory/logicnode/GetMouseMovementNode.hx
+++ b/Sources/armory/logicnode/GetMouseMovementNode.hx
@@ -1,0 +1,29 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+
+class GetMouseMovementNode extends LogicNode {
+
+	var coords = new Vec4();
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var mouse = iron.system.Input.getMouse();
+		var multX: Float = inputs[0].get();
+		var multY: Float = inputs[1].get();
+		var multDelta: Float = inputs[2].get();
+
+		return switch (from) {
+			case 0: mouse.movementX;
+			case 1: mouse.movementY;
+			case 2: mouse.wheelDelta;
+			case 3: mouse.movementX * multX;
+			case 4: mouse.movementY * multY;
+			case 5: mouse.wheelDelta * multDelta;
+		default: null;
+		}
+	}
+}

--- a/Sources/armory/logicnode/GetRigidBodyDataNode.hx
+++ b/Sources/armory/logicnode/GetRigidBodyDataNode.hx
@@ -22,7 +22,8 @@ class GetRigidBodyDataNode extends LogicNode {
 			if (rigidBody == null) return false;
 			return true;
 
-			//case 1: rigidBody.btshape;
+			//case 1: ; // collision shape
+			//case 2: ; // activation state
 			case 1: rigidBody.group;
 			case 2: rigidBody.mask;
 			case 3: rigidBody.animated;

--- a/Sources/armory/logicnode/GetTouchLocationNode.hx
+++ b/Sources/armory/logicnode/GetTouchLocationNode.hx
@@ -1,0 +1,24 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+
+class GetTouchLocationNode extends LogicNode {
+
+	var coords = new Vec4();
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var touch = iron.system.Input.getSurface();
+
+		return switch (from) {
+			case 0: touch.x;
+			case 1: touch.y;
+			case 2: touch.x * -1;
+			case 3: touch.y * -1;
+		default: null;
+		}
+	}
+}

--- a/Sources/armory/logicnode/GetTouchMovementNode.hx
+++ b/Sources/armory/logicnode/GetTouchMovementNode.hx
@@ -1,0 +1,26 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+
+class GetTouchMovementNode extends LogicNode {
+
+	var coords = new Vec4();
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var touch = iron.system.Input.getSurface();
+		var multX: Float = inputs[0].get();
+		var multY: Float = inputs[1].get();
+
+		return switch (from) {
+			case 0: touch.movementX;
+			case 1: touch.movementY;
+			case 2: touch.movementX * multX;
+			case 3: touch.movementY * multY;
+		default: null;
+		}
+	}
+}

--- a/Sources/armory/logicnode/GetWorldNode.hx
+++ b/Sources/armory/logicnode/GetWorldNode.hx
@@ -6,7 +6,7 @@ import iron.math.Vec4;
 class GetWorldNode extends LogicNode {
 
 	public var property0: String;
-	
+
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
@@ -18,11 +18,11 @@ class GetWorldNode extends LogicNode {
 		}
 
 		switch (property0) {
-			case "right":
+			case "Right":
 				return object.transform.world.right();
-			case "look":
+			case "Look":
 				return object.transform.world.look();
-			case "up":
+			case "Up":
 				return object.transform.world.up();
 		}
 		return null;

--- a/Sources/armory/logicnode/SetCursorStateNode.hx
+++ b/Sources/armory/logicnode/SetCursorStateNode.hx
@@ -1,0 +1,29 @@
+package armory.logicnode;
+
+class SetCursorStateNode extends LogicNode {
+
+	public var property0: String;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var state: Bool = inputs[1].get();
+		var mouse = iron.system.Input.getMouse();
+
+		switch (property0) {
+		case "Hide Locked":
+			state ? mouse.hide() : mouse.show();
+ 			mouse.hidden ? mouse.lock() : mouse.unlock();
+
+ 		case "Hide":
+ 			state ? mouse.hide() : mouse.show();
+ 
+ 		case "Lock":
+ 			state ? mouse.lock() : mouse.unlock();
+		}
+
+		runOutput(0);
+	}
+}

--- a/blender/arm/logicnode/array/LN_array_contains.py
+++ b/blender/arm/logicnode/array/LN_array_contains.py
@@ -10,6 +10,6 @@ class ArrayContainsNode(ArmLogicTreeNode):
         super(ArrayContainsNode, self).init(context)
         self.add_input('ArmNodeSocketArray', 'Array')
         self.add_input('NodeSocketShader', 'Value')
-        self.add_output('NodeSocketBool', 'Bool')
+        self.add_output('NodeSocketBool', 'Contains')
 
 add_node(ArrayContainsNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/camera/LN_get_active_camera.py
+++ b/blender/arm/logicnode/camera/LN_get_active_camera.py
@@ -8,6 +8,6 @@ class ActiveCameraNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(ActiveCameraNode, self).init(context)
-        self.add_output('ArmNodeSocketObject', 'Object')
+        self.add_output('ArmNodeSocketObject', 'Camera')
 
 add_node(ActiveCameraNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/camera/LN_set_active_camera.py
+++ b/blender/arm/logicnode/camera/LN_set_active_camera.py
@@ -9,8 +9,7 @@ class SetCameraNode(ArmLogicTreeNode):
     def init(self, context):
         super(SetCameraNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
-
+        self.add_input('ArmNodeSocketObject', 'Camera')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(SetCameraNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/camera/LN_set_camera_fov.py
+++ b/blender/arm/logicnode/camera/LN_set_camera_fov.py
@@ -4,13 +4,12 @@ class SetCameraFovNode(ArmLogicTreeNode):
     """Set the camera's field of view."""
     bl_idname = 'LNSetCameraFovNode'
     bl_label = 'Set Camera FOV'
-    bl_description = 'Set the camera\'s field of view'
     arm_version = 1
 
     def init(self, context):
         super(SetCameraFovNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Camera')
         self.add_input('NodeSocketFloat', 'FOV', default_value=0.85)
         self.add_output('ArmNodeSocketAction', 'Out')
 

--- a/blender/arm/logicnode/canvas/LN_canvas_get_checkbox.py
+++ b/blender/arm/logicnode/canvas/LN_canvas_get_checkbox.py
@@ -1,7 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
 class CanvasGetCheckboxNode(ArmLogicTreeNode):
-    """Get canvas checkbox value"""
+    """Get Canvas Checkbox node"""
     bl_idname = 'LNCanvasGetCheckboxNode'
     bl_label = 'Canvas Get Checkbox'
     arm_version = 1
@@ -9,6 +9,6 @@ class CanvasGetCheckboxNode(ArmLogicTreeNode):
     def init(self, context):
         super(CanvasGetCheckboxNode, self).init(context)
         self.add_input('NodeSocketString', 'Element')
-        self.add_output('NodeSocketBool', 'Value')
+        self.add_output('NodeSocketBool', 'Is Checked')
 
 add_node(CanvasGetCheckboxNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_canvas_get_input_text.py
+++ b/blender/arm/logicnode/canvas/LN_canvas_get_input_text.py
@@ -9,6 +9,6 @@ class CanvasGetInputTextNode(ArmLogicTreeNode):
     def init(self, context):
         super(CanvasGetInputTextNode, self).init(context)
         self.add_input('NodeSocketString', 'Element')
-        self.add_output('NodeSocketString', 'Value')
+        self.add_output('NodeSocketString', 'String')
 
 add_node(CanvasGetInputTextNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_canvas_get_slider.py
+++ b/blender/arm/logicnode/canvas/LN_canvas_get_slider.py
@@ -9,6 +9,6 @@ class CanvasGetSliderNode(ArmLogicTreeNode):
     def init(self, context):
         super(CanvasGetSliderNode, self).init(context)
         self.add_input('NodeSocketString', 'Element')
-        self.add_output('NodeSocketFloat', 'Value')
+        self.add_output('NodeSocketFloat', 'Float')
 
 add_node(CanvasGetSliderNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_canvas_get_visible.py
+++ b/blender/arm/logicnode/canvas/LN_canvas_get_visible.py
@@ -12,6 +12,6 @@ class CanvasGetVisibleNode(ArmLogicTreeNode):
     def init(self, context):
         super(CanvasGetVisibleNode, self).init(context)
         self.inputs.new('NodeSocketString', 'Element')
-        self.outputs.new('NodeSocketBool', 'Visible')
+        self.outputs.new('NodeSocketBool', 'Is Visible')
 
 add_node(CanvasGetVisibleNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_canvas_set_checkbox.py
+++ b/blender/arm/logicnode/canvas/LN_canvas_set_checkbox.py
@@ -10,7 +10,7 @@ class CanvasSetCheckBoxNode(ArmLogicTreeNode):
         super(CanvasSetCheckBoxNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketString', 'Element')
-        self.add_input('NodeSocketBool', 'Value')
+        self.add_input('NodeSocketBool', 'Check')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(CanvasSetCheckBoxNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_canvas_set_slider.py
+++ b/blender/arm/logicnode/canvas/LN_canvas_set_slider.py
@@ -10,7 +10,7 @@ class CanvasSetSliderNode(ArmLogicTreeNode):
         super(CanvasSetSliderNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketString', 'Element')
-        self.add_input('NodeSocketFloat', 'Value')
+        self.add_input('NodeSocketFloat', 'Float')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(CanvasSetSliderNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/input/LN_get_cursor_location.py
+++ b/blender/arm/logicnode/input/LN_get_cursor_location.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class GetCursorLocationNode(ArmLogicTreeNode):
+    """Get Cursor Location node"""
+    bl_idname = 'LNGetCursorLocationNode'
+    bl_label = 'Get Cursor Location'
+    arm_version = 1
+
+    def init(self, context):
+        super(GetCursorLocationNode, self).init(context)
+        self.add_output('NodeSocketInt', 'X')
+        self.add_output('NodeSocketInt', 'Y')
+        self.add_output('NodeSocketInt', 'Inverted X')
+        self.add_output('NodeSocketInt', 'Inverted Y')
+
+add_node(GetCursorLocationNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_get_cursor_state.py
+++ b/blender/arm/logicnode/input/LN_get_cursor_state.py
@@ -1,0 +1,18 @@
+import bpy
+from bpy.props import *
+from bpy.types import Node, NodeSocket
+from arm.logicnode.arm_nodes import *
+
+class GetCursorStateNode(ArmLogicTreeNode):
+    """Get Cursor State node"""
+    bl_idname = 'LNGetCursorStateNode'
+    bl_label = 'Get Cursor State'
+    arm_version = 1
+
+    def init(self, context):
+        super(GetCursorStateNode, self).init(context)
+        self.outputs.new('NodeSocketBool', 'Is Hidden Locked')
+        self.outputs.new('NodeSocketBool', 'Is Hidden')
+        self.outputs.new('NodeSocketBool', 'Is Locked')
+
+add_node(GetCursorStateNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_get_mouse_lock.py
+++ b/blender/arm/logicnode/input/LN_get_mouse_lock.py
@@ -11,6 +11,6 @@ class GetMouseLockNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(GetMouseLockNode, self).init(context)
-        self.outputs.new('NodeSocketBool', 'Lock')
+        self.outputs.new('NodeSocketBool', 'Is Locked')
 
 add_node(GetMouseLockNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_get_mouse_movement.py
+++ b/blender/arm/logicnode/input/LN_get_mouse_movement.py
@@ -1,0 +1,21 @@
+from arm.logicnode.arm_nodes import *
+
+class GetMouseMovementNode(ArmLogicTreeNode):
+    """Get Mouse Movement node"""
+    bl_idname = 'LNGetMouseMovementNode'
+    bl_label = 'Get Mouse Movement'
+    arm_version = 1
+
+    def init(self, context):
+        super(GetMouseMovementNode, self).init(context)
+        self.add_input('NodeSocketFloat', 'X Multiplier' , default_value=1.0)
+        self.add_input('NodeSocketFloat', 'Y Multiplier', default_value=-1.0)
+        self.add_input('NodeSocketFloat', 'Delta Multiplier', default_value=1.0)
+        self.add_output('NodeSocketFloat', 'X')
+        self.add_output('NodeSocketFloat', 'Y')
+        self.add_output('NodeSocketInt', 'Delta')
+        self.add_output('NodeSocketFloat', 'Multiplied X')
+        self.add_output('NodeSocketFloat', 'Multiplied Y')
+        self.add_output('NodeSocketFloat', 'Multiplied Delta')
+
+add_node(GetMouseMovementNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_get_mouse_visible.py
+++ b/blender/arm/logicnode/input/LN_get_mouse_visible.py
@@ -11,6 +11,6 @@ class GetMouseVisibleNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(GetMouseVisibleNode, self).init(context)
-        self.outputs.new('NodeSocketBool', 'Visible')
+        self.outputs.new('NodeSocketBool', 'Is Visible')
 
 add_node(GetMouseVisibleNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_get_touch_location.py
+++ b/blender/arm/logicnode/input/LN_get_touch_location.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class GetTouchLocationNode(ArmLogicTreeNode):
+    """Get Touch Location node"""
+    bl_idname = 'LNGetTouchLocationNode'
+    bl_label = 'Get Touch Location'
+    arm_version = 1
+
+    def init(self, context):
+        super(GetTouchLocationNode, self).init(context)
+        self.add_output('NodeSocketInt', 'X')
+        self.add_output('NodeSocketInt', 'Y')
+        self.add_output('NodeSocketInt', 'Inverted X')
+        self.add_output('NodeSocketInt', 'Inverted Y')
+
+add_node(GetTouchLocationNode, category=PKG_AS_CATEGORY, section='surface')

--- a/blender/arm/logicnode/input/LN_get_touch_movement.py
+++ b/blender/arm/logicnode/input/LN_get_touch_movement.py
@@ -1,0 +1,18 @@
+from arm.logicnode.arm_nodes import *
+
+class GetTouchMovementNode(ArmLogicTreeNode):
+    """Get Touch Movement node"""
+    bl_idname = 'LNGetTouchMovementNode'
+    bl_label = 'Get Touch Movement'
+    arm_version = 1
+
+    def init(self, context):
+        super(GetTouchMovementNode, self).init(context)
+        self.add_input('NodeSocketFloat', 'X Multiplier' , default_value=1.0)
+        self.add_input('NodeSocketFloat', 'Y Multiplier', default_value=-1.0)
+        self.add_output('NodeSocketFloat', 'X')
+        self.add_output('NodeSocketFloat', 'Y')
+        self.add_output('NodeSocketFloat', 'Multiplied X')
+        self.add_output('NodeSocketFloat', 'Multiplied Y')
+
+add_node(GetTouchMovementNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_set_cursor_state.py
+++ b/blender/arm/logicnode/input/LN_set_cursor_state.py
@@ -1,0 +1,25 @@
+from arm.logicnode.arm_nodes import *
+
+class SetCursorStateNode(ArmLogicTreeNode):
+    """Set Cursor State node"""
+    bl_idname = 'LNSetCursorStateNode'
+    bl_label = 'Set Cursor State'
+    arm_version = 1
+
+    property0: EnumProperty(
+        items = [('Hide Locked', 'Hide Locked', 'Hide Locked'),
+                 ('Hide', 'Hide', 'Hide'),
+                 ('Lock', 'Lock', 'Lock'),
+                 ],
+        name='', default='Hide Locked')
+
+    def init(self, context):
+        super(SetCursorStateNode, self).init(context)
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('NodeSocketBool', 'State')
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
+
+add_node(SetCursorStateNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/light/LN_set_light_color.py
+++ b/blender/arm/logicnode/light/LN_set_light_color.py
@@ -9,7 +9,7 @@ class SetLightColorNode(ArmLogicTreeNode):
     def init(self, context):
         super(SetLightColorNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Light')
         self.add_input('NodeSocketColor', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
         self.add_output('ArmNodeSocketAction', 'Out')
 

--- a/blender/arm/logicnode/light/LN_set_light_strength.py
+++ b/blender/arm/logicnode/light/LN_set_light_strength.py
@@ -9,8 +9,8 @@ class SetLightStrengthNode(ArmLogicTreeNode):
     def init(self, context):
         super(SetLightStrengthNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_input('NodeSocketFloat', 'Strength', default_value=100)
+        self.add_input('ArmNodeSocketObject', 'Light')
+        self.add_input('NodeSocketFloat', 'Strength', default_value=250)
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(SetLightStrengthNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_gate.py
+++ b/blender/arm/logicnode/logic/LN_gate.py
@@ -33,8 +33,8 @@ class GateNode(ArmLogicTreeNode):
     def init(self, context):
         super(GateNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('NodeSocketShader', 'Value')
-        self.add_input('NodeSocketShader', 'Value')
+        self.add_input('NodeSocketShader', 'Input 1')
+        self.add_input('NodeSocketShader', 'Input 2')
         self.add_output('ArmNodeSocketAction', 'True')
         self.add_output('ArmNodeSocketAction', 'False')
 

--- a/blender/arm/logicnode/logic/LN_is_false.py
+++ b/blender/arm/logicnode/logic/LN_is_false.py
@@ -10,7 +10,7 @@ class IsFalseNode(ArmLogicTreeNode):
     def init(self, context):
         super(IsFalseNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('NodeSocketBool', 'Value')
+        self.add_input('NodeSocketBool', 'Bool')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 

--- a/blender/arm/logicnode/logic/LN_is_true.py
+++ b/blender/arm/logicnode/logic/LN_is_true.py
@@ -9,7 +9,7 @@ class IsTrueNode(ArmLogicTreeNode):
     def init(self, context):
         super(IsTrueNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('NodeSocketBool', 'Value')
+        self.add_input('NodeSocketBool', 'Bool')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(IsTrueNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_not.py
+++ b/blender/arm/logicnode/logic/LN_not.py
@@ -8,7 +8,7 @@ class NotNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(NotNode, self).init(context)
-        self.add_input('NodeSocketBool', 'Value')
-        self.add_output('NodeSocketBool', 'Value')
+        self.add_input('NodeSocketBool', 'Bool In')
+        self.add_output('NodeSocketBool', 'Bool Out')
 
 add_node(NotNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/material/LN_set_material_value_param.py
+++ b/blender/arm/logicnode/material/LN_set_material_value_param.py
@@ -11,7 +11,7 @@ class SetMaterialValueParamNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketShader', 'Material')
         self.add_input('NodeSocketString', 'Node')
-        self.add_input('NodeSocketFloat', 'Value')
+        self.add_input('NodeSocketFloat', 'Float')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(SetMaterialValueParamNode, category=PKG_AS_CATEGORY, section='params')

--- a/blender/arm/logicnode/math/LN_math.py
+++ b/blender/arm/logicnode/math/LN_math.py
@@ -42,9 +42,9 @@ class MathNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(MathNode, self).init(context)
-        self.add_input('NodeSocketFloat', 'Value', default_value=0.5)
-        self.add_input('NodeSocketFloat', 'Value', default_value=0.5)
-        self.add_output('NodeSocketFloat', 'Value')
+        self.add_input('NodeSocketFloat', 'Value 1', default_value=1.0)
+        self.add_input('NodeSocketFloat', 'Value 2', default_value=1.0)
+        self.add_output('NodeSocketFloat', 'Result')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property1_')

--- a/blender/arm/logicnode/math/LN_matrix_math.py
+++ b/blender/arm/logicnode/math/LN_matrix_math.py
@@ -11,9 +11,9 @@ class MatrixMathNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(MatrixMathNode, self).init(context)
-        self.add_input('NodeSocketShader', 'Matrix')
-        self.add_input('NodeSocketShader', 'Matrix')
-        self.add_output('NodeSocketShader', 'Matrix')
+        self.add_input('NodeSocketShader', 'Matrix 1')
+        self.add_input('NodeSocketShader', 'Matrix 2')
+        self.add_output('NodeSocketShader', 'Result')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')

--- a/blender/arm/logicnode/math/LN_mix.py
+++ b/blender/arm/logicnode/math/LN_mix.py
@@ -33,9 +33,9 @@ class MixNode(ArmLogicTreeNode):
     def init(self, context):
         super(MixNode, self).init(context)
         self.add_input('NodeSocketFloat', 'Factor', default_value=0.0)
-        self.add_input('NodeSocketFloat', 'Value1', default_value=0.0)
-        self.add_input('NodeSocketFloat', 'Value2', default_value=1.0)
-        self.add_output('NodeSocketFloat', 'Value')
+        self.add_input('NodeSocketFloat', 'Value 1', default_value=0.0)
+        self.add_input('NodeSocketFloat', 'Value 2', default_value=1.0)
+        self.add_output('NodeSocketFloat', 'Result')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property2_')

--- a/blender/arm/logicnode/math/LN_screen_to_world_space.py
+++ b/blender/arm/logicnode/math/LN_screen_to_world_space.py
@@ -8,7 +8,7 @@ class ScreenToWorldSpaceNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(ScreenToWorldSpaceNode, self).init(context)
-        self.add_input('NodeSocketVector', 'Vector')
-        self.add_output('NodeSocketVector', 'Vector')
+        self.add_input('NodeSocketVector', 'Screen')
+        self.add_output('NodeSocketVector', 'World')
 
 add_node(ScreenToWorldSpaceNode, category=PKG_AS_CATEGORY, section='matrix')

--- a/blender/arm/logicnode/math/LN_separate_color.py
+++ b/blender/arm/logicnode/math/LN_separate_color.py
@@ -8,8 +8,7 @@ class SeparateColorNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(SeparateColorNode, self).init(context)
-        self.add_input('NodeSocketColor', 'Color', default_value=[0.8, 0.8, 0.8, 1])
-
+        self.add_input('NodeSocketColor', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
         self.add_output('NodeSocketFloat', 'R')
         self.add_output('NodeSocketFloat', 'G')
         self.add_output('NodeSocketFloat', 'B')

--- a/blender/arm/logicnode/math/LN_vector_clamp_to_size.py
+++ b/blender/arm/logicnode/math/LN_vector_clamp_to_size.py
@@ -8,9 +8,9 @@ class VectorClampToSizeNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(VectorClampToSizeNode, self).init(context)
-        self.add_input('NodeSocketVector', 'Vector', default_value=[0.5, 0.5, 0.5])
+        self.add_input('NodeSocketVector', 'Vector In', default_value=[0.0, 0.0, 0.0])
         self.add_input('NodeSocketFloat', 'Min')
         self.add_input('NodeSocketFloat', 'Max')
-        self.add_output('NodeSocketVector', 'Vector')
+        self.add_output('NodeSocketVector', 'Vector Out')
 
 add_node(VectorClampToSizeNode, category=PKG_AS_CATEGORY, section='vector')

--- a/blender/arm/logicnode/math/LN_vector_math.py
+++ b/blender/arm/logicnode/math/LN_vector_math.py
@@ -21,10 +21,10 @@ class VectorMathNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(VectorMathNode, self).init(context)
-        self.add_input('NodeSocketVector', 'Vector', default_value=[0.5, 0.5, 0.5])
-        self.add_input('NodeSocketVector', 'Vector', default_value=[0.5, 0.5, 0.5])
-        self.add_output('NodeSocketVector', 'Vector')
-        self.add_output('NodeSocketFloat', 'Value')
+        self.add_input('NodeSocketVector', 'Vector 1', default_value=[0.0, 0.0, 0.0])
+        self.add_input('NodeSocketVector', 'Vector 2', default_value=[0.0, 0.0, 0.0])
+        self.add_output('NodeSocketVector', 'Result')
+        self.add_output('NodeSocketFloat', 'Distance')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')

--- a/blender/arm/logicnode/math/LN_vector_mix.py
+++ b/blender/arm/logicnode/math/LN_vector_mix.py
@@ -33,9 +33,9 @@ class VectorMixNode(ArmLogicTreeNode):
     def init(self, context):
         super(VectorMixNode, self).init(context)
         self.add_input('NodeSocketFloat', 'Factor', default_value=0.0)
-        self.add_input('NodeSocketVector', 'Vector1', default_value=[0.0, 0.0, 0.0])
-        self.add_input('NodeSocketVector', 'Vector2', default_value=[1.0, 1.0, 1.0])
-        self.add_output('NodeSocketVector', 'Vector')
+        self.add_input('NodeSocketVector', 'Vector 1', default_value=[0.0, 0.0, 0.0])
+        self.add_input('NodeSocketVector', 'Vector 2', default_value=[1.0, 1.0, 1.0])
+        self.add_output('NodeSocketVector', 'Result')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property2_')

--- a/blender/arm/logicnode/math/LN_world_to_screen_space.py
+++ b/blender/arm/logicnode/math/LN_world_to_screen_space.py
@@ -8,7 +8,7 @@ class WorldToScreenSpaceNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(WorldToScreenSpaceNode, self).init(context)
-        self.add_input('NodeSocketVector', 'Vector')
-        self.add_output('NodeSocketVector', 'Vector')
+        self.add_input('NodeSocketVector', 'World')
+        self.add_output('NodeSocketVector', 'Screen')
 
 add_node(WorldToScreenSpaceNode, category=PKG_AS_CATEGORY, section='matrix')

--- a/blender/arm/logicnode/native/LN_loadUrl.py
+++ b/blender/arm/logicnode/native/LN_loadUrl.py
@@ -3,7 +3,7 @@ from arm.logicnode.arm_nodes import *
 class LoadUrlNode(ArmLogicTreeNode):
     """Load Url"""
     bl_idname = 'LNLoadUrlNode'
-    bl_label = 'Load Url (Browser only)'
+    bl_label = 'Load URL (Browser Only)'
     arm_version = 1
 
     def init(self, context):

--- a/blender/arm/logicnode/native/LN_print.py
+++ b/blender/arm/logicnode/native/LN_print.py
@@ -9,7 +9,7 @@ class PrintNode(ArmLogicTreeNode):
     def init(self, context):
         super(PrintNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('NodeSocketString', 'Value')
+        self.add_input('NodeSocketString', 'String')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(PrintNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/object/LN_get_child.py
+++ b/blender/arm/logicnode/object/LN_get_child.py
@@ -15,9 +15,9 @@ class GetChildNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(GetChildNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_input('NodeSocketString', 'Child')
-        self.add_output('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Parent')
+        self.add_input('NodeSocketString', 'Child Name')
+        self.add_output('ArmNodeSocketObject', 'Child')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')

--- a/blender/arm/logicnode/object/LN_get_children.py
+++ b/blender/arm/logicnode/object/LN_get_children.py
@@ -8,7 +8,7 @@ class GetChildrenNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(GetChildrenNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_output('ArmNodeSocketArray', 'Array')
+        self.add_input('ArmNodeSocketObject', 'Parent')
+        self.add_output('ArmNodeSocketArray', 'Children')
 
 add_node(GetChildrenNode, category=PKG_AS_CATEGORY, section='relations')

--- a/blender/arm/logicnode/object/LN_get_object_offscreen.py
+++ b/blender/arm/logicnode/object/LN_get_object_offscreen.py
@@ -9,8 +9,8 @@ class GetObjectOffscreenNode(ArmLogicTreeNode):
     def init(self, context):
         super(GetObjectOffscreenNode, self).init(context)
         self.inputs.new('ArmNodeSocketObject', 'Object')
-        self.outputs.new('NodeSocketBool', 'Object')
-        self.outputs.new('NodeSocketBool', 'Mesh')
-        self.outputs.new('NodeSocketBool', 'Shadow')
+        self.outputs.new('NodeSocketBool', 'Is Object Offscreen')
+        self.outputs.new('NodeSocketBool', 'Is Mesh Offscreen')
+        self.outputs.new('NodeSocketBool', 'Is Shadow Offscreen')
 
 add_node(GetObjectOffscreenNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_get_parent.py
+++ b/blender/arm/logicnode/object/LN_get_parent.py
@@ -8,7 +8,7 @@ class GetParentNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(GetParentNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_output('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Child')
+        self.add_output('ArmNodeSocketObject', 'Parent')
 
 add_node(GetParentNode, category=PKG_AS_CATEGORY, section='relations')

--- a/blender/arm/logicnode/object/LN_get_visible.py
+++ b/blender/arm/logicnode/object/LN_get_visible.py
@@ -9,8 +9,8 @@ class GetVisibleNode(ArmLogicTreeNode):
     def init(self, context):
         super(GetVisibleNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_output('NodeSocketBool', 'Object')
-        self.add_output('NodeSocketBool', 'Mesh')
-        self.add_output('NodeSocketBool', 'Shadow')
+        self.add_output('NodeSocketBool', 'Is Object Visible')
+        self.add_output('NodeSocketBool', 'Is Mesh Visible')
+        self.add_output('NodeSocketBool', 'Is Shadow Visible')
 
 add_node(GetVisibleNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_object.py
+++ b/blender/arm/logicnode/object/LN_object.py
@@ -8,7 +8,7 @@ class ObjectNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(ObjectNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_output('ArmNodeSocketObject', 'Object', is_var=True)
+        self.add_input('ArmNodeSocketObject', 'Object In')
+        self.add_output('ArmNodeSocketObject', 'Object Out', is_var=True)
 
 add_node(ObjectNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_apply_force.py
+++ b/blender/arm/logicnode/physics/LN_apply_force.py
@@ -9,7 +9,7 @@ class ApplyForceNode(ArmLogicTreeNode):
     def init(self, context):
         super(ApplyForceNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
         self.add_input('NodeSocketVector', 'Force')
         self.add_input('NodeSocketBool', 'On Local Axis')
         self.add_output('ArmNodeSocketAction', 'Out')

--- a/blender/arm/logicnode/physics/LN_apply_force_at_location.py
+++ b/blender/arm/logicnode/physics/LN_apply_force_at_location.py
@@ -9,7 +9,7 @@ class ApplyForceAtLocationNode(ArmLogicTreeNode):
     def init(self, context):
         super(ApplyForceAtLocationNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
         self.add_input('NodeSocketVector', 'Force')
         self.add_input('NodeSocketBool', 'Force On Local Axis')
         self.add_input('NodeSocketVector', 'Location')

--- a/blender/arm/logicnode/physics/LN_apply_impulse.py
+++ b/blender/arm/logicnode/physics/LN_apply_impulse.py
@@ -9,7 +9,7 @@ class ApplyImpulseNode(ArmLogicTreeNode):
     def init(self, context):
         super(ApplyImpulseNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
         self.add_input('NodeSocketVector', 'Impulse')
         self.add_input('NodeSocketBool', 'On Local Axis')
         self.add_output('ArmNodeSocketAction', 'Out')

--- a/blender/arm/logicnode/physics/LN_apply_impulse_at_location.py
+++ b/blender/arm/logicnode/physics/LN_apply_impulse_at_location.py
@@ -9,7 +9,7 @@ class ApplyImpulseAtLocationNode(ArmLogicTreeNode):
     def init(self, context):
         super(ApplyImpulseAtLocationNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
         self.add_input('NodeSocketVector', 'Impulse')
         self.add_input('NodeSocketBool', 'Impulse On Local Axis')
         self.add_input('NodeSocketVector', 'Location')

--- a/blender/arm/logicnode/physics/LN_apply_torque.py
+++ b/blender/arm/logicnode/physics/LN_apply_torque.py
@@ -9,7 +9,7 @@ class ApplyTorqueNode(ArmLogicTreeNode):
     def init(self, context):
         super(ApplyTorqueNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
         self.add_input('NodeSocketVector', 'Torque')
         self.add_output('ArmNodeSocketAction', 'Out')
 

--- a/blender/arm/logicnode/physics/LN_apply_torque_impulse.py
+++ b/blender/arm/logicnode/physics/LN_apply_torque_impulse.py
@@ -9,7 +9,7 @@ class ApplyTorqueImpulseNode(ArmLogicTreeNode):
     def init(self, context):
         super(ApplyTorqueImpulseNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
         self.add_input('NodeSocketVector', 'Torque')
         self.add_output('ArmNodeSocketAction', 'Out')
 

--- a/blender/arm/logicnode/physics/LN_get_contacts.py
+++ b/blender/arm/logicnode/physics/LN_get_contacts.py
@@ -8,7 +8,7 @@ class GetContactsNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(GetContactsNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_output('ArmNodeSocketArray', 'Array')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
+        self.add_output('ArmNodeSocketArray', 'Contacts')
 
 add_node(GetContactsNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_get_first_contact.py
+++ b/blender/arm/logicnode/physics/LN_get_first_contact.py
@@ -8,7 +8,7 @@ class GetFirstContactNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(GetFirstContactNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_output('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
+        self.add_output('ArmNodeSocketObject', 'First Contact')
 
 add_node(GetFirstContactNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_get_rigid_body_data.py
+++ b/blender/arm/logicnode/physics/LN_get_rigid_body_data.py
@@ -4,16 +4,17 @@ class GetRigidBodyDataNode(ArmLogicTreeNode):
     """Get Rigid Body Data node"""
     bl_idname = 'LNGetRigidBodyDataNode'
     bl_label = 'Get Rigid Body Data'
-    bl_icon = 'NONE'
+    arm_version = 1
 
     def init(self, context):
         self.inputs.new('ArmNodeSocketObject', 'Object')
-        self.outputs.new('NodeSocketBool', 'Rigid Body')
+        self.outputs.new('NodeSocketBool', 'Is Rigid Body')
         #self.outputs.new('NodeSocketString', 'Collision Shape')
+        #self.outputs.new('NodeSocketInt', 'Activation State')
         self.outputs.new('NodeSocketInt', 'Collision Group')
         self.outputs.new('NodeSocketInt', 'Collision Mask')
-        self.outputs.new('NodeSocketBool', 'Animated')
-        self.outputs.new('NodeSocketBool', 'Static')
+        self.outputs.new('NodeSocketBool', 'Is Animated')
+        self.outputs.new('NodeSocketBool', 'Is Static')
         self.outputs.new('NodeSocketFloat', 'Angular Damping')
         self.outputs.new('NodeSocketFloat', 'Linear Damping')
         self.outputs.new('NodeSocketFloat', 'Friction')

--- a/blender/arm/logicnode/physics/LN_get_velocity.py
+++ b/blender/arm/logicnode/physics/LN_get_velocity.py
@@ -8,7 +8,7 @@ class GetVelocityNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(GetVelocityNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
         self.add_output('NodeSocketVector', 'Linear')
         # self.add_output('NodeSocketVector', 'Linear Factor') # TODO
         # self.outputs[-1].default_value = [1.0, 1.0, 1.0]

--- a/blender/arm/logicnode/physics/LN_has_contact.py
+++ b/blender/arm/logicnode/physics/LN_has_contact.py
@@ -8,8 +8,8 @@ class HasContactNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(HasContactNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object 1')
-        self.add_input('ArmNodeSocketObject', 'Object 2')
-        self.add_output('NodeSocketBool', 'Bool')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body 1')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body 2')
+        self.add_output('NodeSocketBool', 'Has Contact')
 
 add_node(HasContactNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_has_contact_array.py
+++ b/blender/arm/logicnode/physics/LN_has_contact_array.py
@@ -8,8 +8,8 @@ class HasContactArrayNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(HasContactArrayNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object 1')
-        self.add_input('ArmNodeSocketArray', 'Objects')
-        self.add_output('NodeSocketBool', 'Bool')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
+        self.add_input('ArmNodeSocketArray', 'Rigid Bodies')
+        self.add_output('NodeSocketBool', 'Has Contact')
 
 add_node(HasContactArrayNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_on_contact.py
+++ b/blender/arm/logicnode/physics/LN_on_contact.py
@@ -13,8 +13,8 @@ class OnContactNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(OnContactNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object 1')
-        self.add_input('ArmNodeSocketObject', 'Object 2')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body 1')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body 2')
         self.add_output('ArmNodeSocketAction', 'Out')
 
     def draw_buttons(self, context, layout):

--- a/blender/arm/logicnode/physics/LN_on_contact_array.py
+++ b/blender/arm/logicnode/physics/LN_on_contact_array.py
@@ -13,8 +13,8 @@ class OnContactArrayNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(OnContactArrayNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object 1')
-        self.add_input('ArmNodeSocketArray', 'Objects')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
+        self.add_input('ArmNodeSocketArray', 'Rigid Bodies')
         self.add_output('ArmNodeSocketAction', 'Out')
 
     def draw_buttons(self, context, layout):

--- a/blender/arm/logicnode/physics/LN_pick_object.py
+++ b/blender/arm/logicnode/physics/LN_pick_object.py
@@ -9,7 +9,7 @@ class PickObjectNode(ArmLogicTreeNode):
     def init(self, context):
         super(PickObjectNode, self).init(context)
         self.add_input('NodeSocketVector', 'Screen Coords')
-        self.add_output('ArmNodeSocketObject', 'Object')
+        self.add_output('ArmNodeSocketObject', 'Rigid Body')
         self.add_output('NodeSocketVector', 'Hit')
 
 add_node(PickObjectNode, category=PKG_AS_CATEGORY, section='ray')

--- a/blender/arm/logicnode/physics/LN_ray_cast.py
+++ b/blender/arm/logicnode/physics/LN_ray_cast.py
@@ -11,7 +11,7 @@ class RayCastNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'From')
         self.add_input('NodeSocketVector', 'To')
         self.add_input('NodeSocketInt', 'Collision Group Mask')
-        self.add_output('ArmNodeSocketObject', 'Object')
+        self.add_output('ArmNodeSocketObject', 'Rigid Body')
         self.add_output('NodeSocketVector', 'Hit')
         self.add_output('NodeSocketVector', 'Normal')
 

--- a/blender/arm/logicnode/physics/LN_remove_physics.py
+++ b/blender/arm/logicnode/physics/LN_remove_physics.py
@@ -12,7 +12,7 @@ class RemovePhysicsNode (ArmLogicTreeNode):
     def init(self, context):
         super(RemovePhysicsNode, self).init(context)
         self.inputs.new('ArmNodeSocketAction', 'In')
-        self.inputs.new('ArmNodeSocketObject', 'Object')
+        self.inputs.new('ArmNodeSocketObject', 'Rigid Body')
         self.outputs.new('ArmNodeSocketAction', 'Out')
 
 add_node(RemovePhysicsNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_set_activation_state.py
+++ b/blender/arm/logicnode/physics/LN_set_activation_state.py
@@ -20,7 +20,7 @@ class SetActivationStateNode(ArmLogicTreeNode):
     def init(self, context):
         super(SetActivationStateNode, self).init(context)
         self.inputs.new('ArmNodeSocketAction', 'In')
-        self.inputs.new('ArmNodeSocketObject', 'Object')
+        self.inputs.new('ArmNodeSocketObject', 'Rigid Body')
         self.outputs.new('ArmNodeSocketAction', 'Out')
 
     def draw_buttons(self, context, layout):

--- a/blender/arm/logicnode/physics/LN_set_friction.py
+++ b/blender/arm/logicnode/physics/LN_set_friction.py
@@ -13,7 +13,7 @@ class SetFrictionNode (ArmLogicTreeNode):
     def init(self, context):
         super(SetFrictionNode, self).init(context)
         self.inputs.new('ArmNodeSocketAction', 'In')
-        self.inputs.new('ArmNodeSocketObject', 'Object')
+        self.inputs.new('ArmNodeSocketObject', 'Rigid Body')
         self.inputs.new('NodeSocketFloat', 'Friction')
         self.outputs.new('ArmNodeSocketAction', 'Out')
 

--- a/blender/arm/logicnode/physics/LN_set_gravity_enabled.py
+++ b/blender/arm/logicnode/physics/LN_set_gravity_enabled.py
@@ -9,7 +9,7 @@ class SetGravityEnabledNode(ArmLogicTreeNode):
     def init(self, context):
         super(SetGravityEnabledNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
         self.add_input('NodeSocketBool', 'Enabled')
         self.add_output('ArmNodeSocketAction', 'Out')
 

--- a/blender/arm/logicnode/physics/LN_set_velocity.py
+++ b/blender/arm/logicnode/physics/LN_set_velocity.py
@@ -9,7 +9,7 @@ class SetVelocityNode(ArmLogicTreeNode):
     def init(self, context):
         super(SetVelocityNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
         self.add_input('NodeSocketVector', 'Linear')
         self.add_input('NodeSocketVector', 'Linear Factor', default_value=[1.0, 1.0, 1.0])
         self.add_input('NodeSocketVector', 'Angular')

--- a/blender/arm/logicnode/renderpath/LN_rp_config.py
+++ b/blender/arm/logicnode/renderpath/LN_rp_config.py
@@ -17,7 +17,7 @@ class RpConfigNode(ArmLogicTreeNode):
     def init(self, context):
         super(RpConfigNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('NodeSocketBool', 'On')
+        self.add_input('NodeSocketBool', 'Enable')
         self.add_output('ArmNodeSocketAction', 'Out')
 
     def draw_buttons(self, context, layout):

--- a/blender/arm/logicnode/scene/LN_get_group.py
+++ b/blender/arm/logicnode/scene/LN_get_group.py
@@ -9,6 +9,6 @@ class GetGroupNode(ArmLogicTreeNode):
     def init(self, context):
         super(GetGroupNode, self).init(context)
         self.add_input('NodeSocketString', 'Name')
-        self.add_output('ArmNodeSocketArray', 'Array')
+        self.add_output('ArmNodeSocketArray', 'Objects')
 
 add_node(GetGroupNode, category=PKG_AS_CATEGORY, section='collection')

--- a/blender/arm/logicnode/sound/LN_play_sound.py
+++ b/blender/arm/logicnode/sound/LN_play_sound.py
@@ -34,7 +34,7 @@ class PlaySoundNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'Pause')
         self.add_input('ArmNodeSocketAction', 'Stop')
         self.add_output('ArmNodeSocketAction', 'Out')
-        self.add_output('ArmNodeSocketAction', 'Running')
+        self.add_output('ArmNodeSocketAction', 'Is Running')
         self.add_output('ArmNodeSocketAction', 'Done')
 
     def draw_buttons(self, context, layout):

--- a/blender/arm/logicnode/string/LN_case_string.py
+++ b/blender/arm/logicnode/string/LN_case_string.py
@@ -13,8 +13,8 @@ class CaseStringNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(CaseStringNode, self).init(context)
-        self.add_input('NodeSocketString', 'String')
-        self.add_output('NodeSocketString', 'String')
+        self.add_input('NodeSocketString', 'String In')
+        self.add_output('NodeSocketString', 'String Out')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')

--- a/blender/arm/logicnode/string/LN_contains_string.py
+++ b/blender/arm/logicnode/string/LN_contains_string.py
@@ -16,7 +16,7 @@ class ContainsStringNode(ArmLogicTreeNode):
         super(ContainsStringNode, self).init(context)
         self.add_input('NodeSocketString', 'String')
         self.add_input('NodeSocketString', 'Find')
-        self.add_output('NodeSocketBool', 'Bool')
+        self.add_output('NodeSocketBool', 'Contains')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')

--- a/blender/arm/logicnode/string/LN_length_string.py
+++ b/blender/arm/logicnode/string/LN_length_string.py
@@ -8,7 +8,7 @@ class LengthStringNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(LengthStringNode, self).init(context)
-        self.add_output('NodeSocketInt', 'length')
+        self.add_output('NodeSocketInt', 'Length')
         self.add_input('NodeSocketString', 'String')
 
 add_node(LengthStringNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/string/LN_string.py
+++ b/blender/arm/logicnode/string/LN_string.py
@@ -8,7 +8,7 @@ class StringNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(StringNode, self).init(context)
-        self.add_input('NodeSocketString', 'Value')
-        self.add_output('NodeSocketString', 'String', is_var=True)
+        self.add_input('NodeSocketString', 'String In')
+        self.add_output('NodeSocketString', 'String Out', is_var=True)
 
 add_node(StringNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/string/LN_sub_string.py
+++ b/blender/arm/logicnode/string/LN_sub_string.py
@@ -8,8 +8,8 @@ class SubStringNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(SubStringNode, self).init(context)
-        self.add_output('NodeSocketString', 'String')
-        self.add_input('NodeSocketString', 'String')
+        self.add_output('NodeSocketString', 'String In')
+        self.add_input('NodeSocketString', 'String Out')
         self.add_input('NodeSocketInt', 'Start')
         self.add_input('NodeSocketInt', 'End')
 

--- a/blender/arm/logicnode/transform/LN_get_world.py
+++ b/blender/arm/logicnode/transform/LN_get_world.py
@@ -7,10 +7,10 @@ class GetWorldNode(ArmLogicTreeNode):
     arm_version = 1
 
     property0: EnumProperty(
-        items = [('right', 'right', 'right'),
-                 ('look', 'look', 'look'),
-                 ('up', 'up', 'up')],
-        name='', default='right')
+        items = [('Right', 'Right', 'Right'),
+                 ('Look', 'Look', 'Look'),
+                 ('Up', 'Up', 'Up')],
+        name='', default='Look')
 
     def init(self, context):
         super(GetWorldNode, self).init(context)

--- a/blender/arm/logicnode/transform/LN_scale_object.py
+++ b/blender/arm/logicnode/transform/LN_scale_object.py
@@ -10,7 +10,7 @@ class ScaleObjectNode(ArmLogicTreeNode):
         super(ScaleObjectNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_input('NodeSocketVector', 'Vector')
+        self.add_input('NodeSocketVector', 'Scale')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(ScaleObjectNode, category=PKG_AS_CATEGORY, section='scale')

--- a/blender/arm/logicnode/transform/LN_transform_math.py
+++ b/blender/arm/logicnode/transform/LN_transform_math.py
@@ -8,8 +8,8 @@ class TransformMathNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(TransformMathNode, self).init(context)
-        self.add_input('NodeSocketShader', 'Transform')
-        self.add_input('NodeSocketShader', 'Transform')
-        self.add_output('NodeSocketShader', 'Transform')
+        self.add_input('NodeSocketShader', 'Transform 1')
+        self.add_input('NodeSocketShader', 'Transform 2')
+        self.add_output('NodeSocketShader', 'Result')
 
 add_node(TransformMathNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/transform/LN_volume_trigger.py
+++ b/blender/arm/logicnode/transform/LN_volume_trigger.py
@@ -13,8 +13,8 @@ class VolumeTriggerNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(VolumeTriggerNode, self).init(context)
-        self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_input('ArmNodeSocketObject', 'Volume', default_value='Volume')
+        self.add_input('ArmNodeSocketObject', 'Rigid Body')
+        self.add_input('ArmNodeSocketObject', 'Trigger')
         self.add_output('NodeSocketBool', 'Bool')
 
     def draw_buttons(self, context, layout):

--- a/blender/arm/logicnode/variable/LN_boolean.py
+++ b/blender/arm/logicnode/variable/LN_boolean.py
@@ -8,7 +8,7 @@ class BooleanNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(BooleanNode, self).init(context)
-        self.add_input('NodeSocketBool', 'Value')
-        self.add_output('NodeSocketBool', 'Bool', is_var=True)
+        self.add_input('NodeSocketBool', 'Bool In')
+        self.add_output('NodeSocketBool', 'Bool Out', is_var=True)
 
 add_node(BooleanNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/variable/LN_color.py
+++ b/blender/arm/logicnode/variable/LN_color.py
@@ -8,7 +8,7 @@ class ColorNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(ColorNode, self).init(context)
-        self.add_input('NodeSocketColor', 'Color', default_value=[0.8, 0.8, 0.8, 1.0])
-        self.add_output('NodeSocketColor', 'Color', is_var=True)
+        self.add_input('NodeSocketColor', 'Color In', default_value=[1.0, 1.0, 1.0, 1.0])
+        self.add_output('NodeSocketColor', 'Color Out', is_var=True)
 
 add_node(ColorNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/variable/LN_float.py
+++ b/blender/arm/logicnode/variable/LN_float.py
@@ -8,7 +8,7 @@ class FloatNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(FloatNode, self).init(context)
-        self.add_input('NodeSocketFloat', 'Value')
-        self.add_output('NodeSocketFloat', 'Float', is_var=True)
+        self.add_input('NodeSocketFloat', 'Float In')
+        self.add_output('NodeSocketFloat', 'Float Out', is_var=True)
 
 add_node(FloatNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/variable/LN_integer.py
+++ b/blender/arm/logicnode/variable/LN_integer.py
@@ -8,7 +8,7 @@ class IntegerNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(IntegerNode, self).init(context)
-        self.add_input('NodeSocketInt', 'Value')
-        self.add_output('NodeSocketInt', 'Int', is_var=True)
+        self.add_input('NodeSocketInt', 'Int In')
+        self.add_output('NodeSocketInt', 'Int Out', is_var=True)
 
 add_node(IntegerNode, category=PKG_AS_CATEGORY)


### PR DESCRIPTION
* Nodes sockets now have more specific names.

* Values from nodes like `Vector Math` has been reset, because when we need to add a value only for one axis, we have to reset the two other axis every time.

* Separated `Mouse Coords` into `Get Mouse Movement` (with multiplier) and `Get Cursor Location`. The reason for this is that the mouse coords are frequently used into objects that have 3 axis, and this requires separate XYZ everytime and a multiplier node to adjust the "sensibility". The same for `surface` nodes.

* Merged `mouse lock` and `mouse visible` nodes. Most of the times this nodes are used together (only in very specific time we need to just hide or just lock the mouse).

Preview:

![test](https://user-images.githubusercontent.com/63247726/93718643-e8835580-fb53-11ea-9279-87c17ede8eda.png)

![Screenshot from 2020-09-20 14-14-33](https://user-images.githubusercontent.com/63247726/93717376-c259b780-fb4b-11ea-83bf-b705e0ac89e0.png)