### PR TITLE
Fix bump node when connected to vector output

### DIFF
--- a/blender/arm/material/cycles_nodes/nodes_converter.py
+++ b/blender/arm/material/cycles_nodes/nodes_converter.py
@@ -312,8 +312,7 @@ def parse_math(node: bpy.types.ShaderNodeMath, out_socket: bpy.types.NodeSocket,
 
 
 def parse_rgbtobw(node: bpy.types.ShaderNodeRGBToBW, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:
-    col = c.parse_vector_input(node.inputs[0])
-    return '((({0}.r * 0.3 + {0}.g * 0.59 + {0}.b * 0.11) / 3.0) * 2.5)'.format(col)
+    return c.rgb_to_bw(c.parse_vector_input(node.inputs[0]))
 
 
 def parse_sephsv(node: bpy.types.ShaderNodeSeparateHSV, out_socket: bpy.types.NodeSocket) -> floatstr:

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -34,7 +34,7 @@ def parse_tex_brick(node: bpy.types.ShaderNodeTexBrick, out_socket: bpy.types.No
         res = 'tex_brick_f({0} * {1})'.format(co, scale)
 
     if state.sample_bump:
-        c.write_bump(node, res)
+        c.write_bump(node, out_socket, res)
 
     return res
 
@@ -59,7 +59,7 @@ def parse_tex_checker(node: bpy.types.ShaderNodeTexChecker, out_socket: bpy.type
         res = 'tex_checker_f({0}, {1})'.format(co, scale)
 
     if state.sample_bump:
-        c.write_bump(node, res)
+        c.write_bump(node, out_socket, res)
 
     return res
 
@@ -94,7 +94,7 @@ def parse_tex_gradient(node: bpy.types.ShaderNodeTexGradient, out_socket: bpy.ty
         res = f'(clamp({f}, 0.0, 1.0))'
 
     if state.sample_bump:
-        c.write_bump(node, res)
+        c.write_bump(node, out_socket, res)
 
     return res
 
@@ -222,7 +222,7 @@ def parse_tex_magic(node: bpy.types.ShaderNodeTexMagic, out_socket: bpy.types.No
         res = f'tex_magic_f({co} * {scale} * 4.0)'
 
     if state.sample_bump:
-        c.write_bump(node, res, 0.1)
+        c.write_bump(node, out_socket, res, 0.1)
 
     return res
 
@@ -247,7 +247,7 @@ def parse_tex_musgrave(node: bpy.types.ShaderNodeTexMusgrave, out_socket: bpy.ty
         res = 'tex_musgrave_f({0} * {1} * 0.5)'.format(co, scale)
 
     if state.sample_bump:
-        c.write_bump(node, res)
+        c.write_bump(node, out_socket, res)
 
     return res
 
@@ -276,7 +276,7 @@ def parse_tex_noise(node: bpy.types.ShaderNodeTexNoise, out_socket: bpy.types.No
         res = 'tex_noise({0} * {1},{2},{3})'.format(co, scale, detail, distortion)
 
     if state.sample_bump:
-        c.write_bump(node, res, 0.1)
+        c.write_bump(node, out_socket, res, 0.1)
 
     return res
 
@@ -493,7 +493,7 @@ def parse_tex_voronoi(node: bpy.types.ShaderNodeTexVoronoi, out_socket: bpy.type
         res = 'tex_voronoi({0}, {1}, {2}, {3}, {4}, {5}).x'.format(co, randomness, m, outp, scale, exp)
 
     if state.sample_bump:
-        c.write_bump(node, res)
+        c.write_bump(node, out_socket, res)
 
     return res
 
@@ -526,6 +526,6 @@ def parse_tex_wave(node: bpy.types.ShaderNodeTexWave, out_socket: bpy.types.Node
         res = 'tex_wave_f({0} * {1},{2},{3},{4},{5},{6})'.format(co, scale, wave_type, wave_profile, distortion, detail, detail_scale)
 
     if state.sample_bump:
-        c.write_bump(node, res)
+        c.write_bump(node, out_socket, res)
 
     return res


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/935.

The output still looks different in Blender, Armory samples the texture around a coordinate (which might be slow because the (procedural) texture has do be recalculated 5 times, I don't know?) and Eevee seems to use partial derivatives to get the normals from the height map which might be a better solution.