### PR TITLE
Fix volumetric light for different lamp combinations

### DIFF
--- a/Shaders/volumetric_light/volumetric_light.frag.glsl
+++ b/Shaders/volumetric_light/volumetric_light.frag.glsl
@@ -90,11 +90,11 @@ void rayStep(inout vec3 curPos, inout float curOpticalDepth, inout float scatter
 	float l1 = lighting * stepLenWorld * tScat * density;
 	curOpticalDepth *= exp(-tExt * stepLenWorld * density);
 
-    float visibility = 0.0;
+	float visibility = 0.0;
 
 #ifdef _Sun
 	#ifdef _CSM
-    mat4 LWVP = mat4(casData[4], casData[4 + 1], casData[4 + 2], casData[4 + 3]);
+	mat4 LWVP = mat4(casData[4], casData[4 + 1], casData[4 + 2], casData[4 + 3]);
 	#endif
 	vec4 lPos = LWVP * vec4(curPos, 1.0);
 	lPos.xyz /= lPos.w;

--- a/Shaders/volumetric_light/volumetric_light.frag.glsl
+++ b/Shaders/volumetric_light/volumetric_light.frag.glsl
@@ -86,9 +86,11 @@ const float lighting = 0.4;
 void rayStep(inout vec3 curPos, inout float curOpticalDepth, inout float scatteredLightAmount, float stepLenWorld, vec3 viewVecNorm) {
 	curPos += stepLenWorld * viewVecNorm;
 	const float density = 1.0;
-	
+
 	float l1 = lighting * stepLenWorld * tScat * density;
 	curOpticalDepth *= exp(-tExt * stepLenWorld * density);
+
+    float visibility = 0.0;
 
 #ifdef _Sun
 	#ifdef _CSM
@@ -96,20 +98,20 @@ void rayStep(inout vec3 curPos, inout float curOpticalDepth, inout float scatter
 	#endif
 	vec4 lPos = LWVP * vec4(curPos, 1.0);
 	lPos.xyz /= lPos.w;
-	float visibility = texture(shadowMap, vec3(lPos.xy, lPos.z - shadowsBias));
+	visibility = texture(shadowMap, vec3(lPos.xy, lPos.z - shadowsBias));
 #endif
 
 #ifdef _SinglePoint
 	#ifdef _Spot
 	vec4 lPos = LWVPSpot0 * vec4(curPos, 1.0);
-	float visibility = shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, pointBias);
+	visibility = shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, pointBias);
 	float spotEffect = dot(spotDir, normalize(pointPos - curPos)); // lightDir
 	if (spotEffect < spotData.x) { // x - cutoff, y - cutoff - exponent
 		visibility *= smoothstep(spotData.y, spotData.x, spotEffect);
 	}
 	#else
 	vec3 ld = pointPos - curPos;
-	float visibility = PCFCube(shadowMapPoint[0], ld, -normalize(ld), pointBias, lightProj, vec3(0.0));
+	visibility = PCFCube(shadowMapPoint[0], ld, -normalize(ld), pointBias, lightProj, vec3(0.0));
 	#endif
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1944.

Depending on the lights used in the scene, `visibility` could be undeclared or it got re-declared in some cases.

- Now, if the scene has no lights, the volumetric light is invisible.
- If multiple sun lights exist, only one is taken into account (which is not great but it's more of a temporary solution until the light system gets reworked (if that ever happens)).
- If multiple point lights exist (which doesn't work on DirectX due to https://github.com/armory3d/armory/issues/1772), volumetric lighting is also invisible which is not good but before it just didn't compile.