### PR TITLE
Add 3 new context menu options for nodes to inspect source and wiki

### DIFF
--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -13,6 +13,8 @@ from arm.logicnode.arm_nodes import ArmNodeCategory
 from arm.logicnode import arm_sockets
 # Do not remove this line as it runs all node modules for registering!
 from arm.logicnode import *
+import arm.utils
+from pathlib import Path
 
 registered_nodes = []
 registered_categories = []
@@ -169,9 +171,31 @@ class ArmOpenNodeSource(bpy.types.Operator):
     bl_label = 'Open Node Source'
 
     def execute(self, context):
-        if context.active_node is not None and context.active_node.bl_idname.startswith('LN'):
-            name = context.active_node.bl_idname[2:]
-            webbrowser.open('https://github.com/armory3d/armory/tree/master/Sources/armory/logicnode/' + name + '.hx')
+        if context.selected_nodes is not None and context.active_node.bl_idname.startswith('LN'):
+            if len(context.selected_nodes) == 1:
+                name = context.selected_nodes[0].bl_idname[2:]
+                version = arm.utils.get_last_commit()
+                if version == '':
+                    version = 'master'
+
+                webbrowser.open(f'https://github.com/armory3d/armory/tree/{version}/Sources/armory/logicnode/{name}.hx')
+        return{'FINISHED'}
+
+class ArmOpenNodePythonSource(bpy.types.Operator):
+    """Expose Python source"""
+    bl_idname = 'arm.open_node_python_source'
+    bl_label = 'Open Node Python Source'
+
+    def execute(self, context):
+        if context.selected_nodes is not None:
+            if len(context.selected_nodes) == 1:
+                node = context.selected_nodes[0]
+                if node.bl_idname.startswith('LN') and node.arm_version is not None:
+                    version = arm.utils.get_last_commit()
+                    if version == '':
+                        version = 'master'
+                    rel_path = node.__module__.replace('.', '/')
+                    webbrowser.open(f'https://github.com/armory3d/armory/tree/{version}/blender/{rel_path}.py')
         return{'FINISHED'}
 
 #Node Variables Panel
@@ -441,12 +465,24 @@ class ReplaceNodesOperator(bpy.types.Operator):
 
 
 
+# https://blender.stackexchange.com/questions/150101/python-how-to-add-items-in-context-menu-in-2-8
+def draw_custom_logicnode_menu(self, context):
+    if context.space_data.tree_type == 'ArmLogicTreeType' \
+        and context.selected_nodes is not None \
+        and context.active_node.bl_idname.startswith('LN'):
+        if len(context.selected_nodes) == 1:
+            layout = self.layout
+            layout.separator()
+            layout.operator("arm.open_node_source", text="Open .hx source in the browser")
+            layout.operator("arm.open_node_python_source", text="Open .py source in the browser")
+
 def register():
     arm_sockets.register()
 
     bpy.utils.register_class(ArmLogicTree)
     bpy.utils.register_class(ARM_PT_LogicNodePanel)
     bpy.utils.register_class(ArmOpenNodeSource)
+    bpy.utils.register_class(ArmOpenNodePythonSource)
     bpy.utils.register_class(ReplaceNodesOperator)
     bpy.utils.register_class(ARM_PT_Variables)
     bpy.utils.register_class(ARMAddVarNode)
@@ -454,6 +490,8 @@ def register():
     ARM_MT_NodeAddOverride.overridden_draw = bpy.types.NODE_MT_add.draw
     bpy.utils.register_class(ARM_MT_NodeAddOverride)
     bpy.utils.register_class(ARM_OT_AddNodeOverride)
+
+    bpy.types.NODE_MT_context_menu.append(draw_custom_logicnode_menu)
 
     register_nodes()
 
@@ -465,10 +503,13 @@ def unregister():
     bpy.utils.unregister_class(ArmLogicTree)
     bpy.utils.unregister_class(ARM_PT_LogicNodePanel)
     bpy.utils.unregister_class(ArmOpenNodeSource)
+    bpy.utils.unregister_class(ArmOpenNodePythonSource)
     bpy.utils.unregister_class(ARM_PT_Variables)
     bpy.utils.unregister_class(ARMAddVarNode)
     bpy.utils.unregister_class(ARMAddSetVarNode)
     bpy.utils.unregister_class(ARM_OT_AddNodeOverride)
     bpy.utils.unregister_class(ARM_MT_NodeAddOverride)
+
+    bpy.types.NODE_MT_context_menu.remove(draw_custom_logicnode_menu)
 
     arm_sockets.unregister()

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -171,14 +171,14 @@ class ArmOpenNodeSource(bpy.types.Operator):
     bl_label = 'Open Node Source'
 
     def execute(self, context):
-        if context.selected_nodes is not None and context.active_node.bl_idname.startswith('LN'):
+        if context.selected_nodes is not None:
             if len(context.selected_nodes) == 1:
-                name = context.selected_nodes[0].bl_idname[2:]
-                version = arm.utils.get_last_commit()
-                if version == '':
-                    version = 'master'
-
-                webbrowser.open(f'https://github.com/armory3d/armory/tree/{version}/Sources/armory/logicnode/{name}.hx')
+                if context.selected_nodes[0].bl_idname.startswith('LN'):
+                    name = context.selected_nodes[0].bl_idname[2:]
+                    version = arm.utils.get_last_commit()
+                    if version == '':
+                        version = 'master'
+                    webbrowser.open(f'https://github.com/armory3d/armory/tree/{version}/Sources/armory/logicnode/{name}.hx')
         return{'FINISHED'}
 
 class ArmOpenNodePythonSource(bpy.types.Operator):
@@ -468,13 +468,13 @@ class ReplaceNodesOperator(bpy.types.Operator):
 # https://blender.stackexchange.com/questions/150101/python-how-to-add-items-in-context-menu-in-2-8
 def draw_custom_logicnode_menu(self, context):
     if context.space_data.tree_type == 'ArmLogicTreeType' \
-        and context.selected_nodes is not None \
-        and context.active_node.bl_idname.startswith('LN'):
+        and context.selected_nodes is not None:
         if len(context.selected_nodes) == 1:
-            layout = self.layout
-            layout.separator()
-            layout.operator("arm.open_node_source", text="Open .hx source in the browser")
-            layout.operator("arm.open_node_python_source", text="Open .py source in the browser")
+            if context.selected_nodes[0].bl_idname.startswith('LN'):
+                layout = self.layout
+                layout.separator()
+                layout.operator("arm.open_node_source", text="Open .hx source in the browser")
+                layout.operator("arm.open_node_python_source", text="Open .py source in the browser")
 
 def register():
     arm_sockets.register()

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -198,6 +198,27 @@ class ArmOpenNodePythonSource(bpy.types.Operator):
                     webbrowser.open(f'https://github.com/armory3d/armory/tree/{version}/blender/{rel_path}.py')
         return{'FINISHED'}
 
+class ArmOpenNodeWikiEntry(bpy.types.Operator):
+    """Expose Python source"""
+    bl_idname = 'arm.open_node_documentation'
+    bl_label = 'Open Node Documentation'
+
+    def to_wiki_id(self, node_name):
+        """convert from the conventional node name to its wiki counterpart's anchor or id
+            expected node_name format: LN_[a-z_]+
+        """
+        return node_name.replace('_','-')[3:]
+
+    def execute(self, context):
+        if context.selected_nodes is not None:
+            if len(context.selected_nodes) == 1:
+                node = context.selected_nodes[0]
+                if node.bl_idname.startswith('LN') and node.arm_version is not None:
+                    wiki_id = self.to_wiki_id(node.__module__.rsplit('.', 2).pop())
+                    webbrowser.open(f'https://github.com/armory3d/armory/wiki/reference#{wiki_id}')
+        return{'FINISHED'}
+
+
 #Node Variables Panel
 class ARM_PT_Variables(bpy.types.Panel):
     bl_label = 'Armory Node Variables'
@@ -473,6 +494,7 @@ def draw_custom_logicnode_menu(self, context):
             if context.selected_nodes[0].bl_idname.startswith('LN'):
                 layout = self.layout
                 layout.separator()
+                layout.operator("arm.open_node_documentation", text="Show documentation for this node")
                 layout.operator("arm.open_node_source", text="Open .hx source in the browser")
                 layout.operator("arm.open_node_python_source", text="Open .py source in the browser")
 
@@ -483,6 +505,7 @@ def register():
     bpy.utils.register_class(ARM_PT_LogicNodePanel)
     bpy.utils.register_class(ArmOpenNodeSource)
     bpy.utils.register_class(ArmOpenNodePythonSource)
+    bpy.utils.register_class(ArmOpenNodeWikiEntry)
     bpy.utils.register_class(ReplaceNodesOperator)
     bpy.utils.register_class(ARM_PT_Variables)
     bpy.utils.register_class(ARMAddVarNode)
@@ -504,6 +527,7 @@ def unregister():
     bpy.utils.unregister_class(ARM_PT_LogicNodePanel)
     bpy.utils.unregister_class(ArmOpenNodeSource)
     bpy.utils.unregister_class(ArmOpenNodePythonSource)
+    bpy.utils.unregister_class(ArmOpenNodeWikiEntry)
     bpy.utils.unregister_class(ARM_PT_Variables)
     bpy.utils.unregister_class(ARMAddVarNode)
     bpy.utils.unregister_class(ARMAddSetVarNode)

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -144,6 +144,16 @@ def get_sdk_path():
     else:
         return addon_prefs.sdk_path
 
+def get_last_commit():
+    p = get_sdk_path() + 'armory/.git/refs/heads/master'
+
+    try:
+        file = open(p, 'r')
+        commit = file.readline()
+    except:
+        commit = ''
+    return commit
+
 def get_ide_bin():
     preferences = bpy.context.preferences
     addon_prefs = preferences.addons["armory"].preferences


### PR DESCRIPTION
Added 2 new operators and modified an existing one to allow inspecting the documentation reference or the source of a node. For the source it tries to guess the version that the user has based on their git folder, but if it fails it will default to master.
![image](https://user-images.githubusercontent.com/42382648/94738459-d371a800-0345-11eb-9ba9-5eb7ebee406f.png)

Solves this feature request https://github.com/armory3d/armory/issues/1820