### PR TITLE
Prevent exception when node has no bl_description attr and docstring

### DIFF
--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -79,6 +79,9 @@ class ARM_OT_AddNodeOverride(bpy.types.Operator):
         if hasattr(nodetype, 'bl_description'):
             return nodetype.bl_description.split('.')[0]
 
+        if nodetype.__doc__ is None:
+            return ""
+
         return nodetype.__doc__.split('.')[0]
 
     @classmethod


### PR DESCRIPTION
See https://github.com/armory3d/armory/issues/1820#issuecomment-699129393