### PR TITLE
Add Debug Console settings

### DIFF
--- a/Sources/armory/logicnode/GetDebugConsoleSettings.hx
+++ b/Sources/armory/logicnode/GetDebugConsoleSettings.hx
@@ -1,0 +1,26 @@
+package armory.logicnode;
+import armory.trait.internal.DebugConsole;
+
+class GetDebugConsoleSettings extends LogicNode {
+   
+	public function new(tree: LogicTree) {
+		super(tree);	
+	}
+
+	override function get(from: Int): Dynamic {
+        #if arm_debug
+        switch(from) {
+            case 0: return armory.trait.internal.DebugConsole.getVisible();
+            case 1: return armory.trait.internal.DebugConsole.getScale();
+            case 2: {
+                switch (armory.trait.internal.DebugConsole.getPosition()) {
+		        case PositionStateEnum.LEFT: return "Left";
+		        case PositionStateEnum.CENTER: return "Center";
+		        case PositionStateEnum.RIGHT: return "Right";
+		        }
+            }
+        }
+		#end        
+		return null;
+	}
+}

--- a/Sources/armory/logicnode/SetDebugConsoleSettings.hx
+++ b/Sources/armory/logicnode/SetDebugConsoleSettings.hx
@@ -1,0 +1,32 @@
+package armory.logicnode;
+import armory.trait.internal.DebugConsole;
+
+class SetDebugConsoleSettings extends LogicNode {
+   
+    public var property0: String;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+    override function run(from: Int) {
+		#if arm_debug
+        var visible: Dynamic = inputs[1].get();
+        armory.trait.internal.DebugConsole.setVisible(visible);
+
+		var scale: Dynamic = inputs[2].get();
+		if ((scale >= 0.3) && (scale <= 10.0))
+			armory.trait.internal.DebugConsole.setScale(scale);
+
+        switch (property0) {
+		case "Left":
+			return armory.trait.internal.DebugConsole.setPosition(PositionStateEnum.LEFT);
+		case "Center":
+			return armory.trait.internal.DebugConsole.setPosition(PositionStateEnum.CENTER);
+		case "Right":
+			return armory.trait.internal.DebugConsole.setPosition(PositionStateEnum.RIGHT);
+		}
+		#end
+		runOutput(0);
+	}
+}

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2605,10 +2605,25 @@ class ArmoryExporter:
             if 'traits' not in self.output:
                 self.output['traits'] = []
             ArmoryExporter.export_ui = True
+            # Position
+            debug_console_pos_type = 2
+            if (wrd.arm_debug_console_position == 'Left'):
+                debug_console_pos_type = 0
+            elif (wrd.arm_debug_console_position == 'Center'):
+                debug_console_pos_type = 1
+            else:                
+                debug_console_pos_type = 2
+            # Parameters
             out_trait = {
                 'type': 'Script',
                 'class_name': 'armory.trait.internal.DebugConsole',
-                'parameters': [str(arm.utils.get_ui_scale())]
+                'parameters': [str(arm.utils.get_ui_scale()), 
+                str(wrd.arm_debug_console_scale), 
+                str(debug_console_pos_type), 
+                str(int(wrd.arm_debug_console_visible)), 
+                str(int(arm.utils.get_debug_console_visible_sc())), 
+                str(int(arm.utils.get_debug_console_scale_in_sc())), 
+                str(int(arm.utils.get_debug_console_scale_out_sc()))]
             }
             self.output['traits'].append(out_trait)
 

--- a/blender/arm/logicnode/miscellaneous/LN_get_debug_console_settings.py
+++ b/blender/arm/logicnode/miscellaneous/LN_get_debug_console_settings.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class GetDebugConsoleSettings(ArmLogicTreeNode):
+    """Get Debug Console Settings"""
+    bl_idname = 'LNGetDebugConsoleSettings'
+    bl_label = 'Get Debug Console Settings'
+    arm_version = 1
+
+    def init(self, context):  
+        super(GetDebugConsoleSettings, self).init(context)
+        self.add_output('NodeSocketBool', 'Visible') 
+        self.add_output('NodeSocketFloat', 'Scale') 
+        self.add_output('NodeSocketString', 'Position') 
+
+# Add Node
+add_node(GetDebugConsoleSettings, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/miscellaneous/LN_set_debug_console_settings.py
+++ b/blender/arm/logicnode/miscellaneous/LN_set_debug_console_settings.py
@@ -1,0 +1,26 @@
+from arm.logicnode.arm_nodes import *
+
+class SetDebugConsoleSettings(ArmLogicTreeNode):
+    """Set Debug Console Settings"""
+    bl_idname = 'LNSetDebugConsoleSettings'
+    bl_label = 'Set Debug Console Settings'
+    arm_version = 1
+
+    property0: EnumProperty(
+        items = [('Left', 'Left', 'Left'),
+                 ('Center', 'Center', 'Center'),
+                 ('Right', 'Right', 'Right')],
+        name='', default='Right')
+
+    def init(self, context):  
+        super(SetDebugConsoleSettings, self).init(context) 
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('NodeSocketBool', 'Visible')  
+        self.add_input('NodeSocketFloat', 'Scale')  
+        self.inputs[-1].default_value = 1.0
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
+
+add_node(SetDebugConsoleSettings, category=PKG_AS_CATEGORY)

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -68,7 +68,15 @@ def init_properties():
                ('Viewport', 'Viewport', 'Viewport')],
         name="Camera", description="Viewport camera", default='Scene', update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_play_scene = PointerProperty(name="Scene", description="Scene to launch", update=assets.invalidate_compiler_cache, type=bpy.types.Scene)
-    bpy.types.World.arm_debug_console = BoolProperty(name="Debug Console", description="Show inspector in player and enable debug draw.\nRequires that Zui is not disabled", default=False, update=assets.invalidate_shader_cache)
+    # Debug Console
+    bpy.types.World.arm_debug_console = BoolProperty(name="Enable", description="Show inspector in player and enable debug draw.\nRequires that Zui is not disabled", default=arm.utils.get_debug_console_auto(), update=assets.invalidate_shader_cache)
+    bpy.types.World.arm_debug_console_position = EnumProperty(
+        items=[('Left', 'Left', 'Left'),
+               ('Center', 'Center', 'Center'),
+               ('Right', 'Right', 'Right')],
+        name="Position", description="Position Debug Console", default='Right', update=assets.invalidate_shader_cache)
+    bpy.types.World.arm_debug_console_scale = FloatProperty(name="Scale Console", description="Scale Debug Console", default=1.0, min=0.3, max=10.0, subtype='FACTOR', update=assets.invalidate_shader_cache)
+    bpy.types.World.arm_debug_console_visible = BoolProperty(name="Visible", description="Setting the console visibility at application start", default=True, update=assets.invalidate_shader_cache)
     bpy.types.World.arm_verbose_output = BoolProperty(name="Verbose Output", description="Print additional information to the console during compilation", default=False)
     bpy.types.World.arm_runtime = EnumProperty(
         items=[('Krom', 'Krom', 'Krom'),
@@ -303,6 +311,10 @@ def create_wrd():
 def init_properties_on_load():
     if not 'Arm' in bpy.data.worlds:
         init_properties()
+    # New project?
+    if bpy.data.filepath == '':
+        wrd = bpy.data.worlds['Arm']
+        wrd.arm_debug_console = arm.utils.get_debug_console_auto()          
     arm.utils.fetch_script_names()
 
 def update_armory_world():

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -445,9 +445,6 @@ class ARM_PT_ProjectFlagsPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
         wrd = bpy.data.worlds['Arm']
-        row = layout.row()
-        row.enabled = wrd.arm_ui != 'Disabled'
-        row.prop(wrd, 'arm_debug_console')
         layout.prop(wrd, 'arm_verbose_output')
         layout.prop(wrd, 'arm_cache_build')
         layout.prop(wrd, 'arm_live_patch')
@@ -461,6 +458,32 @@ class ARM_PT_ProjectFlagsPanel(bpy.types.Panel):
         layout.prop(wrd, 'arm_loadscreen')
         layout.prop(wrd, 'arm_texture_quality')
         layout.prop(wrd, 'arm_sound_quality')
+
+class ARM_PT_ProjectFlagsDebugConsolePanel(bpy.types.Panel):
+    bl_label = "Debug Console"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "render"
+    bl_options = {'DEFAULT_CLOSED'}
+    bl_parent_id = "ARM_PT_ProjectFlagsPanel"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        wrd = bpy.data.worlds['Arm']
+        row = layout.row()
+        row.enabled = wrd.arm_ui != 'Disabled'
+        row.prop(wrd, 'arm_debug_console')
+        row = layout.row()
+        row.enabled = wrd.arm_debug_console
+        row.prop(wrd, 'arm_debug_console_position')
+        row = layout.row()
+        row.enabled = wrd.arm_debug_console
+        row.prop(wrd, 'arm_debug_console_scale')
+        row = layout.row()
+        row.enabled = wrd.arm_debug_console
+        row.prop(wrd, 'arm_debug_console_visible')
 
 class ARM_PT_ProjectWindowPanel(bpy.types.Panel):
     bl_label = "Window"
@@ -1990,6 +2013,7 @@ def register():
     bpy.utils.register_class(ARM_PT_ArmoryExporterPanel)
     bpy.utils.register_class(ARM_PT_ArmoryProjectPanel)
     bpy.utils.register_class(ARM_PT_ProjectFlagsPanel)
+    bpy.utils.register_class(ARM_PT_ProjectFlagsDebugConsolePanel)
     bpy.utils.register_class(ARM_PT_ProjectWindowPanel)
     bpy.utils.register_class(ARM_PT_ProjectModulesPanel)
     bpy.utils.register_class(ARM_PT_RenderPathPanel)
@@ -2053,6 +2077,7 @@ def unregister():
     bpy.utils.unregister_class(ARM_PT_ArmoryPlayerPanel)
     bpy.utils.unregister_class(ARM_PT_ArmoryExporterPanel)
     bpy.utils.unregister_class(ARM_PT_ArmoryProjectPanel)
+    bpy.utils.unregister_class(ARM_PT_ProjectFlagsDebugConsolePanel)
     bpy.utils.unregister_class(ARM_PT_ProjectFlagsPanel)
     bpy.utils.unregister_class(ARM_PT_ProjectWindowPanel)
     bpy.utils.unregister_class(ARM_PT_ProjectModulesPanel)

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -199,6 +199,26 @@ def get_save_on_build():
     addon_prefs = preferences.addons['armory'].preferences
     return False if not hasattr(addon_prefs, 'save_on_build') else addon_prefs.save_on_build
 
+def get_debug_console_auto():
+    preferences = bpy.context.preferences
+    addon_prefs = preferences.addons['armory'].preferences
+    return False if not hasattr(addon_prefs, 'debug_console_auto') else addon_prefs.debug_console_auto
+
+def get_debug_console_visible_sc():
+    preferences = bpy.context.preferences
+    addon_prefs = preferences.addons['armory'].preferences
+    return 192 if not hasattr(addon_prefs, 'debug_console_visible_sc') else addon_prefs.debug_console_visible_sc
+
+def get_debug_console_scale_in_sc():
+    preferences = bpy.context.preferences
+    addon_prefs = preferences.addons['armory'].preferences
+    return 219 if not hasattr(addon_prefs, 'debug_console_scale_in_sc') else addon_prefs.debug_console_scale_in_sc
+
+def get_debug_console_scale_out_sc():
+    preferences = bpy.context.preferences
+    addon_prefs = preferences.addons['armory'].preferences
+    return 221 if not hasattr(addon_prefs, 'debug_console_scale_out_sc') else addon_prefs.debug_console_scale_out_sc
+
 def get_viewport_controls():
     preferences = bpy.context.preferences
     addon_prefs = preferences.addons['armory'].preferences


### PR DESCRIPTION
1. Adding the ability to customize display, scale (size), shortcuts to the _DebugConsole_ class.
2. Adding a function to _utils.py_ to get Debug Console settings from _Render: Armory_.
3. Added Debug Console settings to the _Armory Project_ interface:
![debug_console_armory_project](https://user-images.githubusercontent.com/7114353/95652494-11b35800-0afa-11eb-8225-5099af4831e0.jpg)
    - Enable (default value - False);
    - Position (Left, Center, Right, default value - Right);
    - Scale Console (from 0.3 to 10);
    - Visible.
4. Added transfer of Debug Console settings to _exporter.py_.
5. Added logical nodes to control DebugConsole while the application is running.
![v2](https://user-images.githubusercontent.com/7114353/95652499-1d068380-0afa-11eb-85bf-1a63dbe4200b.jpg)
