### PR TITLE
More cycles nodes + improvements

### DIFF
--- a/blender/arm/material/cycles_nodes/nodes_color.py
+++ b/blender/arm/material/cycles_nodes/nodes_color.py
@@ -102,6 +102,5 @@ def parse_curvergb(node: bpy.types.ShaderNodeRGBCurve, out_socket: bpy.types.Nod
 
 
 def parse_lightfalloff(node: bpy.types.ShaderNodeLightFalloff, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:
-    # Constant, linear, quadratic
-    # Shaders default to quadratic for now
-    return '1.0'
+    # https://github.com/blender/blender/blob/master/source/blender/gpu/shaders/material/gpu_shader_material_light_falloff.glsl
+    return c.parse_value_input(node.inputs['Strength'])

--- a/blender/arm/material/cycles_nodes/nodes_converter.py
+++ b/blender/arm/material/cycles_nodes/nodes_converter.py
@@ -316,9 +316,18 @@ def parse_rgbtobw(node: bpy.types.ShaderNodeRGBToBW, out_socket: bpy.types.NodeS
     return '((({0}.r * 0.3 + {0}.g * 0.59 + {0}.b * 0.11) / 3.0) * 2.5)'.format(col)
 
 
-def parse_sephsv(node: bpy.types.ShaderNodeSeparateHSV, out_socket: bpy.types.NodeSocket) -> floatstr:
-    # TODO
-    return '0.0'
+def parse_sephsv(node: bpy.types.ShaderNodeSeparateHSV, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:
+    state.curshader.add_function(c_functions.str_hue_sat)
+
+    hsv_var = c.node_name(node.name) + '_hsv'
+    state.curshader.write(f'const vec3 {hsv_var} = rgb_to_hsv({c.parse_vector_input(node.inputs["Color"])}.rgb);')
+
+    if out_socket == node.outputs[0]:
+        return f'{hsv_var}.x'
+    elif out_socket == node.outputs[1]:
+        return f'{hsv_var}.y'
+    elif out_socket == node.outputs[2]:
+        return f'{hsv_var}.z'
 
 
 def parse_seprgb(node: bpy.types.ShaderNodeSeparateRGB, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:

--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -214,6 +214,8 @@ def parse_texcoord(node: bpy.types.ShaderNodeTexCoord, out_socket: bpy.types.Nod
     if out_socket == node.outputs[0]: # Generated - bounds
         return 'bposition'
     elif out_socket == node.outputs[1]: # Normal
+        if state.context == ParserContext.WORLD:
+            return '-n'
         return 'n'
     elif out_socket == node.outputs[2]: # UV
         state.con.add_elem('tex', 'short2norm')

--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -1,6 +1,7 @@
 import bpy
 from typing import Union
 
+import arm.log as log
 import arm.material.cycles as c
 import arm.material.cycles_functions as c_functions
 from arm.material.parser_state import ParserState, ParserContext
@@ -273,28 +274,35 @@ def parse_layerweight(node: bpy.types.ShaderNodeLayerWeight, out_socket: bpy.typ
 
 def parse_lightpath(node: bpy.types.ShaderNodeLightPath, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:
     # https://github.com/blender/blender/blob/master/source/blender/gpu/shaders/material/gpu_shader_material_light_path.glsl
-    if out_socket == node.outputs[0]: # Is Camera Ray
+    if out_socket == node.outputs['Is Camera Ray']:
         return '1.0'
-    elif out_socket == node.outputs[1]: # Is Shadow Ray
+    elif out_socket == node.outputs['Is Shadow Ray']:
         return '0.0'
-    elif out_socket == node.outputs[2]: # Is Diffuse Ray
+    elif out_socket == node.outputs['Is Diffuse Ray']:
         return '1.0'
-    elif out_socket == node.outputs[3]: # Is Glossy Ray
+    elif out_socket == node.outputs['Is Glossy Ray']:
         return '1.0'
-    elif out_socket == node.outputs[4]: # Is Singular Ray
+    elif out_socket == node.outputs['Is Singular Ray']:
         return '0.0'
-    elif out_socket == node.outputs[5]: # Is Reflection Ray
+    elif out_socket == node.outputs['Is Reflection Ray']:
         return '0.0'
-    elif out_socket == node.outputs[6]: # Is Transmission Ray
+    elif out_socket == node.outputs['Is Transmission Ray']:
         return '0.0'
-    elif out_socket == node.outputs[7]: # Ray Length
+    elif out_socket == node.outputs['Ray Length']:
         return '1.0'
-    elif out_socket == node.outputs[8]: # Ray Depth
+    elif out_socket == node.outputs['Ray Depth']:
         return '0.0'
-    elif out_socket == node.outputs[9]: # Transparent Depth
+    elif out_socket == node.outputs['Diffuse Depth']:
         return '0.0'
-    elif out_socket == node.outputs[10]: # Transmission Depth
+    elif out_socket == node.outputs['Glossy Depth']:
         return '0.0'
+    elif out_socket == node.outputs['Transparent Depth']:
+        return '0.0'
+    elif out_socket == node.outputs['Transmission Depth']:
+        return '0.0'
+
+    log.warn(f'Light Path node: unsupported output {out_socket.identifier}.')
+    return '0.0'
 
 
 def parse_value(node: bpy.types.ShaderNodeValue, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:

--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -272,6 +272,7 @@ def parse_layerweight(node: bpy.types.ShaderNodeLayerWeight, out_socket: bpy.typ
 
 
 def parse_lightpath(node: bpy.types.ShaderNodeLightPath, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:
+    # https://github.com/blender/blender/blob/master/source/blender/gpu/shaders/material/gpu_shader_material_light_path.glsl
     if out_socket == node.outputs[0]: # Is Camera Ray
         return '1.0'
     elif out_socket == node.outputs[1]: # Is Shadow Ray
@@ -287,7 +288,7 @@ def parse_lightpath(node: bpy.types.ShaderNodeLightPath, out_socket: bpy.types.N
     elif out_socket == node.outputs[6]: # Is Transmission Ray
         return '0.0'
     elif out_socket == node.outputs[7]: # Ray Length
-        return '0.0'
+        return '1.0'
     elif out_socket == node.outputs[8]: # Ray Depth
         return '0.0'
     elif out_socket == node.outputs[9]: # Transparent Depth

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -266,7 +266,8 @@ def parse_tex_noise(node: bpy.types.ShaderNodeTexNoise, out_socket: bpy.types.No
 
     scale = c.parse_value_input(node.inputs[2])
     detail = c.parse_value_input(node.inputs[3])
-    distortion = c.parse_value_input(node.inputs[4])#
+    roughness = c.parse_value_input(node.inputs[4])
+    distortion = c.parse_value_input(node.inputs[5])
 
     # Color
     if out_socket == node.outputs[1]:

--- a/blender/arm/material/cycles_nodes/nodes_vector.py
+++ b/blender/arm/material/cycles_nodes/nodes_vector.py
@@ -106,11 +106,14 @@ def parse_mapping(node: bpy.types.ShaderNodeMapping, out_socket: bpy.types.NodeS
 
 
 def parse_normal(node: bpy.types.ShaderNodeNormal, out_socket: bpy.types.NodeSocket, state: ParserState) -> Union[floatstr, vec3str]:
-    if out_socket == node.outputs[0]:
-        return c.to_vec3(node.outputs[0].default_value)
-    elif out_socket == node.outputs[1]: # TODO: is parse_value path preferred?
-        nor = c.parse_vector_input(node.inputs[0])
-        return f'dot({c.to_vec3(node.outputs[0].default_value)}, {nor})'
+    nor1 = c.to_vec3(node.outputs['Normal'].default_value)
+
+    if out_socket == node.outputs['Normal']:
+        return nor1
+
+    elif out_socket == node.outputs['Dot']:
+        nor2 = c.parse_vector_input(node.inputs["Normal"])
+        return f'dot({nor1}, {nor2})'
 
 
 def parse_normalmap(node: bpy.types.ShaderNodeNormalMap, out_socket: bpy.types.NodeSocket, state: ParserState) -> vec3str:


### PR DESCRIPTION
- Constant factors for the MixRGB node are now inlined (actually I think we could also do this for non-constant factors, there are stored in a variable anyways I think?)
- Fixed some socket indices and replaced the indices for some nodes with string identifiers (I'm not sure about the speed loss/how Blender handles this internally)
- Fixed `Normal` output in the Texture Coordinate node for world shaders
- The Light Falloff node now follows Eevee's implementation
- Implemented the Separate HSV node
- Aligned the Light Path node to Eevee's implementation and fixed some socket indices