### PR TITLE
Add "On Application State" node

### DIFF
--- a/Sources/armory/logicnode/OnApplicationStateNode.hx
+++ b/Sources/armory/logicnode/OnApplicationStateNode.hx
@@ -1,0 +1,20 @@
+package armory.logicnode;
+
+@:access(iron.Trait)
+class OnApplicationStateNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+		tree.notifyOnInit(init);
+	}
+
+	function init() {
+		kha.System.notifyOnApplicationState(
+			() -> runOutput(0), // On foreground
+			null, // On resume
+			null, // On pause
+			() -> runOutput(1), // On background
+			() -> runOutput(2) // On shutdown
+		);
+	}
+}

--- a/blender/arm/logicnode/event/LN_on_application_state.py
+++ b/blender/arm/logicnode/event/LN_on_application_state.py
@@ -1,0 +1,17 @@
+from arm.logicnode.arm_nodes import *
+
+
+class OnApplicationStateNode(ArmLogicTreeNode):
+    """Listen to different application state changes."""
+    bl_idname = 'LNOnApplicationStateNode'
+    bl_label = 'On Application State'
+    arm_version = 1
+
+    def init(self, context):
+        super().init(context)
+        self.add_output('ArmNodeSocketAction', 'On Foreground')
+        self.add_output('ArmNodeSocketAction', 'On Background')
+        self.add_output('ArmNodeSocketAction', 'On Shutdown')
+
+
+add_node(OnApplicationStateNode, category=PKG_AS_CATEGORY)


### PR DESCRIPTION
This new event node allows to listen to foreground/background and shutdown events.

At least on Windows there are some interesting observations of how the Kha callbacks work (we should probably document that):
- The foreground callback is called twice if the window was minimized (one call for maximize and one for the focus?)
- The background callback is also called before shutdown

![OnApplicationStateNode](https://user-images.githubusercontent.com/17685000/94368078-99ed3280-00e2-11eb-8014-454d0e066228.png)
