### PR TITLE
Bullet: Collision margin was inverted.

### DIFF
--- a/Sources/armory/trait/physics/bullet/RigidBody.hx
+++ b/Sources/armory/trait/physics/bullet/RigidBody.hx
@@ -113,7 +113,7 @@ class RigidBody extends iron.Trait {
 	}
 
 	inline function withMargin(f: Float) {
-		return f - f * collisionMargin;
+		return f + f * collisionMargin;
 	}
 
 	public function notifyOnReady(f: Void->Void) {


### PR DESCRIPTION
This should work now as expected.

Original issue:

https://github.com/armory3d/armory/issues/1707