### PR TITLE
Get System Language - LN

### DIFF
--- a/Sources/armory/logicnode/GetSystemLanguage.hx
+++ b/Sources/armory/logicnode/GetSystemLanguage.hx
@@ -1,0 +1,13 @@
+package armory.logicnode;
+
+class GetSystemLanguage extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		if (from == 0) return kha.System.language;
+		return null;
+	}
+}

--- a/blender/arm/logicnode/native/LN_get_system_language.py
+++ b/blender/arm/logicnode/native/LN_get_system_language.py
@@ -1,0 +1,13 @@
+from arm.logicnode.arm_nodes import *
+
+class GetSystemLanguage(ArmLogicTreeNode):
+    """Returns the name of the current system."""
+    bl_idname = 'LNGetSystemLanguage'
+    bl_label = 'Get System Language'
+    arm_version = 1
+
+    def init(self, context):
+        super(GetSystemLanguage, self).init(context)
+        self.add_output('NodeSocketString', 'Language')
+
+add_node(GetSystemLanguage, category=PKG_AS_CATEGORY, section='Native')

--- a/blender/arm/logicnode/native/LN_get_system_language.py
+++ b/blender/arm/logicnode/native/LN_get_system_language.py
@@ -1,7 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
 class GetSystemLanguage(ArmLogicTreeNode):
-    """Returns the name of the current system."""
+    """Returns the language of the current system."""
     bl_idname = 'LNGetSystemLanguage'
     bl_label = 'Get System Language'
     arm_version = 1


### PR DESCRIPTION
Get System Language

![get_system_language](https://user-images.githubusercontent.com/7114353/95874667-cb6c2c00-0d79-11eb-80f9-a38511188e03.jpg)

Category: _Native_
To get the current system language according to the IS0 639 standard.
The _Krom_ platform always returns “_en_”.