### PR TITLE
Get Tilesheet State node

### DIFF
--- a/Sources/armory/logicnode/AnimationStateNode.hx
+++ b/Sources/armory/logicnode/AnimationStateNode.hx
@@ -12,11 +12,16 @@ class AnimationStateNode extends LogicNode {
 		var object: Object = inputs[0].get();
 
 		if (object == null) return null;
+
 		var animation = object.animation;
+
 		if (animation == null) animation = object.getParentArmature(object.name);
 
-		if (from == 0) return !animation.paused; // is playing
-		else if (from == 1) return animation.action;
-		else return animation.currentFrame();
+		return switch (from) {
+		case 0: animation.action;
+		case 1: animation.currentFrame();
+		case 2: animation.paused;
+		default: null;
+		}
 	}
 }

--- a/Sources/armory/logicnode/AnimationStateNode.hx
+++ b/Sources/armory/logicnode/AnimationStateNode.hx
@@ -18,10 +18,10 @@ class AnimationStateNode extends LogicNode {
 		if (animation == null) animation = object.getParentArmature(object.name);
 
 		return switch (from) {
-		case 0: animation.action;
-		case 1: animation.currentFrame();
-		case 2: animation.paused;
-		default: null;
+			case 0: animation.action;
+			case 1: animation.currentFrame();
+			case 2: animation.paused;
+			default: null;
 		}
 	}
 }

--- a/Sources/armory/logicnode/GetTilesheetStateNode.hx
+++ b/Sources/armory/logicnode/GetTilesheetStateNode.hx
@@ -11,7 +11,7 @@ class GetTilesheetStateNode extends LogicNode {
 	override function get(from: Int): Dynamic {
 		var object: MeshObject = inputs[0].get();
 
-		if (object == null) return;
+		if (object == null) return null;
 
 		var tilesheet = object.tilesheet;
 

--- a/Sources/armory/logicnode/GetTilesheetStateNode.hx
+++ b/Sources/armory/logicnode/GetTilesheetStateNode.hx
@@ -1,0 +1,25 @@
+package armory.logicnode;
+
+import iron.object.MeshObject;
+
+class GetTilesheetStateNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var object: MeshObject = inputs[0].get();
+
+		if (object == null) return;
+
+		var tilesheet = object.tilesheet;
+
+		return switch (from) {
+			case 0: tilesheet.action;
+			case 1: tilesheet.frame;
+			case 2: tilesheet.paused;
+			default: null;
+		}
+	}
+}

--- a/Sources/armory/logicnode/SetActionPausedNode.hx
+++ b/Sources/armory/logicnode/SetActionPausedNode.hx
@@ -18,7 +18,7 @@ class SetActionPausedNode extends LogicNode {
 
 		if (animation == null) animation = object.getParentArmature(object.name);
 
-		paused ? animation.resume() : animation.pause();
+		paused ? animation.pause() : animation.resume();
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/SetTilesheetPausedNode.hx
+++ b/Sources/armory/logicnode/SetTilesheetPausedNode.hx
@@ -14,7 +14,7 @@ class SetTilesheetPausedNode extends LogicNode {
 
 		if (object == null) return;
 
-		paused ? object.tilesheet.resume() : object.tilesheet.pause();
+		paused ? object.tilesheet.pause() : object.tilesheet.resume();
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/SetTraitPausedNode.hx
+++ b/Sources/armory/logicnode/SetTraitPausedNode.hx
@@ -12,7 +12,7 @@ class SetTraitPausedNode extends LogicNode {
 
 		if (trait == null || !Std.is(trait, LogicTree)) return;
 
-		paused ? cast(trait, LogicTree).resume() : cast(trait, LogicTree).pause();
+		paused ? cast(trait, LogicTree).pause() : cast(trait, LogicTree).resume();
 
 		runOutput(0);
 	}

--- a/blender/arm/logicnode/animation/LN_get_action_state.py
+++ b/blender/arm/logicnode/animation/LN_get_action_state.py
@@ -9,8 +9,8 @@ class AnimationStateNode(ArmLogicTreeNode):
     def init(self, context):
         super(AnimationStateNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_output('NodeSocketBool', 'Is Playing')
         self.add_output('NodeSocketString', 'Action')
         self.add_output('NodeSocketInt', 'Frame')
+        self.add_output('NodeSocketBool', 'Is Paused')
 
 add_node(AnimationStateNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_get_tilesheet_state.py
+++ b/blender/arm/logicnode/animation/LN_get_tilesheet_state.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class GetTilesheetStateNode(ArmLogicTreeNode):
+    """Returns the information about the current tilesheet of the given object."""
+    bl_idname = 'LNGetTilesheetStateNode'
+    bl_label = 'Get Tilesheet State'
+    arm_version = 1
+
+    def init(self, context):
+        super(GetTilesheetStateNode, self).init(context)
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_output('NodeSocketString', 'Tilesheet')
+        self.add_output('NodeSocketInt', 'Frame')
+        self.add_output('NodeSocketBool', 'Is Paused')
+
+add_node(GetTilesheetStateNode, category=PKG_AS_CATEGORY, section='tilesheet')

--- a/blender/arm/logicnode/animation/LN_set_action_paused.py
+++ b/blender/arm/logicnode/animation/LN_set_action_paused.py
@@ -10,7 +10,7 @@ class SetActionPausedNode(ArmLogicTreeNode):
         super(SetActionPausedNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_input('ArmNodeSocketBool', 'Paused')
+        self.add_input('NodeSocketBool', 'Paused')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(SetActionPausedNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_set_tilesheet_paused.py
+++ b/blender/arm/logicnode/animation/LN_set_tilesheet_paused.py
@@ -10,7 +10,7 @@ class SetTilesheetPausedNode(ArmLogicTreeNode):
         super(SetTilesheetPausedNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
-        self.add_input('ArmNodeSocketBool', 'Paused')
+        self.add_input('NodeSocketBool', 'Paused')
         self.add_output('ArmNodeSocketAction', 'Out')
 
 add_node(SetTilesheetPausedNode, category=PKG_AS_CATEGORY, section='tilesheet')


### PR DESCRIPTION
This also fixes previous commits that i did not tested.

Users must recreate the `Get Action State` node because i changed it from "Is Playing" to "Is Paused" to match the `Set Action State` node.

Requires: https://github.com/armory3d/iron/pull/106

Question: do `Action` node works also for tilesheets or there is a need for a `Tilesheet` node too?