### PR TITLE
Merged pause/resume nodes

### DIFF
--- a/Sources/armory/logicnode/SetActionPausedNode.hx
+++ b/Sources/armory/logicnode/SetActionPausedNode.hx
@@ -1,0 +1,25 @@
+package armory.logicnode;
+
+import iron.object.Object;
+
+class SetActionPausedNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var object: Object = inputs[1].get();
+		var enabled: Bool = inputs [2].get();
+
+		if (object == null) return;
+
+		var animation = object.animation;
+
+		if (animation == null) animation = object.getParentArmature(object.name);
+
+		enabled ? animation.resume() : animation.pause();
+
+		runOutput(0);
+	}
+}

--- a/Sources/armory/logicnode/SetActionPausedNode.hx
+++ b/Sources/armory/logicnode/SetActionPausedNode.hx
@@ -10,7 +10,7 @@ class SetActionPausedNode extends LogicNode {
 
 	override function run(from: Int) {
 		var object: Object = inputs[1].get();
-		var enabled: Bool = inputs [2].get();
+		var paused: Bool = inputs [2].get();
 
 		if (object == null) return;
 
@@ -18,7 +18,7 @@ class SetActionPausedNode extends LogicNode {
 
 		if (animation == null) animation = object.getParentArmature(object.name);
 
-		enabled ? animation.resume() : animation.pause();
+		paused ? animation.resume() : animation.pause();
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/SetTilesheetPausedNode.hx
+++ b/Sources/armory/logicnode/SetTilesheetPausedNode.hx
@@ -1,0 +1,21 @@
+package armory.logicnode;
+
+import iron.object.MeshObject;
+
+class SetTilesheetPausedNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var object: MeshObject = inputs[1].get();
+		var enabled: Bool = inputs[2].get();
+
+		if (object == null) return;
+
+		enabled ? object.tilesheet.resume() : object.tilesheet.pause();
+
+		runOutput(0);
+	}
+}

--- a/Sources/armory/logicnode/SetTilesheetPausedNode.hx
+++ b/Sources/armory/logicnode/SetTilesheetPausedNode.hx
@@ -10,11 +10,11 @@ class SetTilesheetPausedNode extends LogicNode {
 
 	override function run(from: Int) {
 		var object: MeshObject = inputs[1].get();
-		var enabled: Bool = inputs[2].get();
+		var paused: Bool = inputs[2].get();
 
 		if (object == null) return;
 
-		enabled ? object.tilesheet.resume() : object.tilesheet.pause();
+		paused ? object.tilesheet.resume() : object.tilesheet.pause();
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/SetTraitPausedNode.hx
+++ b/Sources/armory/logicnode/SetTraitPausedNode.hx
@@ -8,11 +8,11 @@ class SetTraitPausedNode extends LogicNode {
 
 	override function run(from: Int) {
 		var trait: Dynamic = inputs[1].get();
-		var enabled: Bool = inputs[2].get();
+		var paused: Bool = inputs[2].get();
 
 		if (trait == null || !Std.is(trait, LogicTree)) return;
 
-		enabled ? cast(trait, LogicTree).resume() : cast(trait, LogicTree).pause();
+		paused ? cast(trait, LogicTree).resume() : cast(trait, LogicTree).pause();
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/SetTraitPausedNode.hx
+++ b/Sources/armory/logicnode/SetTraitPausedNode.hx
@@ -1,0 +1,19 @@
+package armory.logicnode;
+
+class SetTraitPausedNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var trait: Dynamic = inputs[1].get();
+		var enabled: Bool = inputs[2].get();
+
+		if (trait == null || !Std.is(trait, LogicTree)) return;
+
+		enabled ? cast(trait, LogicTree).resume() : cast(trait, LogicTree).pause();
+
+		runOutput(0);
+	}
+}

--- a/blender/arm/logicnode/animation/LN_get_action_state.py
+++ b/blender/arm/logicnode/animation/LN_get_action_state.py
@@ -3,7 +3,7 @@ from arm.logicnode.arm_nodes import *
 class AnimationStateNode(ArmLogicTreeNode):
     """Returns the information about the current action of the given object."""
     bl_idname = 'LNAnimationStateNode'
-    bl_label = 'Action State'
+    bl_label = 'Get Action State'
     arm_version = 1
 
     def init(self, context):

--- a/blender/arm/logicnode/animation/LN_set_action_paused.py
+++ b/blender/arm/logicnode/animation/LN_set_action_paused.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class SetActionPausedNode(ArmLogicTreeNode):
+    """Sets the action paused state of the given object."""
+    bl_idname = 'LNSetActionPausedNode'
+    bl_label = 'Set Action Paused'
+    arm_version = 1
+
+    def init(self, context):
+        super(SetActionPausedNode, self).init(context)
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketBool', 'Paused')
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+add_node(SetActionPausedNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_set_tilesheet_paused.py
+++ b/blender/arm/logicnode/animation/LN_set_tilesheet_paused.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class SetTilesheetPausedNode(ArmLogicTreeNode):
+    """Sets the tilesheet paused state of the given object."""
+    bl_idname = 'LNSetTilesheetPausedNode'
+    bl_label = 'Set Tilesheet Paused'
+    arm_version = 1
+
+    def init(self, context):
+        super(SetTilesheetPausedNode, self).init(context)
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketBool', 'Paused')
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+add_node(SetTilesheetPausedNode, category=PKG_AS_CATEGORY, section='tilesheet')

--- a/blender/arm/logicnode/deprecated/LN_pause_action.py
+++ b/blender/arm/logicnode/deprecated/LN_pause_action.py
@@ -4,7 +4,9 @@ class PauseActionNode(ArmLogicTreeNode):
     """Pauses the given action."""
     bl_idname = 'LNPauseActionNode'
     bl_label = 'Pause Action'
-    arm_version = 1
+    bl_description = "Please use the \"Set Action Paused\" node instead"
+    bl_icon = 'ERROR'
+    arm_version = 2
 
     def init(self, context):
         super(PauseActionNode, self).init(context)
@@ -12,4 +14,4 @@ class PauseActionNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
 
-add_node(PauseActionNode, category=PKG_AS_CATEGORY)
+add_node(PauseActionNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_pause_tilesheet.py
+++ b/blender/arm/logicnode/deprecated/LN_pause_tilesheet.py
@@ -3,8 +3,9 @@ from arm.logicnode.arm_nodes import *
 class PauseTilesheetNode(ArmLogicTreeNode):
     """Pauses the given tilesheet action."""
     bl_idname = 'LNPauseTilesheetNode'
-    bl_label = 'Pause Tilesheet'
-    arm_version = 1
+    bl_description = "Please use the \"Set Tilesheet Paused\" node instead"
+    bl_icon = 'ERROR'
+    arm_version = 2
 
     def init(self, context):
         super(PauseTilesheetNode, self).init(context)
@@ -12,4 +13,4 @@ class PauseTilesheetNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
 
-add_node(PauseTilesheetNode, category=PKG_AS_CATEGORY, section='tilesheet')
+add_node(PauseTilesheetNode, category=PKG_AS_CATEGORY, section='tilesheet', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_pause_trait.py
+++ b/blender/arm/logicnode/deprecated/LN_pause_trait.py
@@ -3,8 +3,9 @@ from arm.logicnode.arm_nodes import *
 class PauseTraitNode(ArmLogicTreeNode):
     """Pauses the given trait."""
     bl_idname = 'LNPauseTraitNode'
-    bl_label = 'Pause Trait'
-    arm_version = 1
+    bl_description = "Please use the \"Set Trait Paused\" node instead"
+    bl_icon = 'ERROR'
+    arm_version = 2
 
     def init(self, context):
         super(PauseTraitNode, self).init(context)
@@ -12,4 +13,4 @@ class PauseTraitNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Trait')
         self.add_output('ArmNodeSocketAction', 'Out')
 
-add_node(PauseTraitNode, category=PKG_AS_CATEGORY)
+add_node(PauseTraitNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_play_action.py
+++ b/blender/arm/logicnode/deprecated/LN_play_action.py
@@ -3,8 +3,9 @@ from arm.logicnode.arm_nodes import *
 class PlayActionNode(ArmLogicTreeNode):
     """Plays the given action."""
     bl_idname = 'LNPlayActionNode'
-    bl_label = 'Play Action'
-    arm_version = 1
+    bl_description = "Please use the \"Play Action From\" node instead"
+    bl_icon = 'ERROR'
+    arm_version = 2
 
     def init(self, context):
         super(PlayActionNode, self).init(context)
@@ -15,4 +16,4 @@ class PlayActionNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Done')
 
-add_node(PlayActionNode, category=PKG_AS_CATEGORY)
+add_node(PlayActionNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_resume_action.py
+++ b/blender/arm/logicnode/deprecated/LN_resume_action.py
@@ -3,8 +3,9 @@ from arm.logicnode.arm_nodes import *
 class ResumeActionNode(ArmLogicTreeNode):
     """Resumes the given action."""
     bl_idname = 'LNResumeActionNode'
-    bl_label = 'Resume Action'
-    arm_version = 1
+    bl_description = "Please use the \"Set Action Paused\" node instead"
+    bl_icon = 'ERROR'
+    arm_version = 2
 
     def init(self, context):
         super(ResumeActionNode, self).init(context)
@@ -12,4 +13,4 @@ class ResumeActionNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
 
-add_node(ResumeActionNode, category=PKG_AS_CATEGORY)
+add_node(ResumeActionNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_resume_tilesheet.py
+++ b/blender/arm/logicnode/deprecated/LN_resume_tilesheet.py
@@ -4,7 +4,9 @@ class ResumeTilesheetNode(ArmLogicTreeNode):
     """Resumes the given tilesheet action."""
     bl_idname = 'LNResumeTilesheetNode'
     bl_label = 'Resume Tilesheet'
-    arm_version = 1
+    bl_description = "Please use the \"Set Tilesheet Paused\" node instead"
+    bl_icon = 'ERROR'
+    arm_version = 2
 
     def init(self, context):
         super(ResumeTilesheetNode, self).init(context)
@@ -12,4 +14,4 @@ class ResumeTilesheetNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
 
-add_node(ResumeTilesheetNode, category=PKG_AS_CATEGORY)
+add_node(ResumeTilesheetNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_resume_trait.py
+++ b/blender/arm/logicnode/deprecated/LN_resume_trait.py
@@ -3,8 +3,9 @@ from arm.logicnode.arm_nodes import *
 class ResumeTraitNode(ArmLogicTreeNode):
     """Resumes the given trait."""
     bl_idname = 'LNResumeTraitNode'
-    bl_label = 'Resume Trait'
-    arm_version = 1
+    bl_description = "Please use the \"Set Trait Paused\" node instead"
+    bl_icon = 'ERROR'
+    arm_version = 2
 
     def init(self, context):
         super(ResumeTraitNode, self).init(context)
@@ -12,4 +13,4 @@ class ResumeTraitNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Trait')
         self.add_output('ArmNodeSocketAction', 'Out')
 
-add_node(ResumeTraitNode, category=PKG_AS_CATEGORY)
+add_node(ResumeTraitNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_set_object_material.py
+++ b/blender/arm/logicnode/deprecated/LN_set_object_material.py
@@ -3,8 +3,9 @@ from arm.logicnode.arm_nodes import *
 class SetMaterialNode(ArmLogicTreeNode):
     """Sets the material of the given object."""
     bl_idname = 'LNSetMaterialNode'
-    bl_label = 'Set Object Material'
-    arm_version = 1
+    bl_description = "Please use the \"Set Object Material Slot\" node instead"
+    bl_icon = 'ERROR'
+    arm_version = 2
 
     def init(self, context):
         super(SetMaterialNode, self).init(context)
@@ -13,4 +14,4 @@ class SetMaterialNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Material')
         self.add_output('ArmNodeSocketAction', 'Out')
 
-add_node(SetMaterialNode, category=PKG_AS_CATEGORY)
+add_node(SetMaterialNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/trait/LN_set_trait_paused.py
+++ b/blender/arm/logicnode/trait/LN_set_trait_paused.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class SetTraitPausedNode(ArmLogicTreeNode):
+    """Sets the paused state of the given trait."""
+    bl_idname = 'LNSetTraitPausedNode'
+    bl_label = 'Set Trait Paused'
+    arm_version = 1
+
+    def init(self, context):
+        super(SetTraitPausedNode, self).init(context)
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('NodeSocketShader', 'Trait')
+        self.add_input('NodeSocketBool', 'Paused')
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+add_node(SetTraitPausedNode, category=PKG_AS_CATEGORY)


### PR DESCRIPTION
I think it is more user friendly and cleaner now. I had misunderstood the speaker functionality, now it is not affected.

* `Pause Trait` and `Resume Trait` merged to `Set Trait Paused`.

* `Pause Tilesheet` and `Resume Tilesheet` merged to `Set Tilesheet Paused`.

* `Pause Action` and `Resume Action` merged to `Set Action Paused`.

* Deprecated `Play Action` and `Set Object Material` by `Play Action From` and `Set Object Material Slot` respectively.

* Renamed `Action State` to `Get Action State`.