### PR TITLE
Snapshot node / add progress output to On Timer

### DIFF
--- a/Sources/armory/logicnode/OnTimerNode.hx
+++ b/Sources/armory/logicnode/OnTimerNode.hx
@@ -12,7 +12,6 @@ class OnTimerNode extends LogicNode {
 	}
 
 	function update() {
-
 		if (duration <= 0.0) {
 			duration = inputs[0].get();
 			repeat = inputs[1].get();

--- a/Sources/armory/logicnode/OnTimerNode.hx
+++ b/Sources/armory/logicnode/OnTimerNode.hx
@@ -19,9 +19,13 @@ class OnTimerNode extends LogicNode {
 		}
 
 		duration -= iron.system.Time.delta;
+
 		if (duration <= 0.0) {
-			if (!repeat) tree.removeUpdate(update);
-			runOutput(0);
+			repeat ? runOutput(0): tree.removeUpdate(update);
 		}
+	}
+
+	override function get(from: Int): Dynamic {
+		return 1 - duration / inputs[0].get();
 	}
 }

--- a/Sources/armory/logicnode/SnapshotNode.hx
+++ b/Sources/armory/logicnode/SnapshotNode.hx
@@ -9,7 +9,6 @@ class SnapshotNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
-
 		var value: Dynamic = inputs[1].get();
 
 		snapshot = value;

--- a/Sources/armory/logicnode/SnapshotNode.hx
+++ b/Sources/armory/logicnode/SnapshotNode.hx
@@ -1,0 +1,22 @@
+package armory.logicnode;
+
+class SnapshotNode extends LogicNode {
+
+	var snapshot: Dynamic = null;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+
+		var value: Dynamic = inputs[1].get();
+
+		snapshot = value;
+
+		runOutput(0);
+	}
+	override function get(from: Dynamic) {
+		return snapshot;
+	}
+}

--- a/blender/arm/logicnode/event/LN_on_timer.py
+++ b/blender/arm/logicnode/event/LN_on_timer.py
@@ -17,5 +17,4 @@ class OnTimerNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('NodeSocketFloat', 'Progress')
 
-
 add_node(OnTimerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/event/LN_on_timer.py
+++ b/blender/arm/logicnode/event/LN_on_timer.py
@@ -1,10 +1,11 @@
 from arm.logicnode.arm_nodes import *
 
 class OnTimerNode(ArmLogicTreeNode):
-    """Activates the output when a given time elapsed (optionally repeating the timer).
+    """Activates the output when the given time has elapsed (optionally repeating the timer).
 
-    @input Duration: the time in seconds after which to activate the output
-    @input Repeat: whether to repeat the timer"""
+    @input Duration: the time interval before the output activation
+    @input Repeat: while `true` will repeat after done
+    @output Progress: the progress of the time from 0.0 to 1.0"""
     bl_idname = 'LNOnTimerNode'
     bl_label = 'On Timer'
     arm_version = 1
@@ -14,5 +15,7 @@ class OnTimerNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Duration')
         self.add_input('NodeSocketBool', 'Repeat')
         self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('NodeSocketFloat', 'Progress')
+
 
 add_node(OnTimerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/miscellaneous/LN_snapshot.py
+++ b/blender/arm/logicnode/miscellaneous/LN_snapshot.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class SnapshotNode(ArmLogicTreeNode):
+    """Stores the given value snapshot whether activated."""
+    bl_idname = 'LNSnapshotNode'
+    bl_label = 'Snapshot'
+    arm_version = 1
+
+    def init(self, context):
+        super(SnapshotNode, self).init(context)
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('NodeSocketShader', 'Value')
+        self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('NodeSocketShader', 'Snapshot')
+
+add_node(SnapshotNode, category=PKG_AS_CATEGORY)


### PR DESCRIPTION
I don't know if this node should be included because it can be done with `Set Variable` node. Maybe as an alternative?

The value is updated every time the node is activated.

![Screenshot from 2020-10-26 17-57-10](https://user-images.githubusercontent.com/63247726/97228127-36275980-17b5-11eb-8af4-fa9e40f7f3b0.png)

There is an example of `On Timer` and this node running: [PlayerController.zip](https://github.com/armory3d/armory/files/5441520/PlayerController.zip)

