### PR TITLE
LN for Traits

### DIFF
--- a/Sources/armory/logicnode/GetObjectTraitsNode.hx
+++ b/Sources/armory/logicnode/GetObjectTraitsNode.hx
@@ -1,0 +1,16 @@
+package armory.logicnode;
+
+import iron.object.Object;
+
+class GetObjectTraitsNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var object: Object = inputs[0].get();
+		if (object == null) return null;
+		return object.traits;
+	}
+}

--- a/Sources/armory/logicnode/GetTraitNameNode.hx
+++ b/Sources/armory/logicnode/GetTraitNameNode.hx
@@ -1,0 +1,44 @@
+package armory.logicnode;
+
+import iron.Trait;
+
+class GetTraitNameNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var trait: Dynamic = inputs[0].get();
+        if (trait == null) return null;
+       	switch (from) { 
+			// Name
+			case 0: {
+			// Check CanvasScript
+			var cname = cast Type.resolveClass("armory.trait.internal.CanvasScript");
+			if (Std.is(trait, cname)) {
+				return trait.cnvName;
+			}
+			// Check WasmScript
+			var cname = cast Type.resolveClass("armory.trait.internal.WasmScript");
+			if (Std.is(trait, cname)) {
+				return trait.wasmName;
+			}
+			// Other
+            var res_arr = (Type.getClassName(Type.getClass(trait))).split(".");
+            return res_arr[res_arr.length - 1];
+			}
+			// Class Type
+			case 1: {
+				var cname = Type.getClassName(Type.getClass(trait));
+				if (cname.indexOf("CanvasScript") > -1) return "Canvas";
+				if (cname.indexOf("WasmScript") > -1) return "Wasm";
+				if (cname.indexOf("armory.trait.") > -1) return "Bundle";
+				if (cname.indexOf("arm.node.") > -1) return "LogicNode";
+				if (cname.indexOf("Trait") > -1) return "Haxe";
+				return null;
+			}
+		}
+		return null;
+	}
+}

--- a/Sources/armory/trait/internal/CanvasScript.hx
+++ b/Sources/armory/trait/internal/CanvasScript.hx
@@ -8,6 +8,7 @@ import zui.Canvas;
 
 class CanvasScript extends Trait {
 
+	public var cnvName: String;
 #if arm_ui
 
 	var cui: Zui;
@@ -23,6 +24,7 @@ class CanvasScript extends Trait {
 	 */
 	public function new(canvasName: String, font: String = "font_default.ttf") {
 		super();
+		cnvName = canvasName;
 
 		iron.data.Data.getBlob(canvasName + ".json", function(blob: kha.Blob) {
 
@@ -147,7 +149,7 @@ class CanvasScript extends Trait {
 
 #else
 
-	public function new(canvasName: String) { super(); }
+	public function new(canvasName: String) { super(); cnvName = canvasName; }
 
 #end
 }

--- a/Sources/armory/trait/internal/WasmScript.hx
+++ b/Sources/armory/trait/internal/WasmScript.hx
@@ -10,11 +10,13 @@ import iron.system.Time;
 class WasmScript extends iron.Trait {
 
 	var wasm: Wasm;
+	public var wasmName: String;
 
 	var objectMap: Map<Int, iron.object.Object> = new Map();
 
 	public function new(handle: String) {
 		super();
+		wasmName = handle;
 
 		// Armory API exposed to WebAssembly
 		// TODO: static

--- a/blender/arm/logicnode/trait/LN_get_object_traits.py
+++ b/blender/arm/logicnode/trait/LN_get_object_traits.py
@@ -1,0 +1,14 @@
+from arm.logicnode.arm_nodes import *
+
+class GetObjectTraitsNode(ArmLogicTreeNode):
+    """Returns the children of the given object."""
+    bl_idname = 'LNGetObjectTraitsNode'
+    bl_label = 'Get Object Traits'
+    arm_version = 1
+
+    def init(self, context):
+        super(GetObjectTraitsNode, self).init(context)
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_output('ArmNodeSocketArray', 'Traits')
+
+add_node(GetObjectTraitsNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/trait/LN_get_trait_name.py
+++ b/blender/arm/logicnode/trait/LN_get_trait_name.py
@@ -1,0 +1,15 @@
+from arm.logicnode.arm_nodes import *
+
+class GetTraitNameNode(ArmLogicTreeNode):
+    """Getting the name Trait."""
+    bl_idname = 'LNGetTraitNameNode'
+    bl_label = 'Get Trait Name'
+    arm_version = 1
+
+    def init(self, context):
+        super(GetTraitNameNode, self).init(context)
+        self.add_input('NodeSocketShader', 'Trait')
+        self.add_output('NodeSocketString', 'Name')
+        self.add_output('NodeSocketString', 'Class Type')
+
+add_node(GetTraitNameNode, category=PKG_AS_CATEGORY)


### PR DESCRIPTION
1. Modification of `CanvasScript` and `WasmScript` classes: added a field to save the name of the script/file in the class.
2. Added logical nodes for working with `Traits`. 
Categories: _Trait_.

![get_taits_name_v3](https://user-images.githubusercontent.com/7114353/97091512-08bb9e00-1645-11eb-90fb-af1d32492d25.jpg)

- `Get Object Traits` - gets an array of `Traits` for the specified object;
- `Get Trait Name` - get the `Trait` name (the name that appears in the list in `Armory Traits`) and its type (_Canvas_, _Wasm_, _Bundle_, _LogicNode_ or _Haxe_).