### PR TITLE
Added settings for building APK

### DIFF
--- a/blender/arm/make_state.py
+++ b/blender/arm/make_state.py
@@ -8,6 +8,7 @@ last_scene = ''
 last_world_defs = ''
 proc_play = None
 proc_build = None
+proc_publish_build = None
 mod_scripts = []
 is_export = False
 is_play = False

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -23,6 +23,11 @@ def init_properties():
     bpy.types.World.arm_project_android_sdk_compile = IntProperty(name="Compile Version SDK", description="Compile Android SDK Version", default=29, min=26, max=30, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_android_sdk_min = IntProperty(name="Minimal Version SDK", description="Minimal Version Android SDK", default=14, min=14, max=30, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_android_sdk_target = IntProperty(name="Target Version SDK", description="Target Version Android SDK", default=29, min=26, max=30, update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_project_android_build_apk = BoolProperty(name="Building APK After Publishing", description="Starting APK build after publishing", default=False, update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_project_android_run_avd = BoolProperty(name="Run Emulator After Building APK", description="Starting android emulator after APK build", default=False, update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_project_android_list_avd = EnumProperty(
+        items=[(' ', ' ', ' ')],
+        name="Emulator", update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_icon = StringProperty(name="Icon (PNG)", description="Exported project icon, must be a PNG image", default="", subtype="FILE_PATH", update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_root = StringProperty(name="Root", description="Set root folder for linked assets", default="", subtype="DIR_PATH", update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_physics = EnumProperty(


### PR DESCRIPTION
Added a panel with settings:
![build_apk_emulator_run](https://user-images.githubusercontent.com/7114353/96903894-120b0600-149f-11eb-87fc-34ed2b7e5d85.jpg)

- _Building APK After Publish_ - to start the build after the project has been successfully published (False by default). Disabled if SDK path is not specified;
- _Emulator_ - list of installed emulators in _Android Studio_ (_AVD Manager_). At the start of Blender, the list is always empty, to fill and update it, you must click the _Refresh_ button. To start the emulator, if you wish, you need to press the _Start_ button (the list of emulators is obtained with the `emulator -list-avds` command, the launch is performed with the `emulator -avd [name]` command). The _Start_ button is disabled if the name of the emulator is not selected from the list;
- _Run Emulator After Building APK_ - launch the emulator after successfully building the APK file. Disabled if no APK build is installed or no emulator name selected.

To perform these operations, you need to specify the _ANDROID_SDK_ROOT_ environment variable, if it is not specified in the OS, then the "_Android SDK Path_" setting is read and set as the environment variable `os.environ ['ANDROID_SDK_ROOT']` to perform operations.
If no value is specified, then the user receives a corresponding message to the console. If the specified value is incorrect, then the user will receive messages from the corresponding programs.