### PR TITLE
Get Object node: allow getting objects from other scenes

### DIFF
--- a/Sources/armory/logicnode/GetObjectNode.hx
+++ b/Sources/armory/logicnode/GetObjectNode.hx
@@ -1,6 +1,12 @@
 package armory.logicnode;
 
+import iron.data.SceneFormat;
+import iron.object.Object;
+
 class GetObjectNode extends LogicNode {
+
+	/** Scene from which to take the object **/
+	public var property0: Null<String>;
 
 	public function new(tree: LogicTree) {
 		super(tree);
@@ -9,6 +15,35 @@ class GetObjectNode extends LogicNode {
 	override function get(from: Int): Dynamic {
 		var objectName: String = inputs[0].get();
 
-		return iron.Scene.active.getChild(objectName);
+		if (property0 == null || property0 == iron.Scene.active.raw.name) {
+			return iron.Scene.active.getChild(objectName);
+		}
+
+		#if arm_json
+		property0 += ".json";
+		#elseif arm_compress
+		property0 += ".lz4";
+		#end
+
+		var outObj: Null<Object> = null;
+
+		// Create the object in the active scene if it is from an inactive scene
+		iron.data.Data.getSceneRaw(property0, (rawScene: TSceneFormat) -> {
+			var objData: Null<TObj> = null;
+
+			for (o in rawScene.objects) {
+				if (o.name == objectName) {
+					objData = o;
+					break;
+				}
+			}
+			if (objData == null) return;
+
+			iron.Scene.active.createObject(objData, rawScene, null, null, (newObj: Object) -> {
+				outObj = newObj;
+			});
+		});
+
+		return outObj;
 	}
 }

--- a/Sources/armory/logicnode/SpawnObjectNode.hx
+++ b/Sources/armory/logicnode/SpawnObjectNode.hx
@@ -14,12 +14,12 @@ class SpawnObjectNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
-
-		var objectName = "";
 		var objectInput = inputs[1].get();
-		if (objectInput == null) objectName = cast(inputs[1].node, ObjectNode).objectName;
-		else objectName = objectInput.name;
+		if (objectInput == null) return;
+
+		var objectName = objectInput.name;
 		if (objectName == "") objectName = tree.object.name;
+
 		var m: Mat4 = inputs[2].get();
 		matrices.push(m != null ? m.clone() : null);
 		var spawnChildren: Bool = inputs.length > 3 ? inputs[3].get() : true; // TODO


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1889.

The Python part of this PR was accidentally commited already when moving the node definitions into subpackages which led to the above bug. Now it is possible to choose the scene from which to take the object in the `Get Object` node. When the scene selection field is empty, the active scene is used.

I've also fixed a bug that resulted in an invalid cast when any other node other than the `Object` node that returned `null` was connected to the `Spawn Object` node.

@luboslenco Is it much work for you to update Krom? It seems to me that it is very unstable since the Kha update, sometimes the game crashes instantly, sometimes after a while or after spawning an object (happened alot during testing this node but also with other nodes, without any error message). Also compiling to HL/C throws a lot of linker errors suddenly (related to some kore compute shader functions), I don't know where that comes from. All submodules are checked out to the commit they are supposed to in armsdk.