### PR TITLE
Fix and improve registration of nodes

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -6,6 +6,7 @@ import bpy
 from bpy.app.handlers import persistent
 
 import arm.api
+import arm.logicnode.arm_nodes
 import arm.nodes_logic
 import arm.make as make
 import arm.make_state as state
@@ -135,6 +136,7 @@ def on_load_post(context):
                     sys.path.remove(fp)
 
         # Register newly added nodes and node categories
+        arm.logicnode.arm_nodes.reset_globals()
         arm.nodes_logic.register_nodes()
 
     # Show trait users as collections

--- a/blender/arm/logicnode/animation/LN_action.py
+++ b/blender/arm/logicnode/animation/LN_action.py
@@ -10,5 +10,3 @@ class AnimActionNode(ArmLogicTreeNode):
         super(AnimActionNode, self).init(context)
         self.add_input('ArmNodeSocketAnimAction', 'Action')
         self.add_output('ArmNodeSocketAnimAction', 'Action', is_var=True)
-
-add_node(AnimActionNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_blend_action.py
+++ b/blender/arm/logicnode/animation/LN_blend_action.py
@@ -14,5 +14,3 @@ class BlendActionNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAnimAction', 'Action 2')
         self.add_input('NodeSocketFloat', 'Factor', default_value = 0.5)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(BlendActionNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_bone_fk.py
+++ b/blender/arm/logicnode/animation/LN_bone_fk.py
@@ -5,6 +5,7 @@ class BoneFKNode(ArmLogicTreeNode):
     bl_idname = 'LNBoneFKNode'
     bl_label = 'Bone FK'
     arm_version = 1
+    arm_section = 'armature'
 
     def init(self, context):
         super(BoneFKNode, self).init(context)
@@ -13,5 +14,3 @@ class BoneFKNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Bone')
         self.add_input('NodeSocketShader', 'Transform')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(BoneFKNode, category=PKG_AS_CATEGORY, section='armature')

--- a/blender/arm/logicnode/animation/LN_bone_ik.py
+++ b/blender/arm/logicnode/animation/LN_bone_ik.py
@@ -5,6 +5,7 @@ class BoneIKNode(ArmLogicTreeNode):
     bl_idname = 'LNBoneIKNode'
     bl_label = 'Bone IK'
     arm_version = 1
+    arm_section = 'armature'
 
     def init(self, context):
         super(BoneIKNode, self).init(context)
@@ -13,5 +14,3 @@ class BoneIKNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Bone')
         self.add_input('NodeSocketVector', 'Goal')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(BoneIKNode, category=PKG_AS_CATEGORY, section='armature')

--- a/blender/arm/logicnode/animation/LN_get_action_state.py
+++ b/blender/arm/logicnode/animation/LN_get_action_state.py
@@ -12,5 +12,3 @@ class AnimationStateNode(ArmLogicTreeNode):
         self.add_output('NodeSocketString', 'Action')
         self.add_output('NodeSocketInt', 'Frame')
         self.add_output('NodeSocketBool', 'Is Paused')
-
-add_node(AnimationStateNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_get_tilesheet_state.py
+++ b/blender/arm/logicnode/animation/LN_get_tilesheet_state.py
@@ -5,6 +5,7 @@ class GetTilesheetStateNode(ArmLogicTreeNode):
     bl_idname = 'LNGetTilesheetStateNode'
     bl_label = 'Get Tilesheet State'
     arm_version = 1
+    arm_section = 'tilesheet'
 
     def init(self, context):
         super(GetTilesheetStateNode, self).init(context)
@@ -12,5 +13,3 @@ class GetTilesheetStateNode(ArmLogicTreeNode):
         self.add_output('NodeSocketString', 'Name')
         self.add_output('NodeSocketInt', 'Frame')
         self.add_output('NodeSocketBool', 'Is Paused')
-
-add_node(GetTilesheetStateNode, category=PKG_AS_CATEGORY, section='tilesheet')

--- a/blender/arm/logicnode/animation/LN_on_action_marker.py
+++ b/blender/arm/logicnode/animation/LN_on_action_marker.py
@@ -11,5 +11,3 @@ class OnActionMarkerNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketString', 'Marker')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(OnActionMarkerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_play_action_from.py
+++ b/blender/arm/logicnode/animation/LN_play_action_from.py
@@ -15,5 +15,3 @@ class PlayActionFromNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Blend', default_value=0.2)
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Done')
-
-add_node(PlayActionFromNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_play_tilesheet.py
+++ b/blender/arm/logicnode/animation/LN_play_tilesheet.py
@@ -5,6 +5,7 @@ class PlayTilesheetNode(ArmLogicTreeNode):
     bl_idname = 'LNPlayTilesheetNode'
     bl_label = 'Play Tilesheet'
     arm_version = 1
+    arm_section = 'tilesheet'
 
     def init(self, context):
         super(PlayTilesheetNode, self).init(context)
@@ -13,5 +14,3 @@ class PlayTilesheetNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Name')
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Done')
-
-add_node(PlayTilesheetNode, category=PKG_AS_CATEGORY, section='tilesheet')

--- a/blender/arm/logicnode/animation/LN_set_action_paused.py
+++ b/blender/arm/logicnode/animation/LN_set_action_paused.py
@@ -12,5 +12,3 @@ class SetActionPausedNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketBool', 'Paused')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetActionPausedNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_set_action_speed.py
+++ b/blender/arm/logicnode/animation/LN_set_action_speed.py
@@ -12,5 +12,3 @@ class SetActionSpeedNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketFloat', 'Speed', default_value=1.0)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetActionSpeedNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_set_parent_bone.py
+++ b/blender/arm/logicnode/animation/LN_set_parent_bone.py
@@ -5,6 +5,7 @@ class SetParentBoneNode(ArmLogicTreeNode):
     bl_idname = 'LNSetParentBoneNode'
     bl_label = 'Set Parent Bone'
     arm_version = 1
+    arm_section = 'armature'
 
     def init(self, context):
         super(SetParentBoneNode, self).init(context)
@@ -13,5 +14,3 @@ class SetParentBoneNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Parent', default_value='Parent')
         self.add_input('NodeSocketString', 'Bone', default_value='Bone')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetParentBoneNode, category=PKG_AS_CATEGORY, section='armature')

--- a/blender/arm/logicnode/animation/LN_set_particle_speed.py
+++ b/blender/arm/logicnode/animation/LN_set_particle_speed.py
@@ -12,5 +12,3 @@ class SetParticleSpeedNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketFloat', 'Speed', default_value=1.0)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetParticleSpeedNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/animation/LN_set_tilesheet_paused.py
+++ b/blender/arm/logicnode/animation/LN_set_tilesheet_paused.py
@@ -4,6 +4,7 @@ class SetTilesheetPausedNode(ArmLogicTreeNode):
     """Sets the tilesheet paused state of the given object."""
     bl_idname = 'LNSetTilesheetPausedNode'
     bl_label = 'Set Tilesheet Paused'
+    arm_section = 'tilesheet'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class SetTilesheetPausedNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketBool', 'Paused')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetTilesheetPausedNode, category=PKG_AS_CATEGORY, section='tilesheet')

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -19,6 +19,10 @@ array_nodes = dict()
 
 
 class ArmLogicTreeNode(bpy.types.Node):
+    arm_category = PKG_AS_CATEGORY
+    arm_section = 'default'
+    arm_is_obsolete = False
+
     def init(self, context):
         # make sure a given node knows the version of the NodeClass from when it was created
         if isinstance(type(self).arm_version, int):
@@ -29,6 +33,16 @@ class ArmLogicTreeNode(bpy.types.Node):
     @classmethod
     def poll(cls, ntree):
         return ntree.bl_idname == 'ArmLogicTreeType'
+
+    @classmethod
+    def on_register(cls):
+        """Don't call this method register() as it will be triggered before Blender registers the class, resulting in
+        a double registration."""
+        add_node(cls, cls.arm_category, cls.arm_section, cls.arm_is_obsolete)
+
+    @classmethod
+    def on_unregister(cls):
+        pass
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
         # needs to be overridden by individual node classes with arm_version>1
@@ -454,6 +468,8 @@ def add_node(node_type: Type[bpy.types.Node], category: str, section: str = 'def
     """
     Registers a node to the given category. If no section is given, the
     node is put into the default section that does always exist.
+
+    Warning: Make sure that this function is not called multiple times per node!
     """
     global nodes
 

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -491,6 +491,15 @@ def add_node(node_type: Type[bpy.types.Node], category: str, section: str = 'def
     node_type.bl_icon = node_category.icon
 
 
+def reset_globals():
+    global nodes
+    global category_items
+    global array_nodes
+    nodes = []
+    category_items = OrderedDict()
+    array_nodes = dict()
+
+
 bpy.utils.register_class(ArmNodeSearch)
 bpy.utils.register_class(ArmNodeAddInputButton)
 bpy.utils.register_class(ArmNodeAddInputValueButton)

--- a/blender/arm/logicnode/array/LN_array.py
+++ b/blender/arm/logicnode/array/LN_array.py
@@ -5,6 +5,7 @@ class ArrayNode(ArmLogicTreeNode):
     bl_idname = 'LNArrayNode'
     bl_label = 'Array Dynamic'
     arm_version = 1
+    arm_section = 'variable'
 
     def __init__(self):
         array_nodes[str(id(self))] = self
@@ -22,5 +23,3 @@ class ArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketShader'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(ArrayNode, category=PKG_AS_CATEGORY, section='variable')

--- a/blender/arm/logicnode/array/LN_array_add.py
+++ b/blender/arm/logicnode/array/LN_array_add.py
@@ -32,5 +32,3 @@ class ArrayAddNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketShader'
         op2 = row.operator('arm.node_remove_input_value', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(ArrayAddNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_boolean.py
+++ b/blender/arm/logicnode/array/LN_array_boolean.py
@@ -5,6 +5,7 @@ class BooleanArrayNode(ArmLogicTreeNode):
     bl_idname = 'LNArrayBooleanNode'
     bl_label = 'Array Boolean'
     arm_version = 1
+    arm_section = 'variable'
 
     def __init__(self):
         array_nodes[str(id(self))] = self
@@ -22,5 +23,3 @@ class BooleanArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketBool'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(BooleanArrayNode, category=PKG_AS_CATEGORY, section='variable')

--- a/blender/arm/logicnode/array/LN_array_color.py
+++ b/blender/arm/logicnode/array/LN_array_color.py
@@ -5,6 +5,7 @@ class ColorArrayNode(ArmLogicTreeNode):
     bl_idname = 'LNArrayColorNode'
     bl_label = 'Array Color'
     arm_version = 1
+    arm_section = 'variable'
 
     def __init__(self):
         array_nodes[str(id(self))] = self
@@ -22,5 +23,3 @@ class ColorArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketColor'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(ColorArrayNode, category=PKG_AS_CATEGORY, section='variable')

--- a/blender/arm/logicnode/array/LN_array_contains.py
+++ b/blender/arm/logicnode/array/LN_array_contains.py
@@ -11,5 +11,3 @@ class ArrayContainsNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketArray', 'Array')
         self.add_input('NodeSocketShader', 'Value')
         self.add_output('NodeSocketBool', 'Contains')
-
-add_node(ArrayContainsNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_float.py
+++ b/blender/arm/logicnode/array/LN_array_float.py
@@ -5,6 +5,7 @@ class FloatArrayNode(ArmLogicTreeNode):
     bl_idname = 'LNArrayFloatNode'
     bl_label = 'Array Float'
     arm_version = 1
+    arm_section = 'variable'
 
     def __init__(self):
         array_nodes[str(id(self))] = self
@@ -22,5 +23,3 @@ class FloatArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketFloat'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(FloatArrayNode, category=PKG_AS_CATEGORY, section='variable')

--- a/blender/arm/logicnode/array/LN_array_get.py
+++ b/blender/arm/logicnode/array/LN_array_get.py
@@ -11,5 +11,3 @@ class ArrayGetNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketArray', 'Array')
         self.add_input('NodeSocketInt', 'Index')
         self.add_output('NodeSocketShader', 'Value')
-
-add_node(ArrayGetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_integer.py
+++ b/blender/arm/logicnode/array/LN_array_integer.py
@@ -5,6 +5,7 @@ class IntegerArrayNode(ArmLogicTreeNode):
     bl_idname = 'LNArrayIntegerNode'
     bl_label = 'Array Integer'
     arm_version = 1
+    arm_section = 'variable'
 
     def __init__(self):
         array_nodes[str(id(self))] = self
@@ -22,5 +23,3 @@ class IntegerArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketInt'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(IntegerArrayNode, category=PKG_AS_CATEGORY, section='variable')

--- a/blender/arm/logicnode/array/LN_array_length.py
+++ b/blender/arm/logicnode/array/LN_array_length.py
@@ -10,5 +10,3 @@ class ArrayLengthNode(ArmLogicTreeNode):
         super(ArrayLengthNode, self).init(context)
         self.add_input('ArmNodeSocketArray', 'Array')
         self.add_output('NodeSocketInt', 'Length')
-
-add_node(ArrayLengthNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_loop_node.py
+++ b/blender/arm/logicnode/array/LN_array_loop_node.py
@@ -15,6 +15,3 @@ class ArrayLoopNode(ArmLogicTreeNode):
         self.add_output('NodeSocketShader', 'Value')
         self.add_output('NodeSocketInt', 'Index')
         self.add_output('ArmNodeSocketAction', 'Done')
-
-
-add_node(ArrayLoopNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_object.py
+++ b/blender/arm/logicnode/array/LN_array_object.py
@@ -5,6 +5,7 @@ class ObjectArrayNode(ArmLogicTreeNode):
     bl_idname = 'LNArrayObjectNode'
     bl_label = 'Array Object'
     arm_version = 1
+    arm_section = 'variable'
 
     def __init__(self):
         array_nodes[str(id(self))] = self
@@ -22,5 +23,3 @@ class ObjectArrayNode(ArmLogicTreeNode):
         op.socket_type = 'ArmNodeSocketObject'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(ObjectArrayNode, category=PKG_AS_CATEGORY, section='variable')

--- a/blender/arm/logicnode/array/LN_array_pop.py
+++ b/blender/arm/logicnode/array/LN_array_pop.py
@@ -12,5 +12,3 @@ class ArrayPopNode(ArmLogicTreeNode):
         super(ArrayPopNode, self).init(context)
         self.add_input('ArmNodeSocketArray', 'Array')
         self.add_output('NodeSocketShader', 'Value')
-
-add_node(ArrayPopNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_remove_index.py
+++ b/blender/arm/logicnode/array/LN_array_remove_index.py
@@ -15,5 +15,3 @@ class ArrayRemoveIndexNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'Index')
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('NodeSocketShader', 'Value')
-
-add_node(ArrayRemoveIndexNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_remove_value.py
+++ b/blender/arm/logicnode/array/LN_array_remove_value.py
@@ -27,5 +27,3 @@ class ArrayRemoveValueNode(ArmLogicTreeNode):
     #     op.socket_type = 'NodeSocketShader'
     #     op2 = row.operator('arm.node_remove_input_value', text='', icon='X', emboss=True)
     #     op2.node_index = str(id(self))
-
-add_node(ArrayRemoveValueNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_set.py
+++ b/blender/arm/logicnode/array/LN_array_set.py
@@ -13,5 +13,3 @@ class ArraySetNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'Index')
         self.add_input('NodeSocketShader', 'Value')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ArraySetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_shift.py
+++ b/blender/arm/logicnode/array/LN_array_shift.py
@@ -12,5 +12,3 @@ class ArrayShiftNode(ArmLogicTreeNode):
         super(ArrayShiftNode, self).init(context)
         self.add_input('ArmNodeSocketArray', 'Array')
         self.add_output('NodeSocketShader', 'Value')
-
-add_node(ArrayShiftNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_slice.py
+++ b/blender/arm/logicnode/array/LN_array_slice.py
@@ -14,5 +14,3 @@ class ArraySliceNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'Index')
         self.add_input('NodeSocketInt', 'End')
         self.add_output('ArmNodeSocketArray', 'Array')
-
-add_node(ArraySliceNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_splice.py
+++ b/blender/arm/logicnode/array/LN_array_splice.py
@@ -15,5 +15,3 @@ class ArraySpliceNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'Index')
         self.add_input('NodeSocketInt', 'Length')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ArraySpliceNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/array/LN_array_string.py
+++ b/blender/arm/logicnode/array/LN_array_string.py
@@ -5,6 +5,7 @@ class StringArrayNode(ArmLogicTreeNode):
     bl_idname = 'LNArrayStringNode'
     bl_label = 'Array String'
     arm_version = 1
+    arm_section = 'variable'
 
     def __init__(self):
         array_nodes[str(id(self))] = self
@@ -22,5 +23,3 @@ class StringArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketString'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(StringArrayNode, category=PKG_AS_CATEGORY, section='variable')

--- a/blender/arm/logicnode/array/LN_array_vector.py
+++ b/blender/arm/logicnode/array/LN_array_vector.py
@@ -5,6 +5,7 @@ class VectorArrayNode(ArmLogicTreeNode):
     bl_idname = 'LNArrayVectorNode'
     bl_label = 'Array Vector'
     arm_version = 1
+    arm_section = 'variable'
 
     def __init__(self):
         array_nodes[str(id(self))] = self
@@ -22,5 +23,3 @@ class VectorArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketVector'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(VectorArrayNode, category=PKG_AS_CATEGORY, section='variable')

--- a/blender/arm/logicnode/camera/LN_get_camera_active.py
+++ b/blender/arm/logicnode/camera/LN_get_camera_active.py
@@ -11,5 +11,3 @@ class ActiveCameraNode(ArmLogicTreeNode):
     def init(self, context):
         super(ActiveCameraNode, self).init(context)
         self.add_output('ArmNodeSocketObject', 'Camera')
-
-add_node(ActiveCameraNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/camera/LN_get_camera_fov.py
+++ b/blender/arm/logicnode/camera/LN_get_camera_fov.py
@@ -12,5 +12,3 @@ class GetCameraFovNode(ArmLogicTreeNode):
         super(GetCameraFovNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('NodeSocketFloat', 'FOV')
-
-add_node(GetCameraFovNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/camera/LN_set_camera_active.py
+++ b/blender/arm/logicnode/camera/LN_set_camera_active.py
@@ -13,5 +13,3 @@ class SetCameraNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Camera')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetCameraNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/camera/LN_set_camera_fov.py
+++ b/blender/arm/logicnode/camera/LN_set_camera_fov.py
@@ -14,5 +14,3 @@ class SetCameraFovNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Camera')
         self.add_input('NodeSocketFloat', 'FOV', default_value=0.85)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetCameraFovNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_get_canvas_checkbox.py
+++ b/blender/arm/logicnode/canvas/LN_get_canvas_checkbox.py
@@ -10,5 +10,3 @@ class CanvasGetCheckboxNode(ArmLogicTreeNode):
         super(CanvasGetCheckboxNode, self).init(context)
         self.add_input('NodeSocketString', 'Element')
         self.add_output('NodeSocketBool', 'Is Checked')
-
-add_node(CanvasGetCheckboxNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_get_canvas_input_text.py
+++ b/blender/arm/logicnode/canvas/LN_get_canvas_input_text.py
@@ -10,5 +10,3 @@ class CanvasGetInputTextNode(ArmLogicTreeNode):
         super(CanvasGetInputTextNode, self).init(context)
         self.add_input('NodeSocketString', 'Element')
         self.add_output('NodeSocketString', 'Text')
-
-add_node(CanvasGetInputTextNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_get_canvas_location.py
+++ b/blender/arm/logicnode/canvas/LN_get_canvas_location.py
@@ -13,5 +13,3 @@ class CanvasGetLocationNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('NodeSocketInt', 'X')
         self.add_output('NodeSocketInt', 'Y')
-
-add_node(CanvasGetLocationNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_get_canvas_position.py
+++ b/blender/arm/logicnode/canvas/LN_get_canvas_position.py
@@ -10,5 +10,3 @@ class CanvasGetPositionNode(ArmLogicTreeNode):
         super(CanvasGetPositionNode, self).init(context)
         self.add_input('NodeSocketString', 'Element')
         self.add_output('NodeSocketInt', 'Position')
-
-add_node(CanvasGetPositionNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_get_canvas_progress_bar.py
+++ b/blender/arm/logicnode/canvas/LN_get_canvas_progress_bar.py
@@ -13,5 +13,3 @@ class CanvasGetPBNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('NodeSocketInt', 'At')
         self.add_output('NodeSocketInt', 'Max')
-
-add_node(CanvasGetPBNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_get_canvas_rotation.py
+++ b/blender/arm/logicnode/canvas/LN_get_canvas_rotation.py
@@ -12,5 +12,3 @@ class CanvasGetRotationNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Element')
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('NodeSocketFloat', 'Rad')
-
-add_node(CanvasGetRotationNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_get_canvas_scale.py
+++ b/blender/arm/logicnode/canvas/LN_get_canvas_scale.py
@@ -13,5 +13,3 @@ class CanvasGetScaleNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('NodeSocketInt', 'Height')
         self.add_output('NodeSocketInt', 'Width')
-
-add_node(CanvasGetScaleNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_get_canvas_slider.py
+++ b/blender/arm/logicnode/canvas/LN_get_canvas_slider.py
@@ -10,5 +10,3 @@ class CanvasGetSliderNode(ArmLogicTreeNode):
         super(CanvasGetSliderNode, self).init(context)
         self.add_input('NodeSocketString', 'Element')
         self.add_output('NodeSocketFloat', 'Float')
-
-add_node(CanvasGetSliderNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_get_canvas_visible.py
+++ b/blender/arm/logicnode/canvas/LN_get_canvas_visible.py
@@ -13,5 +13,3 @@ class CanvasGetVisibleNode(ArmLogicTreeNode):
         super(CanvasGetVisibleNode, self).init(context)
         self.inputs.new('NodeSocketString', 'Element')
         self.outputs.new('NodeSocketBool', 'Is Visible')
-
-add_node(CanvasGetVisibleNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_on_canvas_element.py
+++ b/blender/arm/logicnode/canvas/LN_on_canvas_element.py
@@ -32,5 +32,3 @@ class OnCanvasElementNode(ArmLogicTreeNode):
         if self.property0 == "click":
             layout.prop(self, 'property1')
             layout.prop(self, 'property2')
-
-add_node(OnCanvasElementNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_asset.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_asset.py
@@ -12,5 +12,3 @@ class CanvasSetAssetNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Element')
         self.add_input('NodeSocketString', 'Asset')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetAssetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_checkbox.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_checkbox.py
@@ -12,5 +12,3 @@ class CanvasSetCheckBoxNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Element')
         self.add_input('NodeSocketBool', 'Check')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetCheckBoxNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_location.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_location.py
@@ -13,5 +13,3 @@ class CanvasSetLocationNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'X')
         self.add_input('NodeSocketFloat', 'Y')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetLocationNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_progress_bar.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_progress_bar.py
@@ -13,5 +13,3 @@ class CanvasSetPBNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'At')
         self.add_input('NodeSocketInt', 'Max')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetPBNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_rotation.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_rotation.py
@@ -12,5 +12,3 @@ class CanvasSetRotationNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Element')
         self.add_input('NodeSocketFloat', 'Rad')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetRotationNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_scale.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_scale.py
@@ -13,5 +13,3 @@ class CanvasSetScaleNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'Height')
         self.add_input('NodeSocketInt', 'Width')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetScaleNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_slider.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_slider.py
@@ -12,5 +12,3 @@ class CanvasSetSliderNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Element')
         self.add_input('NodeSocketFloat', 'Float')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetSliderNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_text.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_text.py
@@ -12,5 +12,3 @@ class CanvasSetTextNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Element')
         self.add_input('NodeSocketString', 'Text')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetTextNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_text_color.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_text_color.py
@@ -15,5 +15,3 @@ class CanvasSetTextColorNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'B')
         self.add_input('NodeSocketFloat', 'A')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetTextColorNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/canvas/LN_set_canvas_visible.py
+++ b/blender/arm/logicnode/canvas/LN_set_canvas_visible.py
@@ -12,5 +12,3 @@ class CanvasSetVisibleNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Element')
         self.add_input('NodeSocketBool', 'Visible')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CanvasSetVisibleNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/deprecated/LN_get_mouse_lock.py
+++ b/blender/arm/logicnode/deprecated/LN_get_mouse_lock.py
@@ -10,6 +10,9 @@ class GetMouseLockNode(ArmLogicTreeNode):
     bl_description = "Please use the \"Get Cursor State\" node instead"
     bl_icon = 'ERROR'
     arm_version = 2
+    arm_category = 'input'
+    arm_section = 'mouse'
+    arm_is_obsolete = True
 
     def init(self, context):
         super(GetMouseLockNode, self).init(context)
@@ -23,5 +26,3 @@ class GetMouseLockNode(ArmLogicTreeNode):
             'LNGetMouseLockNode', self.arm_version, 'LNGetCursorStateNode', 1,
             in_socket_mapping = {}, out_socket_mapping={0:2}
         )
-
-add_node(GetMouseLockNode, category='input', section='mouse', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_get_mouse_visible.py
+++ b/blender/arm/logicnode/deprecated/LN_get_mouse_visible.py
@@ -8,7 +8,10 @@ class GetMouseVisibleNode(ArmLogicTreeNode):
     bl_idname = 'LNGetMouseVisibleNode'
     bl_label = 'Get Mouse Visible (Deprecated)'
     bl_description = "Please use the \"Get Cursor State\" node instead"
-    bl_icon='ERROR'
+    bl_icon = 'ERROR'
+    arm_category = 'input'
+    arm_section = 'mouse'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -26,5 +29,3 @@ class GetMouseVisibleNode(ArmLogicTreeNode):
             node_tree.links.new(secondnode.outputs[0], link.to_socket)
 
         return [mainnode, secondnode]
-
-add_node(GetMouseVisibleNode, category='input', section='mouse', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_mouse_coords.py
+++ b/blender/arm/logicnode/deprecated/LN_mouse_coords.py
@@ -6,6 +6,9 @@ class MouseCoordsNode(ArmLogicTreeNode):
     bl_label = 'Mouse Coords (Deprecated)'
     bl_description = "Please use the \"Get Cursor Location\" and \"Get Mouse Movement\" nodes instead"
     bl_icon = 'ERROR'
+    arm_category = 'input'
+    arm_section = 'mouse'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -46,5 +49,3 @@ class MouseCoordsNode(ArmLogicTreeNode):
                 node_tree.links.new(newmain.outputs[2], link.to_socket)
 
         return all_new_nodes
-
-add_node(MouseCoordsNode, category='input', section='mouse', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_on_gamepad.py
+++ b/blender/arm/logicnode/deprecated/LN_on_gamepad.py
@@ -6,6 +6,9 @@ class OnGamepadNode(ArmLogicTreeNode):
     bl_label = "On Gamepad (Deprecated)"
     bl_description = "Please use the \"Gamepad\" node instead"
     bl_icon = 'ERROR'
+    arm_category = 'input'
+    arm_section = 'gamepad'
+    arm_is_obsolete = True
     arm_version = 2
 
     property0: EnumProperty(
@@ -56,5 +59,3 @@ class OnGamepadNode(ArmLogicTreeNode):
             in_socket_mapping={0: 0}, out_socket_mapping={0: 0},
             property_mapping={"property0": "property0", "property1": "property1"}
         )
-
-add_node(OnGamepadNode, category='input', section='gamepad', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_on_keyboard.py
+++ b/blender/arm/logicnode/deprecated/LN_on_keyboard.py
@@ -6,6 +6,9 @@ class OnKeyboardNode(ArmLogicTreeNode):
     bl_label = "On Keyboard (Deprecated)"
     bl_descrition = "Please use the \"Keyboard\" node instead"
     bl_icon = 'ERROR'
+    arm_category = 'input'
+    arm_section = 'keyboard'
+    arm_is_obsolete = True
     arm_version = 2
 
     property0: EnumProperty(
@@ -87,5 +90,3 @@ class OnKeyboardNode(ArmLogicTreeNode):
             in_socket_mapping={}, out_socket_mapping={0: 0},
             property_mapping={"property0": "property0", "property1": "property1"}
         )
-
-add_node(OnKeyboardNode, category='input', section='keyboard', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_on_mouse.py
+++ b/blender/arm/logicnode/deprecated/LN_on_mouse.py
@@ -6,6 +6,9 @@ class OnMouseNode(ArmLogicTreeNode):
     bl_label = "On Mouse (Deprecated)"
     bl_description = "Please use the \"Mouse\" node instead"
     bl_icon = 'ERROR'
+    arm_category = 'input'
+    arm_section = 'mouse'
+    arm_is_obsolete = True
     arm_version = 2
 
     property0: EnumProperty(
@@ -38,5 +41,3 @@ class OnMouseNode(ArmLogicTreeNode):
             in_socket_mapping={}, out_socket_mapping={0: 0},
             property_mapping={"property0": "property0", "property1": "property1"}
         )
-
-add_node(OnMouseNode, category='input', section='mouse', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_on_surface.py
+++ b/blender/arm/logicnode/deprecated/LN_on_surface.py
@@ -6,6 +6,9 @@ class OnSurfaceNode(ArmLogicTreeNode):
     bl_label = 'On Surface'
     bl_description = "Please use the \"Surface\" node instead"
     bl_icon = 'ERROR'
+    arm_category = 'input'
+    arm_section = 'surface'
+    arm_is_obsolete = True
     arm_version = 2
     property0: EnumProperty(
         items = [('Touched', 'Touched', 'Touched'),
@@ -20,5 +23,3 @@ class OnSurfaceNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(OnSurfaceNode, category=PKG_AS_CATEGORY, section='surface', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_on_virtual_button.py
+++ b/blender/arm/logicnode/deprecated/LN_on_virtual_button.py
@@ -6,6 +6,8 @@ class OnVirtualButtonNode(ArmLogicTreeNode):
     bl_label = 'On Virtual Button'
     bl_description = "Please use the \"Virtual Button\" node instead"
     bl_icon = 'ERROR'
+    arm_section = 'virtual'
+    arm_is_obsolete = True
     arm_version = 2
     property0: EnumProperty(
         items = [('Down', 'Down', 'Down'),
@@ -21,5 +23,3 @@ class OnVirtualButtonNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
-
-add_node(OnVirtualButtonNode, category=PKG_AS_CATEGORY, section='virtual', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_pause_action.py
+++ b/blender/arm/logicnode/deprecated/LN_pause_action.py
@@ -6,6 +6,7 @@ class PauseActionNode(ArmLogicTreeNode):
     bl_label = 'Pause Action'
     bl_description = "Please use the \"Set Action Paused\" node instead"
     bl_icon = 'ERROR'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -13,5 +14,3 @@ class PauseActionNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(PauseActionNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_pause_tilesheet.py
+++ b/blender/arm/logicnode/deprecated/LN_pause_tilesheet.py
@@ -6,6 +6,8 @@ class PauseTilesheetNode(ArmLogicTreeNode):
     bl_label = 'Pause Tilesheet'
     bl_description = "Please use the \"Set Tilesheet Paused\" node instead"
     bl_icon = 'ERROR'
+    arm_section = 'tilesheet'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -13,5 +15,3 @@ class PauseTilesheetNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(PauseTilesheetNode, category=PKG_AS_CATEGORY, section='tilesheet', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_pause_trait.py
+++ b/blender/arm/logicnode/deprecated/LN_pause_trait.py
@@ -6,6 +6,7 @@ class PauseTraitNode(ArmLogicTreeNode):
     bl_label = 'Pause Trait'
     bl_description = "Please use the \"Set Trait Paused\" node instead"
     bl_icon = 'ERROR'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -13,5 +14,3 @@ class PauseTraitNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketShader', 'Trait')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(PauseTraitNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_play_action.py
+++ b/blender/arm/logicnode/deprecated/LN_play_action.py
@@ -6,6 +6,7 @@ class PlayActionNode(ArmLogicTreeNode):
     bl_label = 'Play Action'
     bl_description = "Please use the \"Play Action From\" node instead"
     bl_icon = 'ERROR'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -16,5 +17,3 @@ class PlayActionNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Blend', default_value=0.2)
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Done')
-
-add_node(PlayActionNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_resume_action.py
+++ b/blender/arm/logicnode/deprecated/LN_resume_action.py
@@ -6,6 +6,7 @@ class ResumeActionNode(ArmLogicTreeNode):
     bl_label = 'Resume Action'
     bl_description = "Please use the \"Set Action Paused\" node instead"
     bl_icon = 'ERROR'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -13,5 +14,3 @@ class ResumeActionNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ResumeActionNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_resume_tilesheet.py
+++ b/blender/arm/logicnode/deprecated/LN_resume_tilesheet.py
@@ -6,6 +6,7 @@ class ResumeTilesheetNode(ArmLogicTreeNode):
     bl_label = 'Resume Tilesheet'
     bl_description = "Please use the \"Set Tilesheet Paused\" node instead"
     bl_icon = 'ERROR'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -13,5 +14,3 @@ class ResumeTilesheetNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ResumeTilesheetNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_resume_trait.py
+++ b/blender/arm/logicnode/deprecated/LN_resume_trait.py
@@ -6,6 +6,7 @@ class ResumeTraitNode(ArmLogicTreeNode):
     bl_label = 'Resume Trait'
     bl_description = "Please use the \"Set Trait Paused\" node instead"
     bl_icon = 'ERROR'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -13,5 +14,3 @@ class ResumeTraitNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketShader', 'Trait')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ResumeTraitNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_rotate_object_around_axis.py
+++ b/blender/arm/logicnode/deprecated/LN_rotate_object_around_axis.py
@@ -5,8 +5,11 @@ class RotateObjectAroundAxisNode(ArmLogicTreeNode):
     bl_idname = 'LNRotateObjectAroundAxisNode'
     bl_label = 'Rotate Object Around Axis (Deprecated)'
     bl_description = "Please use the \"Rotate Object\" node instead"
+    arm_category = 'transform'
+    arm_section = 'rotation'
+    arm_is_obsolete = True
     bl_icon = 'ERROR'
-    arm_version=2
+    arm_version = 2
 
     def init(self, context):
         super(RotateObjectAroundAxisNode, self).init(context)
@@ -25,6 +28,3 @@ class RotateObjectAroundAxisNode(ArmLogicTreeNode):
             in_socket_mapping = {0:0, 1:1, 2:2, 3:3}, out_socket_mapping={0:0},
             property_defaults={'property0': "Angle Axies (Radians)"}
         )
-
-
-add_node(RotateObjectAroundAxisNode, category='transform', section='rotation', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_scale_object.py
+++ b/blender/arm/logicnode/deprecated/LN_scale_object.py
@@ -6,6 +6,8 @@ class ScaleObjectNode(ArmLogicTreeNode):
     bl_label = 'Scale Object'
     bl_description = "Please use the \"Set Object Scale\" node instead"
     bl_icon = 'ERROR'
+    arm_section = 'scale'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -14,5 +16,3 @@ class ScaleObjectNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketVector', 'Scale')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ScaleObjectNode, category=PKG_AS_CATEGORY, section='scale', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_set_mouse_lock.py
+++ b/blender/arm/logicnode/deprecated/LN_set_mouse_lock.py
@@ -6,6 +6,9 @@ class SetMouseLockNode(ArmLogicTreeNode):
     bl_label = 'Set Mouse Lock (Deprecated)'
     bl_description = "Please use the \"Set Cursor State\" node instead"
     bl_icon = 'ERROR'
+    arm_category = 'input'
+    arm_section = 'mouse'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -23,5 +26,3 @@ class SetMouseLockNode(ArmLogicTreeNode):
             in_socket_mapping = {0:0, 1:1}, out_socket_mapping={0:0},
             property_defaults={'property0': "Lock"}
         )
-
-add_node(SetMouseLockNode, category='input', section='mouse', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_set_mouse_visible.py
+++ b/blender/arm/logicnode/deprecated/LN_set_mouse_visible.py
@@ -6,6 +6,9 @@ class ShowMouseNode(ArmLogicTreeNode):
     bl_label = "Set Mouse Visible (Deprecated)"
     bl_description = "Please use the \"Set Cursor State\" node instead"
     bl_icon = 'ERROR'
+    arm_category = 'input'
+    arm_section = 'mouse'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -39,5 +42,3 @@ class ShowMouseNode(ArmLogicTreeNode):
             node_tree.links.new(new_main.outputs[0], link.to_socket)  # Action out
 
         return [new_main, new_secondary]
-
-add_node(ShowMouseNode, category='input', section='mouse', is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_set_object_material.py
+++ b/blender/arm/logicnode/deprecated/LN_set_object_material.py
@@ -6,6 +6,7 @@ class SetMaterialNode(ArmLogicTreeNode):
     bl_label = 'Set Object Material'
     bl_description = "Please use the \"Set Object Material Slot\" node instead"
     bl_icon = 'ERROR'
+    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):
@@ -14,5 +15,3 @@ class SetMaterialNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketShader', 'Material')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetMaterialNode, category=PKG_AS_CATEGORY, is_obsolete=True)

--- a/blender/arm/logicnode/deprecated/LN_surface_coords.py
+++ b/blender/arm/logicnode/deprecated/LN_surface_coords.py
@@ -6,11 +6,12 @@ class SurfaceCoordsNode(ArmLogicTreeNode):
     bl_label = 'Surface Coords'
     bl_description = "Please use the \"Get Touch Movement\" and \"Get Touch Location\" nodes instead"
     bl_icon = 'ERROR'
+    arm_category = 'input'
+    arm_section = 'surface'
+    arm_is_obsolete = 'is_obsolete'
     arm_version = 2
 
     def init(self, context):
         super(SurfaceCoordsNode, self).init(context)
         self.add_output('NodeSocketVector', 'Coords')
         self.add_output('NodeSocketVector', 'Movement')
-
-add_node(SurfaceCoordsNode, category=PKG_AS_CATEGORY, section='surface', is_obsolete=True)

--- a/blender/arm/logicnode/event/LN_on_application_state.py
+++ b/blender/arm/logicnode/event/LN_on_application_state.py
@@ -12,6 +12,3 @@ class OnApplicationStateNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'On Foreground')
         self.add_output('ArmNodeSocketAction', 'On Background')
         self.add_output('ArmNodeSocketAction', 'On Shutdown')
-
-
-add_node(OnApplicationStateNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/event/LN_on_event.py
+++ b/blender/arm/logicnode/event/LN_on_event.py
@@ -8,6 +8,8 @@ class OnEventNode(ArmLogicTreeNode):
     bl_idname = 'LNOnEventNode'
     bl_label = 'On Event'
     arm_version = 1
+    arm_section = 'custom'
+
     property0: StringProperty(name='', default='')
 
     def init(self, context):
@@ -16,5 +18,3 @@ class OnEventNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(OnEventNode, category=PKG_AS_CATEGORY, section='custom')

--- a/blender/arm/logicnode/event/LN_on_init.py
+++ b/blender/arm/logicnode/event/LN_on_init.py
@@ -9,5 +9,3 @@ class OnInitNode(ArmLogicTreeNode):
     def init(self, context):
         super(OnInitNode, self).init(context)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(OnInitNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/event/LN_on_timer.py
+++ b/blender/arm/logicnode/event/LN_on_timer.py
@@ -14,5 +14,3 @@ class OnTimerNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Duration')
         self.add_input('NodeSocketBool', 'Repeat')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(OnTimerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/event/LN_on_update.py
+++ b/blender/arm/logicnode/event/LN_on_update.py
@@ -22,5 +22,3 @@ class OnUpdateNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(OnUpdateNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/event/LN_send_event_to_object.py
+++ b/blender/arm/logicnode/event/LN_send_event_to_object.py
@@ -10,6 +10,7 @@ class SendEventNode(ArmLogicTreeNode):
     @input Object: the receiving object"""
     bl_idname = 'LNSendEventNode'
     bl_label = 'Send Event To Object'
+    arm_section = 'custom'
     arm_version = 1
 
     def init(self, context):
@@ -18,5 +19,3 @@ class SendEventNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Event')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SendEventNode, category=PKG_AS_CATEGORY, section='custom')

--- a/blender/arm/logicnode/event/LN_send_global_event.py
+++ b/blender/arm/logicnode/event/LN_send_global_event.py
@@ -10,11 +10,10 @@ class SendGlobalEventNode(ArmLogicTreeNode):
     bl_idname = 'LNSendGlobalEventNode'
     bl_label = 'Send Global Event'
     arm_version = 1
+    arm_section = 'custom'
 
     def init(self, context):
         super(SendGlobalEventNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketString', 'Event')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SendGlobalEventNode, category=PKG_AS_CATEGORY, section='custom')

--- a/blender/arm/logicnode/input/LN_gamepad.py
+++ b/blender/arm/logicnode/input/LN_gamepad.py
@@ -13,6 +13,7 @@ class GamepadNode(ArmLogicTreeNode):
     bl_idname = 'LNMergedGamepadNode'
     bl_label = 'Gamepad'
     arm_version = 1
+    arm_section = 'gamepad'
 
     property0: EnumProperty(
         items = [('Down', 'Down', 'Down'),
@@ -52,5 +53,3 @@ class GamepadNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
-
-add_node(GamepadNode, category=PKG_AS_CATEGORY, section='gamepad')

--- a/blender/arm/logicnode/input/LN_gamepad_coords.py
+++ b/blender/arm/logicnode/input/LN_gamepad_coords.py
@@ -9,6 +9,7 @@ class GamepadCoordsNode(ArmLogicTreeNode):
     bl_idname = 'LNGamepadCoordsNode'
     bl_label = 'Gamepad Coords'
     arm_version = 1
+    arm_section = 'gamepad'
 
     def init(self, context):
         super(GamepadCoordsNode, self).init(context)
@@ -19,5 +20,3 @@ class GamepadCoordsNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'Left Trigger')
         self.add_output('NodeSocketFloat', 'Right Trigger')
         self.add_input('NodeSocketInt', 'Gamepad')
-
-add_node(GamepadCoordsNode, category=PKG_AS_CATEGORY, section='gamepad')

--- a/blender/arm/logicnode/input/LN_get_cursor_location.py
+++ b/blender/arm/logicnode/input/LN_get_cursor_location.py
@@ -4,6 +4,7 @@ class GetCursorLocationNode(ArmLogicTreeNode):
     """Returns the mouse cursor location in screen coordinates (pixels)."""
     bl_idname = 'LNGetCursorLocationNode'
     bl_label = 'Get Cursor Location'
+    arm_section = 'mouse'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class GetCursorLocationNode(ArmLogicTreeNode):
         self.add_output('NodeSocketInt', 'Y')
         self.add_output('NodeSocketInt', 'Inverted X')
         self.add_output('NodeSocketInt', 'Inverted Y')
-
-add_node(GetCursorLocationNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_get_cursor_state.py
+++ b/blender/arm/logicnode/input/LN_get_cursor_state.py
@@ -13,6 +13,7 @@ class GetCursorStateNode(ArmLogicTreeNode):
     @output Is Locked: `true` if the mouse cursor is locked."""
     bl_idname = 'LNGetCursorStateNode'
     bl_label = 'Get Cursor State'
+    arm_section = 'mouse'
     arm_version = 1
 
     def init(self, context):
@@ -20,5 +21,3 @@ class GetCursorStateNode(ArmLogicTreeNode):
         self.outputs.new('NodeSocketBool', 'Is Hidden Locked')
         self.outputs.new('NodeSocketBool', 'Is Hidden')
         self.outputs.new('NodeSocketBool', 'Is Locked')
-
-add_node(GetCursorStateNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_get_mouse_movement.py
+++ b/blender/arm/logicnode/input/LN_get_mouse_movement.py
@@ -4,6 +4,7 @@ class GetMouseMovementNode(ArmLogicTreeNode):
     """Returns the movement coordinates of the mouse."""
     bl_idname = 'LNGetMouseMovementNode'
     bl_label = 'Get Mouse Movement'
+    arm_section = 'mouse'
     arm_version = 1
 
     def init(self, context):
@@ -17,5 +18,3 @@ class GetMouseMovementNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'Multiplied X')
         self.add_output('NodeSocketFloat', 'Multiplied Y')
         self.add_output('NodeSocketFloat', 'Multiplied Delta')
-
-add_node(GetMouseMovementNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_get_touch_location.py
+++ b/blender/arm/logicnode/input/LN_get_touch_location.py
@@ -4,6 +4,7 @@ class GetTouchLocationNode(ArmLogicTreeNode):
     """Returns the location of the last touch event in screen coordinates (pixels)."""
     bl_idname = 'LNGetTouchLocationNode'
     bl_label = 'Get Touch Location'
+    arm_section = 'surface'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class GetTouchLocationNode(ArmLogicTreeNode):
         self.add_output('NodeSocketInt', 'Y')
         self.add_output('NodeSocketInt', 'Inverted X')
         self.add_output('NodeSocketInt', 'Inverted Y')
-
-add_node(GetTouchLocationNode, category=PKG_AS_CATEGORY, section='surface')

--- a/blender/arm/logicnode/input/LN_get_touch_movement.py
+++ b/blender/arm/logicnode/input/LN_get_touch_movement.py
@@ -4,6 +4,7 @@ class GetTouchMovementNode(ArmLogicTreeNode):
     """Returns the movement values of the current touch event."""
     bl_idname = 'LNGetTouchMovementNode'
     bl_label = 'Get Touch Movement'
+    arm_section = 'surface'
     arm_version = 1
 
     def init(self, context):
@@ -14,5 +15,3 @@ class GetTouchMovementNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'Y')
         self.add_output('NodeSocketFloat', 'Multiplied X')
         self.add_output('NodeSocketFloat', 'Multiplied Y')
-
-add_node(GetTouchMovementNode, category=PKG_AS_CATEGORY, section='surface')

--- a/blender/arm/logicnode/input/LN_keyboard.py
+++ b/blender/arm/logicnode/input/LN_keyboard.py
@@ -4,6 +4,7 @@ class KeyboardNode(ArmLogicTreeNode):
     """Activates the output when the given keyboard action is done."""
     bl_idname = 'LNMergedKeyboardNode'
     bl_label = 'Keyboard'
+    arm_section = 'keyboard'
     arm_version = 1
 
     property0: EnumProperty(
@@ -76,4 +77,3 @@ class KeyboardNode(ArmLogicTreeNode):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
 
-add_node(KeyboardNode, category=PKG_AS_CATEGORY, section='keyboard')

--- a/blender/arm/logicnode/input/LN_mouse.py
+++ b/blender/arm/logicnode/input/LN_mouse.py
@@ -4,7 +4,9 @@ class MouseNode(ArmLogicTreeNode):
     """Activates the output when the given mouse action is done."""
     bl_idname = 'LNMergedMouseNode'
     bl_label = 'Mouse'
+    arm_section = 'mouse'
     arm_version = 1
+
     property0: EnumProperty(
         items = [('Down', 'Down', 'Down'),
                  ('Started', 'Started', 'Started'),
@@ -25,5 +27,3 @@ class MouseNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
-
-add_node(MouseNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_on_swipe.py
+++ b/blender/arm/logicnode/input/LN_on_swipe.py
@@ -49,6 +49,7 @@ class OnSwipeNode(ArmLogicTreeNode):
     bl_idname = 'LNOnSwipeNode'
     bl_label = 'On Swipe'
     arm_version = 1
+    arm_section = 'Input'
     min_outputs = 4
     max_outputs = 12
 
@@ -84,9 +85,14 @@ class OnSwipeNode(ArmLogicTreeNode):
         if (len(self.outputs) == self.min_outputs):
             column.enabled = False
 
-# Register custom class
-bpy.utils.register_class(NodeAddOutputButton)
-bpy.utils.register_class(NodeRemoveOutputButton)
+    @classmethod
+    def on_register(cls):
+        bpy.utils.register_class(NodeAddOutputButton)
+        bpy.utils.register_class(NodeRemoveOutputButton)
+        super().on_register()
 
-# Add Node
-add_node(OnSwipeNode, category=PKG_AS_CATEGORY, section='Input')
+    @classmethod
+    def on_unregister(cls):
+        super().on_unregister()
+        bpy.utils.unregister_class(NodeRemoveOutputButton)
+        bpy.utils.unregister_class(NodeAddOutputButton)

--- a/blender/arm/logicnode/input/LN_on_tap_screen.py
+++ b/blender/arm/logicnode/input/LN_on_tap_screen.py
@@ -5,6 +5,7 @@ class OnTapScreen(ArmLogicTreeNode):
     """Activates the output when the given tap action is done."""
     bl_idname = 'LNOnTapScreen'
     bl_label = 'On Tap Screen'
+    arm_section = 'Input'
     arm_version = 1
 
     def init(self, context):
@@ -20,6 +21,3 @@ class OnTapScreen(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Tap')
         self.add_output('NodeSocketInt', 'Tap Number')
         self.add_output('NodeSocketVector', 'Coords')
-
-# Add Node
-add_node(OnTapScreen, category=PKG_AS_CATEGORY, section='Input')

--- a/blender/arm/logicnode/input/LN_sensor_coords.py
+++ b/blender/arm/logicnode/input/LN_sensor_coords.py
@@ -4,10 +4,9 @@ class SensorCoordsNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNSensorCoordsNode'
     bl_label = 'Sensor Coords'
+    arm_section = 'sensor'
     arm_version = 1
 
     def init(self, context):
         super(SensorCoordsNode, self).init(context)
         self.add_output('NodeSocketVector', 'Coords')
-
-add_node(SensorCoordsNode, category=PKG_AS_CATEGORY, section='sensor')

--- a/blender/arm/logicnode/input/LN_set_cursor_state.py
+++ b/blender/arm/logicnode/input/LN_set_cursor_state.py
@@ -10,6 +10,7 @@ class SetCursorStateNode(ArmLogicTreeNode):
     @output Lock: lock/unlock the mouse cursor."""
     bl_idname = 'LNSetCursorStateNode'
     bl_label = 'Set Cursor State'
+    arm_section = 'mouse'
     arm_version = 1
 
     property0: EnumProperty(
@@ -28,4 +29,3 @@ class SetCursorStateNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
 
-add_node(SetCursorStateNode, category=PKG_AS_CATEGORY, section='mouse')

--- a/blender/arm/logicnode/input/LN_surface.py
+++ b/blender/arm/logicnode/input/LN_surface.py
@@ -4,7 +4,9 @@ class SurfaceNode(ArmLogicTreeNode):
     """Activates the output when the given action over the screen is done."""
     bl_idname = 'LNMergedSurfaceNode'
     bl_label = 'Surface'
+    arm_section = 'surface'
     arm_version = 1
+
     property0: EnumProperty(
         items = [('Touched', 'Touched', 'Touched'),
                  ('Started', 'Started', 'Started'),
@@ -19,5 +21,3 @@ class SurfaceNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(SurfaceNode, category=PKG_AS_CATEGORY, section='surface')

--- a/blender/arm/logicnode/input/LN_virtual_button.py
+++ b/blender/arm/logicnode/input/LN_virtual_button.py
@@ -4,7 +4,9 @@ class VirtualButtonNode(ArmLogicTreeNode):
     """Activates the output when the given action over the virtual button is done."""
     bl_idname = 'LNMergedVirtualButtonNode'
     bl_label = 'Virtual Button'
+    arm_section = 'virtual'
     arm_version = 1
+
     property0: EnumProperty(
         items = [('Down', 'Down', 'Down'),
                  ('Started', 'Started', 'Started'),
@@ -20,5 +22,3 @@ class VirtualButtonNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
-
-add_node(VirtualButtonNode, category=PKG_AS_CATEGORY, section='virtual')

--- a/blender/arm/logicnode/light/LN_set_light_color.py
+++ b/blender/arm/logicnode/light/LN_set_light_color.py
@@ -12,5 +12,3 @@ class SetLightColorNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Light')
         self.add_input('NodeSocketColor', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetLightColorNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/light/LN_set_light_strength.py
+++ b/blender/arm/logicnode/light/LN_set_light_strength.py
@@ -12,5 +12,3 @@ class SetLightStrengthNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Light')
         self.add_input('NodeSocketFloat', 'Strength', default_value=250)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetLightStrengthNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_alternate.py
+++ b/blender/arm/logicnode/logic/LN_alternate.py
@@ -5,6 +5,7 @@ class AlternateNode(ArmLogicTreeNode):
     """Activates the outputs "0" and "1" alternating every time it is active."""
     bl_idname = 'LNAlternateNode'
     bl_label = 'Alternate'
+    arm_section = 'flow'
     arm_version = 1
 
     def init(self, context):
@@ -12,6 +13,3 @@ class AlternateNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_output('ArmNodeSocketAction', '0')
         self.add_output('ArmNodeSocketAction', '1')
-
-
-add_node(AlternateNode, category=PKG_AS_CATEGORY, section='flow')

--- a/blender/arm/logicnode/logic/LN_branch.py
+++ b/blender/arm/logicnode/logic/LN_branch.py
@@ -14,6 +14,3 @@ class BranchNode(ArmLogicTreeNode):
         self.add_input('NodeSocketBool', 'Bool')
         self.add_output('ArmNodeSocketAction', 'True')
         self.add_output('ArmNodeSocketAction', 'False')
-
-
-add_node(BranchNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_call_function.py
+++ b/blender/arm/logicnode/logic/LN_call_function.py
@@ -5,6 +5,7 @@ class CallFunctionNode(ArmLogicTreeNode):
     bl_idname = 'LNCallFunctionNode'
     bl_label = 'Call Function'
     bl_description = 'Calls a function that was created by the Function node.'
+    arm_section = 'function'
     arm_version = 1
     min_inputs = 3
 
@@ -28,5 +29,3 @@ class CallFunctionNode(ArmLogicTreeNode):
         op.index_name_offset = -2
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(CallFunctionNode, category=PKG_AS_CATEGORY, section='function')

--- a/blender/arm/logicnode/logic/LN_function.py
+++ b/blender/arm/logicnode/logic/LN_function.py
@@ -7,6 +7,7 @@ class FunctionNode(ArmLogicTreeNode):
     bl_idname = 'LNFunctionNode'
     bl_label = 'Function'
     bl_description = 'Creates a reusable function that can be called by the Call Function node'
+    arm_section = 'function'
     arm_version = 1
     min_outputs = 1
 
@@ -31,5 +32,3 @@ class FunctionNode(ArmLogicTreeNode):
         op2 = row.operator('arm.node_remove_output', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
 
-
-add_node(FunctionNode, category=PKG_AS_CATEGORY, section='function')

--- a/blender/arm/logicnode/logic/LN_function_output.py
+++ b/blender/arm/logicnode/logic/LN_function_output.py
@@ -7,6 +7,7 @@ class FunctionOutputNode(ArmLogicTreeNode):
     @seeNode Function"""
     bl_idname = 'LNFunctionOutputNode'
     bl_label = 'Function Output'
+    arm_section = 'function'
     arm_version = 1
 
     def init(self, context):
@@ -19,6 +20,3 @@ class FunctionOutputNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         row = layout.row(align=True)
         row.prop(self, 'function_name')
-
-
-add_node(FunctionOutputNode, category=PKG_AS_CATEGORY, section='function')

--- a/blender/arm/logicnode/logic/LN_gate.py
+++ b/blender/arm/logicnode/logic/LN_gate.py
@@ -57,6 +57,3 @@ class GateNode(ArmLogicTreeNode):
             op.socket_type = 'NodeSocketShader'
             op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
             op2.node_index = str(id(self))
-
-
-add_node(GateNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_invert_boolean.py
+++ b/blender/arm/logicnode/logic/LN_invert_boolean.py
@@ -10,5 +10,3 @@ class NotNode(ArmLogicTreeNode):
         super(NotNode, self).init(context)
         self.add_input('NodeSocketBool', 'Bool In')
         self.add_output('NodeSocketBool', 'Bool Out')
-
-add_node(NotNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_invert_output.py
+++ b/blender/arm/logicnode/logic/LN_invert_output.py
@@ -5,12 +5,10 @@ class InverseNode(ArmLogicTreeNode):
     """Activates the output if the input is not active."""
     bl_idname = 'LNInverseNode'
     bl_label = 'Invert Output'
+    arm_section = 'flow'
     arm_version = 1
 
     def init(self, context):
         super(InverseNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-
-add_node(InverseNode, category=PKG_AS_CATEGORY, section='flow')

--- a/blender/arm/logicnode/logic/LN_is_false.py
+++ b/blender/arm/logicnode/logic/LN_is_false.py
@@ -15,6 +15,3 @@ class IsFalseNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketBool', 'Bool')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-
-add_node(IsFalseNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_is_none.py
+++ b/blender/arm/logicnode/logic/LN_is_none.py
@@ -15,6 +15,3 @@ class IsNoneNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketShader', 'Value')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-
-add_node(IsNoneNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_is_not_none.py
+++ b/blender/arm/logicnode/logic/LN_is_not_none.py
@@ -14,5 +14,3 @@ class IsNotNoneNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketShader', 'Value')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(IsNotNoneNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_is_true.py
+++ b/blender/arm/logicnode/logic/LN_is_true.py
@@ -14,5 +14,3 @@ class IsTrueNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketBool', 'Bool')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(IsTrueNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_loop.py
+++ b/blender/arm/logicnode/logic/LN_loop.py
@@ -17,6 +17,7 @@ class LoopNode(ArmLogicTreeNode):
     bl_idname = 'LNLoopNode'
     bl_label = 'Loop'
     bl_description = 'Resembles a for-loop that is executed at once when this node is activated'
+    arm_section = 'flow'
     arm_version = 1
 
     def init(self, context):
@@ -27,5 +28,3 @@ class LoopNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Loop')
         self.add_output('NodeSocketInt', 'Index')
         self.add_output('ArmNodeSocketAction', 'Done')
-
-add_node(LoopNode, category=PKG_AS_CATEGORY, section='flow')

--- a/blender/arm/logicnode/logic/LN_loop_break.py
+++ b/blender/arm/logicnode/logic/LN_loop_break.py
@@ -9,10 +9,9 @@ class LoopBreakNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNLoopBreakNode'
     bl_label = 'Loop Break'
+    arm_section = 'flow'
     arm_version = 1
 
     def init(self, context):
         super(LoopBreakNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-
-add_node(LoopBreakNode, category=PKG_AS_CATEGORY, section='flow')

--- a/blender/arm/logicnode/logic/LN_merge.py
+++ b/blender/arm/logicnode/logic/LN_merge.py
@@ -7,6 +7,7 @@ class MergeNode(ArmLogicTreeNode):
     @option X Button: Remove the lowermost input socket."""
     bl_idname = 'LNMergeNode'
     bl_label = 'Merge'
+    arm_section = 'flow'
     arm_version = 1
 
     def __init__(self):
@@ -24,5 +25,3 @@ class MergeNode(ArmLogicTreeNode):
         op.socket_type = 'ArmNodeSocketAction'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(MergeNode, category=PKG_AS_CATEGORY, section='flow')

--- a/blender/arm/logicnode/logic/LN_none.py
+++ b/blender/arm/logicnode/logic/LN_none.py
@@ -9,5 +9,3 @@ class NoneNode(ArmLogicTreeNode):
     def init(self, context):
         super(NoneNode, self).init(context)
         self.add_output('NodeSocketShader', 'None')
-
-add_node(NoneNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_sequence.py
+++ b/blender/arm/logicnode/logic/LN_sequence.py
@@ -4,6 +4,7 @@ class SequenceNode(ArmLogicTreeNode):
     """Activates the outputs one by one sequentially and repeatedly."""
     bl_idname = 'LNSequenceNode'
     bl_label = 'Sequence'
+    arm_section = 'flow'
     arm_version = 1
 
     def __init__(self):
@@ -21,5 +22,3 @@ class SequenceNode(ArmLogicTreeNode):
         op.socket_type = 'ArmNodeSocketAction'
         op2 = row.operator('arm.node_remove_output', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(SequenceNode, category=PKG_AS_CATEGORY, section='flow')

--- a/blender/arm/logicnode/logic/LN_switch_output.py
+++ b/blender/arm/logicnode/logic/LN_switch_output.py
@@ -31,5 +31,3 @@ class SwitchNode(ArmLogicTreeNode):
         op.in_index_name_offset = -1
         op2 = row.operator('arm.node_remove_input_output', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-add_node(SwitchNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_to_boolean.py
+++ b/blender/arm/logicnode/logic/LN_to_boolean.py
@@ -11,5 +11,3 @@ class ToBoolNode(ArmLogicTreeNode):
         super(ToBoolNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_output('NodeSocketBool', 'Bool')
-
-add_node(ToBoolNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/logic/LN_while.py
+++ b/blender/arm/logicnode/logic/LN_while.py
@@ -12,6 +12,7 @@ class WhileNode(ArmLogicTreeNode):
     @output Done: Activated when the loop is done executing"""
     bl_idname = 'LNWhileNode'
     bl_label = 'While'
+    arm_section = 'flow'
     arm_version = 1
 
     def init(self, context):
@@ -20,5 +21,3 @@ class WhileNode(ArmLogicTreeNode):
         self.add_input('NodeSocketBool', 'Condition')
         self.add_output('ArmNodeSocketAction', 'Loop')
         self.add_output('ArmNodeSocketAction', 'Done')
-
-add_node(WhileNode, category=PKG_AS_CATEGORY, section='flow')

--- a/blender/arm/logicnode/material/LN_get_object_material.py
+++ b/blender/arm/logicnode/material/LN_get_object_material.py
@@ -11,5 +11,3 @@ class GetMaterialNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketInt', 'Slot')
         self.add_output('NodeSocketShader', 'Material')
-
-add_node(GetMaterialNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/material/LN_material.py
+++ b/blender/arm/logicnode/material/LN_material.py
@@ -26,5 +26,3 @@ class MaterialNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0', bpy.data, 'materials', icon='NONE', text='')
-
-add_node(MaterialNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/material/LN_set_material_image_param.py
+++ b/blender/arm/logicnode/material/LN_set_material_image_param.py
@@ -4,6 +4,7 @@ class SetMaterialImageParamNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNSetMaterialImageParamNode'
     bl_label = 'Set Material Image Param'
+    arm_section = 'params'
     arm_version = 1
 
     def init(self, context):
@@ -13,5 +14,3 @@ class SetMaterialImageParamNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Node')
         self.add_input('NodeSocketString', 'Image')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetMaterialImageParamNode, category=PKG_AS_CATEGORY, section='params')

--- a/blender/arm/logicnode/material/LN_set_material_rgb_param.py
+++ b/blender/arm/logicnode/material/LN_set_material_rgb_param.py
@@ -4,6 +4,7 @@ class SetMaterialRgbParamNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNSetMaterialRgbParamNode'
     bl_label = 'Set Material RGB Param'
+    arm_section = 'params'
     arm_version = 1
 
     def init(self, context):
@@ -13,5 +14,3 @@ class SetMaterialRgbParamNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Node')
         self.add_input('NodeSocketColor', 'Color')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetMaterialRgbParamNode, category=PKG_AS_CATEGORY, section='params')

--- a/blender/arm/logicnode/material/LN_set_material_value_param.py
+++ b/blender/arm/logicnode/material/LN_set_material_value_param.py
@@ -4,6 +4,7 @@ class SetMaterialValueParamNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNSetMaterialValueParamNode'
     bl_label = 'Set Material Value Param'
+    arm_section = 'params'
     arm_version = 1
 
     def init(self, context):
@@ -13,5 +14,3 @@ class SetMaterialValueParamNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Node')
         self.add_input('NodeSocketFloat', 'Float')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetMaterialValueParamNode, category=PKG_AS_CATEGORY, section='params')

--- a/blender/arm/logicnode/material/LN_set_object_material_slot.py
+++ b/blender/arm/logicnode/material/LN_set_object_material_slot.py
@@ -13,5 +13,3 @@ class SetMaterialSlotNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Material')
         self.add_input('NodeSocketInt', 'Slot')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetMaterialSlotNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/math/LN_compare.py
+++ b/blender/arm/logicnode/math/LN_compare.py
@@ -46,6 +46,3 @@ class CompareNode(ArmLogicTreeNode):
             op.socket_type = 'NodeSocketShader'
             op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
             op2.node_index = str(id(self))
-
-
-add_node(CompareNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/math/LN_deg_to_rad.py
+++ b/blender/arm/logicnode/math/LN_deg_to_rad.py
@@ -5,10 +5,9 @@ class DegToRadNode(ArmLogicTreeNode):
     bl_idname = 'LNDegToRadNode'
     bl_label = 'Deg to Rad'
     arm_version = 1
+    arm_section = 'angle'
 
     def init(self, context):
         super(DegToRadNode, self).init(context)
         self.add_input('NodeSocketFloat', 'Degrees')
         self.add_output('NodeSocketFloat', 'Radians')
-
-add_node(DegToRadNode, category=PKG_AS_CATEGORY, section='angle')

--- a/blender/arm/logicnode/math/LN_math.py
+++ b/blender/arm/logicnode/math/LN_math.py
@@ -49,5 +49,3 @@ class MathNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property1_')
         layout.prop(self, 'property0')
-
-add_node(MathNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/math/LN_matrix_math.py
+++ b/blender/arm/logicnode/math/LN_matrix_math.py
@@ -4,7 +4,9 @@ class MatrixMathNode(ArmLogicTreeNode):
     """Multiplies matrices."""
     bl_idname = 'LNMatrixMathNode'
     bl_label = 'Matrix Math'
+    arm_section = 'matrix'
     arm_version = 1
+
     property0: EnumProperty(
         items = [('Multiply', 'Multiply', 'Multiply')],
         name='', default='Multiply')
@@ -17,5 +19,3 @@ class MatrixMathNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(MatrixMathNode, category=PKG_AS_CATEGORY, section='matrix')

--- a/blender/arm/logicnode/math/LN_mix.py
+++ b/blender/arm/logicnode/math/LN_mix.py
@@ -41,5 +41,3 @@ class MixNode(ArmLogicTreeNode):
         layout.prop(self, 'property2_')
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
-
-add_node(MixNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/math/LN_mix_vector.py
+++ b/blender/arm/logicnode/math/LN_mix_vector.py
@@ -4,7 +4,9 @@ class VectorMixNode(ArmLogicTreeNode):
     """Interpolates between the two given vectors."""
     bl_idname = 'LNVectorMixNode'
     bl_label = 'Mix Vector'
+    arm_section = 'vector'
     arm_version = 1
+
     property0: EnumProperty(
         items = [('Linear', 'Linear', 'Linear'),
                  ('Sine', 'Sine', 'Sine'),
@@ -42,5 +44,3 @@ class VectorMixNode(ArmLogicTreeNode):
         layout.prop(self, 'property0')
         if self.property0 != 'Linear':
             layout.prop(self, 'property1')
-
-add_node(VectorMixNode, category=PKG_AS_CATEGORY, section='vector')

--- a/blender/arm/logicnode/math/LN_rad_to_deg.py
+++ b/blender/arm/logicnode/math/LN_rad_to_deg.py
@@ -5,10 +5,9 @@ class RadToDegNode(ArmLogicTreeNode):
     bl_idname = 'LNRadToDegNode'
     bl_label = 'Rad to Deg'
     arm_version = 1
+    arm_section = 'angle'
 
     def init(self, context):
         super(RadToDegNode, self).init(context)
         self.add_input('NodeSocketFloat', 'Radians')
         self.add_output('NodeSocketFloat', 'Degrees')
-
-add_node(RadToDegNode, category=PKG_AS_CATEGORY, section='angle')

--- a/blender/arm/logicnode/math/LN_screen_to_world_space.py
+++ b/blender/arm/logicnode/math/LN_screen_to_world_space.py
@@ -5,6 +5,7 @@ class ScreenToWorldSpaceNode(ArmLogicTreeNode):
     bl_idname = 'LNScreenToWorldSpaceNode'
     bl_label = 'Screen To World Space'
     node_index: StringProperty(name='Node Index', default='')
+    arm_section = 'matrix'
     arm_version = 1
     min_outputs = 2
     max_outputs = 8
@@ -13,7 +14,7 @@ class ScreenToWorldSpaceNode(ArmLogicTreeNode):
     @property
     def property0(self):
         return True if self.property0_ else False
-        
+
     property0_: BoolProperty(name='Separator Out', default=False)
 
     def init(self, context):
@@ -30,7 +31,7 @@ class ScreenToWorldSpaceNode(ArmLogicTreeNode):
                 self.outputs.remove(self.outputs.values()[-1]) # Direction vector
                 self.add_output('NodeSocketFloat', 'X') # World X
                 self.add_output('NodeSocketFloat', 'Y') # World Y
-                self.add_output('NodeSocketFloat', 'Z') # World Z 
+                self.add_output('NodeSocketFloat', 'Z') # World Z
                 self.add_output('NodeSocketVector', 'Direction') # Vector
                 self.add_output('NodeSocketFloat', 'X') # Direction X
                 self.add_output('NodeSocketFloat', 'Y') # Direction Y
@@ -45,5 +46,3 @@ class ScreenToWorldSpaceNode(ArmLogicTreeNode):
                 self.outputs.remove(self.outputs.values()[-1]) # Y
                 self.outputs.remove(self.outputs.values()[-1]) # X
                 self.add_output('NodeSocketVector', 'Direction')
-
-add_node(ScreenToWorldSpaceNode, category=PKG_AS_CATEGORY, section='matrix')

--- a/blender/arm/logicnode/math/LN_separate_rgb.py
+++ b/blender/arm/logicnode/math/LN_separate_rgb.py
@@ -4,6 +4,7 @@ class SeparateColorNode(ArmLogicTreeNode):
     """Splits the given color into RGB values."""
     bl_idname = 'LNSeparateColorNode'
     bl_label = 'Separate RGB'
+    arm_section = 'color'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class SeparateColorNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'R')
         self.add_output('NodeSocketFloat', 'G')
         self.add_output('NodeSocketFloat', 'B')
-
-add_node(SeparateColorNode, category=PKG_AS_CATEGORY, section='color')

--- a/blender/arm/logicnode/math/LN_separate_xyz.py
+++ b/blender/arm/logicnode/math/LN_separate_xyz.py
@@ -4,6 +4,7 @@ class SeparateVectorNode(ArmLogicTreeNode):
     """Splits the given vector into XYZ values."""
     bl_idname = 'LNSeparateVectorNode'
     bl_label = 'Separate XYZ'
+    arm_section = 'vector'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class SeparateVectorNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'X')
         self.add_output('NodeSocketFloat', 'Y')
         self.add_output('NodeSocketFloat', 'Z')
-
-add_node(SeparateVectorNode, category=PKG_AS_CATEGORY, section='vector')

--- a/blender/arm/logicnode/math/LN_vector_clamp_to_size.py
+++ b/blender/arm/logicnode/math/LN_vector_clamp_to_size.py
@@ -4,6 +4,7 @@ class VectorClampToSizeNode(ArmLogicTreeNode):
     """Keeps the vector value inside the given range."""
     bl_idname = 'LNVectorClampToSizeNode'
     bl_label = 'Vector Clamp To Size'
+    arm_section = 'vector'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class VectorClampToSizeNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Min')
         self.add_input('NodeSocketFloat', 'Max')
         self.add_output('NodeSocketVector', 'Vector Out')
-
-add_node(VectorClampToSizeNode, category=PKG_AS_CATEGORY, section='vector')

--- a/blender/arm/logicnode/math/LN_vector_math.py
+++ b/blender/arm/logicnode/math/LN_vector_math.py
@@ -4,7 +4,9 @@ class VectorMathNode(ArmLogicTreeNode):
     """Operates vectors. Some operations uses only the first input."""
     bl_idname = 'LNVectorMathNode'
     bl_label = 'Vector Math'
+    arm_section = 'vector'
     arm_version = 1
+
     property0: EnumProperty(
         items = [('Add', 'Add', 'Add'),
                  ('Dot Product', 'Dot Product', 'Dot Product'),
@@ -28,5 +30,3 @@ class VectorMathNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(VectorMathNode, category=PKG_AS_CATEGORY, section='vector')

--- a/blender/arm/logicnode/math/LN_world_to_screen_space.py
+++ b/blender/arm/logicnode/math/LN_world_to_screen_space.py
@@ -4,11 +4,10 @@ class WorldToScreenSpaceNode(ArmLogicTreeNode):
     """Transforms the given world coordinates into screen coordinates."""
     bl_idname = 'LNWorldToScreenSpaceNode'
     bl_label = 'World To Screen Space'
+    arm_section = 'matrix'
     arm_version = 1
 
     def init(self, context):
         super(WorldToScreenSpaceNode, self).init(context)
         self.add_input('NodeSocketVector', 'World')
         self.add_output('NodeSocketVector', 'Screen')
-
-add_node(WorldToScreenSpaceNode, category=PKG_AS_CATEGORY, section='matrix')

--- a/blender/arm/logicnode/miscellaneous/LN_call_group.py
+++ b/blender/arm/logicnode/miscellaneous/LN_call_group.py
@@ -8,6 +8,7 @@ class CallGroupNode(ArmLogicTreeNode):
     """Calls the given group of nodes."""
     bl_idname = 'LNCallGroupNode'
     bl_label = 'Call Node Group'
+    arm_section = 'group'
     arm_version = 1
 
     @property
@@ -23,5 +24,3 @@ class CallGroupNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0_', bpy.data, 'node_groups', icon='NONE', text='')
-
-add_node(CallGroupNode, category=PKG_AS_CATEGORY, section='group')

--- a/blender/arm/logicnode/miscellaneous/LN_get_application_time.py
+++ b/blender/arm/logicnode/miscellaneous/LN_get_application_time.py
@@ -10,5 +10,3 @@ class TimeNode(ArmLogicTreeNode):
         super(TimeNode, self).init(context)
         self.add_output('NodeSocketFloat', 'Time')
         self.add_output('NodeSocketFloat', 'Delta')
-
-add_node(TimeNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/miscellaneous/LN_get_debug_console_settings.py
+++ b/blender/arm/logicnode/miscellaneous/LN_get_debug_console_settings.py
@@ -6,11 +6,8 @@ class GetDebugConsoleSettings(ArmLogicTreeNode):
     bl_label = 'Get Debug Console Settings'
     arm_version = 1
 
-    def init(self, context):  
+    def init(self, context):
         super(GetDebugConsoleSettings, self).init(context)
-        self.add_output('NodeSocketBool', 'Visible') 
-        self.add_output('NodeSocketFloat', 'Scale') 
-        self.add_output('NodeSocketString', 'Position') 
-
-# Add Node
-add_node(GetDebugConsoleSettings, category=PKG_AS_CATEGORY)
+        self.add_output('NodeSocketBool', 'Visible')
+        self.add_output('NodeSocketFloat', 'Scale')
+        self.add_output('NodeSocketString', 'Position')

--- a/blender/arm/logicnode/miscellaneous/LN_get_display_resolution.py
+++ b/blender/arm/logicnode/miscellaneous/LN_get_display_resolution.py
@@ -2,16 +2,15 @@ from arm.logicnode.arm_nodes import *
 
 class DisplayInfoNode(ArmLogicTreeNode):
     """Returns the current display resolution.
-    
+
     @seeNode Get Window Resolution
     """
     bl_idname = 'LNDisplayInfoNode'
     bl_label = 'Get Display Resolution'
+    arm_section = 'screen'
     arm_version = 1
 
     def init(self, context):
         super(DisplayInfoNode, self).init(context)
         self.add_output('NodeSocketInt', 'Width')
         self.add_output('NodeSocketInt', 'Height')
-
-add_node(DisplayInfoNode, category=PKG_AS_CATEGORY, section='screen')

--- a/blender/arm/logicnode/miscellaneous/LN_get_window_resolution.py
+++ b/blender/arm/logicnode/miscellaneous/LN_get_window_resolution.py
@@ -2,16 +2,15 @@ from arm.logicnode.arm_nodes import *
 
 class WindowInfoNode(ArmLogicTreeNode):
     """Returns the current window resolution.
-    
+
     @seeNode Get Display Resolution
     """
     bl_idname = 'LNWindowInfoNode'
     bl_label = 'Get Window Resolution'
+    arm_section = 'screen'
     arm_version = 1
 
     def init(self, context):
         super(WindowInfoNode, self).init(context)
         self.add_output('NodeSocketInt', 'Width')
         self.add_output('NodeSocketInt', 'Height')
-
-add_node(WindowInfoNode, category=PKG_AS_CATEGORY, section='screen')

--- a/blender/arm/logicnode/miscellaneous/LN_group_nodes.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_nodes.py
@@ -4,10 +4,9 @@ class GroupOutputNode(ArmLogicTreeNode):
     """Sets the connected chain of nodes as a group of nodes."""
     bl_idname = 'LNGroupOutputNode'
     bl_label = 'Group Nodes'
+    arm_section = 'group'
     arm_version = 1
 
     def init(self, context):
         super(GroupOutputNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
-
-add_node(GroupOutputNode, category=PKG_AS_CATEGORY, section='group')

--- a/blender/arm/logicnode/miscellaneous/LN_set_debug_console_settings.py
+++ b/blender/arm/logicnode/miscellaneous/LN_set_debug_console_settings.py
@@ -22,5 +22,3 @@ class SetDebugConsoleSettings(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(SetDebugConsoleSettings, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/miscellaneous/LN_set_time_scale.py
+++ b/blender/arm/logicnode/miscellaneous/LN_set_time_scale.py
@@ -11,5 +11,3 @@ class SetTimeScaleNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketFloat', 'Scale', default_value=1.0)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetTimeScaleNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/miscellaneous/LN_sleep.py
+++ b/blender/arm/logicnode/miscellaneous/LN_sleep.py
@@ -12,5 +12,3 @@ class SleepNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketFloat', 'Time')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SleepNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/miscellaneous/LN_timer.py
+++ b/blender/arm/logicnode/miscellaneous/LN_timer.py
@@ -21,5 +21,3 @@ class TimerNode(ArmLogicTreeNode):
         self.add_output('NodeSocketInt', 'Time Left')
         self.add_output('NodeSocketFloat', 'Progress')
         self.add_output('NodeSocketFloat', 'Repetitions')
-
-add_node(TimerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/miscellaneous/LN_vector_from_boolean.py
+++ b/blender/arm/logicnode/miscellaneous/LN_vector_from_boolean.py
@@ -16,5 +16,3 @@ class VectorFromBooleanNode(ArmLogicTreeNode):
         self.inputs.new('NodeSocketBool', '-Z')
 
         self.outputs.new('NodeSocketVector', 'Vector')
-
-add_node(VectorFromBooleanNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/native/LN_call_haxe_static.py
+++ b/blender/arm/logicnode/native/LN_call_haxe_static.py
@@ -7,6 +7,7 @@ class CallHaxeStaticNode(ArmLogicTreeNode):
     @output Result: the result of the function."""
     bl_idname = 'LNCallHaxeStaticNode'
     bl_label = 'Call Haxe Static'
+    arm_section = 'haxe'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class CallHaxeStaticNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Function')
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('NodeSocketShader', 'Result')
-
-add_node(CallHaxeStaticNode, category=PKG_AS_CATEGORY, section='haxe')

--- a/blender/arm/logicnode/native/LN_expression.py
+++ b/blender/arm/logicnode/native/LN_expression.py
@@ -7,6 +7,7 @@ class ExpressionNode(ArmLogicTreeNode):
     bl_idname = 'LNExpressionNode'
     bl_label = 'Expression'
     arm_version = 1
+    arm_section = 'haxe'
 
     property0: StringProperty(name='', default='')
 
@@ -18,5 +19,3 @@ class ExpressionNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(ExpressionNode, category=PKG_AS_CATEGORY, section='haxe')

--- a/blender/arm/logicnode/native/LN_get_haxe_property.py
+++ b/blender/arm/logicnode/native/LN_get_haxe_property.py
@@ -7,11 +7,10 @@ class GetHaxePropertyNode(ArmLogicTreeNode):
     bl_idname = 'LNGetHaxePropertyNode'
     bl_label = 'Get Haxe Property'
     arm_version = 1
+    arm_section = 'haxe'
 
     def init(self, context):
         super(GetHaxePropertyNode, self).init(context)
         self.add_input('NodeSocketShader', 'Dynamic')
         self.add_input('NodeSocketString', 'Property')
         self.add_output('NodeSocketShader', 'Value')
-
-add_node(GetHaxePropertyNode, category=PKG_AS_CATEGORY, section='haxe')

--- a/blender/arm/logicnode/native/LN_get_system_language.py
+++ b/blender/arm/logicnode/native/LN_get_system_language.py
@@ -4,10 +4,9 @@ class GetSystemLanguage(ArmLogicTreeNode):
     """Returns the language of the current system."""
     bl_idname = 'LNGetSystemLanguage'
     bl_label = 'Get System Language'
+    arm_section = 'Native'
     arm_version = 1
 
     def init(self, context):
         super(GetSystemLanguage, self).init(context)
         self.add_output('NodeSocketString', 'Language')
-
-add_node(GetSystemLanguage, category=PKG_AS_CATEGORY, section='Native')

--- a/blender/arm/logicnode/native/LN_get_system_name.py
+++ b/blender/arm/logicnode/native/LN_get_system_name.py
@@ -5,16 +5,14 @@ class GetSystemName(ArmLogicTreeNode):
     """Returns the name of the current system."""
     bl_idname = 'LNGetSystemName'
     bl_label = 'Get System Name'
+    arm_section = 'Native'
     arm_version = 1
 
-    def init(self, context):  
-        super(GetSystemName, self).init(context) 
+    def init(self, context):
+        super(GetSystemName, self).init(context)
         self.add_output('NodeSocketString', 'System Name')
         self.add_output('NodeSocketBool', 'Windows')
         self.add_output('NodeSocketBool', 'Linux')
         self.add_output('NodeSocketBool', 'Mac')
         self.add_output('NodeSocketBool', 'HTML5')
         self.add_output('NodeSocketBool', 'Android')
-
-# Add Node
-add_node(GetSystemName, category=PKG_AS_CATEGORY, section='Native')

--- a/blender/arm/logicnode/native/LN_loadUrl.py
+++ b/blender/arm/logicnode/native/LN_loadUrl.py
@@ -10,5 +10,3 @@ class LoadUrlNode(ArmLogicTreeNode):
         super(LoadUrlNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketString', 'URL')
-
-add_node(LoadUrlNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/native/LN_print.py
+++ b/blender/arm/logicnode/native/LN_print.py
@@ -11,5 +11,3 @@ class PrintNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketString', 'String')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(PrintNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/native/LN_read_file.py
+++ b/blender/arm/logicnode/native/LN_read_file.py
@@ -6,6 +6,7 @@ class ReadFileNode(ArmLogicTreeNode):
     @seeNode Write File"""
     bl_idname = 'LNReadFileNode'
     bl_label = 'Read File'
+    arm_section = 'file'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class ReadFileNode(ArmLogicTreeNode):
         self.add_input('NodeSocketBool', 'Use cache', default_value=1)
         self.add_output('ArmNodeSocketAction', 'Loaded')
         self.add_output('NodeSocketString', 'String')
-
-add_node(ReadFileNode, category=PKG_AS_CATEGORY, section='file')

--- a/blender/arm/logicnode/native/LN_read_json.py
+++ b/blender/arm/logicnode/native/LN_read_json.py
@@ -6,6 +6,7 @@ class ReadJsonNode(ArmLogicTreeNode):
     @seeNode Write JSON"""
     bl_idname = 'LNReadJsonNode'
     bl_label = 'Read JSON'
+    arm_section = 'file'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class ReadJsonNode(ArmLogicTreeNode):
         self.add_input('NodeSocketBool', 'Use cache', default_value=1)
         self.add_output('ArmNodeSocketAction', 'Loaded')
         self.add_output('NodeSocketShader', 'Dynamic')
-
-add_node(ReadJsonNode, category=PKG_AS_CATEGORY, section='file')

--- a/blender/arm/logicnode/native/LN_read_storage.py
+++ b/blender/arm/logicnode/native/LN_read_storage.py
@@ -6,6 +6,7 @@ class ReadStorageNode(ArmLogicTreeNode):
     @seeNode Write Storage"""
     bl_idname = 'LNReadStorageNode'
     bl_label = 'Read Storage'
+    arm_section = 'file'
     arm_version = 1
 
     def init(self, context):
@@ -13,5 +14,3 @@ class ReadStorageNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Key')
         self.add_input('NodeSocketString', 'Default')
         self.add_output('NodeSocketShader', 'Value')
-
-add_node(ReadStorageNode, category=PKG_AS_CATEGORY, section='file')

--- a/blender/arm/logicnode/native/LN_script.py
+++ b/blender/arm/logicnode/native/LN_script.py
@@ -7,6 +7,7 @@ class ScriptNode(ArmLogicTreeNode):
     """Executes the given script."""
     bl_idname = 'LNScriptNode'
     bl_label = 'Script'
+    arm_section = 'haxe'
     arm_version = 1
 
     @property
@@ -25,5 +26,3 @@ class ScriptNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0_', bpy.data, 'texts', icon='NONE', text='')
-
-add_node(ScriptNode, category=PKG_AS_CATEGORY, section='haxe')

--- a/blender/arm/logicnode/native/LN_set_haxe_property.py
+++ b/blender/arm/logicnode/native/LN_set_haxe_property.py
@@ -6,6 +6,7 @@ class SetHaxePropertyNode(ArmLogicTreeNode):
     @seeNode Get Haxe Property"""
     bl_idname = 'LNSetHaxePropertyNode'
     bl_label = 'Set Haxe Property'
+    arm_section = 'haxe'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class SetHaxePropertyNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Property')
         self.add_input('NodeSocketShader', 'Value')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetHaxePropertyNode, category=PKG_AS_CATEGORY, section='haxe')

--- a/blender/arm/logicnode/native/LN_set_vibrate.py
+++ b/blender/arm/logicnode/native/LN_set_vibrate.py
@@ -5,6 +5,7 @@ class SetVibrateNode(ArmLogicTreeNode):
     """Pulses the vibration hardware on the device for time in milliseconds, if such hardware exists."""
     bl_idname = 'LNSetVibrateNode'
     bl_label = 'Set Vibrate'
+    arm_section = 'Native'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class SetVibrateNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Out')
         # Add permission for target android
         arm.utils.add_permission_target_android(arm.utils.PermissionName.VIBRATE)
-
-add_node(SetVibrateNode, category=PKG_AS_CATEGORY, section='Native')

--- a/blender/arm/logicnode/native/LN_shutdown.py
+++ b/blender/arm/logicnode/native/LN_shutdown.py
@@ -10,5 +10,3 @@ class ShutdownNode(ArmLogicTreeNode):
         super(ShutdownNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ShutdownNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/native/LN_write_file.py
+++ b/blender/arm/logicnode/native/LN_write_file.py
@@ -6,6 +6,7 @@ class WriteFileNode(ArmLogicTreeNode):
     @seeNode Read File"""
     bl_idname = 'LNWriteFileNode'
     bl_label = 'Write File'
+    arm_section = 'file'
     arm_version = 1
 
     def init(self, context):
@@ -13,5 +14,3 @@ class WriteFileNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketString', 'File')
         self.add_input('NodeSocketString', 'String')
-
-add_node(WriteFileNode, category=PKG_AS_CATEGORY, section='file')

--- a/blender/arm/logicnode/native/LN_write_json.py
+++ b/blender/arm/logicnode/native/LN_write_json.py
@@ -6,6 +6,7 @@ class WriteJsonNode(ArmLogicTreeNode):
     @seeNode Read JSON"""
     bl_idname = 'LNWriteJsonNode'
     bl_label = 'Write JSON'
+    arm_section = 'file'
     arm_version = 1
 
     def init(self, context):
@@ -13,5 +14,3 @@ class WriteJsonNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketString', 'File')
         self.add_input('NodeSocketShader', 'Dynamic')
-
-add_node(WriteJsonNode, category=PKG_AS_CATEGORY, section='file')

--- a/blender/arm/logicnode/native/LN_write_storage.py
+++ b/blender/arm/logicnode/native/LN_write_storage.py
@@ -6,6 +6,7 @@ class WriteStorageNode(ArmLogicTreeNode):
     @seeNode Read Storage"""
     bl_idname = 'LNWriteStorageNode'
     bl_label = 'Write Storage'
+    arm_section = 'file'
     arm_version = 1
 
     def init(self, context):
@@ -14,5 +15,3 @@ class WriteStorageNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Key')
         self.add_input('NodeSocketShader', 'Value')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(WriteStorageNode, category=PKG_AS_CATEGORY, section='file')

--- a/blender/arm/logicnode/navmesh/LN_go_to_location.py
+++ b/blender/arm/logicnode/navmesh/LN_go_to_location.py
@@ -13,4 +13,3 @@ class GoToLocationNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Location')
         self.add_output('ArmNodeSocketAction', 'Out')
 
-add_node(GoToLocationNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/navmesh/LN_navigable_location.py
+++ b/blender/arm/logicnode/navmesh/LN_navigable_location.py
@@ -9,5 +9,3 @@ class NavigableLocationNode(ArmLogicTreeNode):
     def init(self, context):
         super(NavigableLocationNode, self).init(context)
         self.add_output('NodeSocketShader', 'Location')
-
-add_node(NavigableLocationNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/navmesh/LN_pick_navmesh_location.py
+++ b/blender/arm/logicnode/navmesh/LN_pick_navmesh_location.py
@@ -11,5 +11,3 @@ class PickLocationNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'NavMesh')
         self.add_input('NodeSocketVector', 'Screen Coords')
         self.add_output('NodeSocketVector', 'Location')
-
-add_node(PickLocationNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/navmesh/LN_stop_agent.py
+++ b/blender/arm/logicnode/navmesh/LN_stop_agent.py
@@ -11,5 +11,3 @@ class StopAgentNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(StopAgentNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/object/LN_get_distance.py
+++ b/blender/arm/logicnode/object/LN_get_distance.py
@@ -14,5 +14,3 @@ class GetDistanceNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('NodeSocketFloat', 'Distance')
-
-add_node(GetDistanceNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/object/LN_get_object_by_name.py
+++ b/blender/arm/logicnode/object/LN_get_object_by_name.py
@@ -20,5 +20,3 @@ class GetObjectNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0', bpy.data, "scenes")
-
-add_node(GetObjectNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/object/LN_get_object_child.py
+++ b/blender/arm/logicnode/object/LN_get_object_child.py
@@ -4,7 +4,9 @@ class GetChildNode(ArmLogicTreeNode):
     """Returns the child of the given object by the child object's name."""
     bl_idname = 'LNGetChildNode'
     bl_label = 'Get Object Child'
+    arm_section = 'relations'
     arm_version = 1
+
     property0: EnumProperty(
         items = [('By Name', 'By Name', 'By Name'),
                  ('Contains', 'Contains', 'Contains'),
@@ -21,5 +23,3 @@ class GetChildNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(GetChildNode, category=PKG_AS_CATEGORY, section='relations')

--- a/blender/arm/logicnode/object/LN_get_object_children.py
+++ b/blender/arm/logicnode/object/LN_get_object_children.py
@@ -4,11 +4,10 @@ class GetChildrenNode(ArmLogicTreeNode):
     """Returns the children of the given object."""
     bl_idname = 'LNGetChildrenNode'
     bl_label = 'Get Object Children'
+    arm_section = 'relations'
     arm_version = 1
 
     def init(self, context):
         super(GetChildrenNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Parent')
         self.add_output('ArmNodeSocketArray', 'Children')
-
-add_node(GetChildrenNode, category=PKG_AS_CATEGORY, section='relations')

--- a/blender/arm/logicnode/object/LN_get_object_mesh.py
+++ b/blender/arm/logicnode/object/LN_get_object_mesh.py
@@ -4,11 +4,10 @@ class GetMeshNode(ArmLogicTreeNode):
     """Returns the mesh of the given object."""
     bl_idname = 'LNGetMeshNode'
     bl_label = 'Get Object Mesh'
+    arm_section = 'props'
     arm_version = 1
 
     def init(self, context):
         super(GetMeshNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('NodeSocketShader', 'Mesh')
-
-add_node(GetMeshNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_get_object_name.py
+++ b/blender/arm/logicnode/object/LN_get_object_name.py
@@ -4,11 +4,10 @@ class GetNameNode(ArmLogicTreeNode):
     """Returns the name of the given object."""
     bl_idname = 'LNGetNameNode'
     bl_label = 'Get Object Name'
+    arm_section = 'props'
     arm_version = 1
 
     def init(self, context):
         super(GetNameNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('NodeSocketString', 'Name')
-
-add_node(GetNameNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_get_object_offscreen.py
+++ b/blender/arm/logicnode/object/LN_get_object_offscreen.py
@@ -4,6 +4,7 @@ class GetObjectOffscreenNode(ArmLogicTreeNode):
     """Returns if the given object is offscreen. Don't works if culling is disabled."""
     bl_idname = 'LNGetObjectOffscreenNode'
     bl_label = 'Get Object Offscreen'
+    arm_section = 'props'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class GetObjectOffscreenNode(ArmLogicTreeNode):
         self.outputs.new('NodeSocketBool', 'Is Object Offscreen')
         self.outputs.new('NodeSocketBool', 'Is Mesh Offscreen')
         self.outputs.new('NodeSocketBool', 'Is Shadow Offscreen')
-
-add_node(GetObjectOffscreenNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_get_object_parent.py
+++ b/blender/arm/logicnode/object/LN_get_object_parent.py
@@ -6,11 +6,10 @@ class GetParentNode(ArmLogicTreeNode):
     @seeNode Set Object Parent"""
     bl_idname = 'LNGetParentNode'
     bl_label = 'Get Object Parent'
+    arm_section = 'relations'
     arm_version = 1
 
     def init(self, context):
         super(GetParentNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Child')
         self.add_output('ArmNodeSocketObject', 'Parent')
-
-add_node(GetParentNode, category=PKG_AS_CATEGORY, section='relations')

--- a/blender/arm/logicnode/object/LN_get_object_property.py
+++ b/blender/arm/logicnode/object/LN_get_object_property.py
@@ -7,6 +7,7 @@ class GetPropertyNode(ArmLogicTreeNode):
     bl_idname = 'LNGetPropertyNode'
     bl_label = 'Get Object Property'
     arm_version = 1
+    arm_section = 'props'
 
     def init(self, context):
         super(GetPropertyNode, self).init(context)
@@ -14,5 +15,3 @@ class GetPropertyNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Property')
         self.add_output('NodeSocketShader', 'Value')
         self.add_output('NodeSocketString', 'Property')
-
-add_node(GetPropertyNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_get_object_visible.py
+++ b/blender/arm/logicnode/object/LN_get_object_visible.py
@@ -7,6 +7,7 @@ class GetVisibleNode(ArmLogicTreeNode):
     @seeNode Set Object Visible"""
     bl_idname = 'LNGetVisibleNode'
     bl_label = 'Get Object Visible'
+    arm_section = 'props'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class GetVisibleNode(ArmLogicTreeNode):
         self.add_output('NodeSocketBool', 'Is Object Visible')
         self.add_output('NodeSocketBool', 'Is Mesh Visible')
         self.add_output('NodeSocketBool', 'Is Shadow Visible')
-
-add_node(GetVisibleNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_mesh.py
+++ b/blender/arm/logicnode/object/LN_mesh.py
@@ -17,5 +17,3 @@ class MeshNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0_get', bpy.data, 'meshes', icon='NONE', text='')
-
-add_node(MeshNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/object/LN_object.py
+++ b/blender/arm/logicnode/object/LN_object.py
@@ -10,5 +10,3 @@ class ObjectNode(ArmLogicTreeNode):
         super(ObjectNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object In')
         self.add_output('ArmNodeSocketObject', 'Object Out', is_var=True)
-
-add_node(ObjectNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/object/LN_remove_object.py
+++ b/blender/arm/logicnode/object/LN_remove_object.py
@@ -11,5 +11,3 @@ class RemoveObjectNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(RemoveObjectNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/object/LN_remove_object_parent.py
+++ b/blender/arm/logicnode/object/LN_remove_object_parent.py
@@ -4,6 +4,7 @@ class ClearParentNode(ArmLogicTreeNode):
     """Removes the parent of the given object."""
     bl_idname = 'LNClearParentNode'
     bl_label = 'Remove Object Parent'
+    arm_section = 'relations'
     arm_version = 1
 
     def init(self, context):
@@ -12,6 +13,3 @@ class ClearParentNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketBool', 'Keep Transform', default_value=True)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ClearParentNode, category=PKG_AS_CATEGORY, section='relations')
-

--- a/blender/arm/logicnode/object/LN_self_object.py
+++ b/blender/arm/logicnode/object/LN_self_object.py
@@ -9,5 +9,3 @@ class SelfObjectNode(ArmLogicTreeNode):
     def init(self, context):
         super(SelfObjectNode, self).init(context)
         self.add_output('ArmNodeSocketObject', 'Object')
-
-add_node(SelfObjectNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/object/LN_set_object_mesh.py
+++ b/blender/arm/logicnode/object/LN_set_object_mesh.py
@@ -4,6 +4,7 @@ class SetMeshNode(ArmLogicTreeNode):
     """Sets the mesh of the given object."""
     bl_idname = 'LNSetMeshNode'
     bl_label = 'Set Object Mesh'
+    arm_section = 'props'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class SetMeshNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketShader', 'Mesh')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetMeshNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_set_object_name.py
+++ b/blender/arm/logicnode/object/LN_set_object_name.py
@@ -4,6 +4,7 @@ class SetNameNode(ArmLogicTreeNode):
     """Sets the name of the given object."""
     bl_idname = 'LNSetNameNode'
     bl_label = 'Set Object Name'
+    arm_section = 'props'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class SetNameNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketString', 'Name')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetNameNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_set_object_parent.py
+++ b/blender/arm/logicnode/object/LN_set_object_parent.py
@@ -6,6 +6,7 @@ class SetParentNode(ArmLogicTreeNode):
     @seeNode Get Object Parent"""
     bl_idname = 'LNSetParentNode'
     bl_label = 'Set Object Parent'
+    arm_section = 'relations'
     arm_version = 1
 
     def init(self, context):
@@ -14,5 +15,3 @@ class SetParentNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('ArmNodeSocketObject', 'Parent', default_value='Parent')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetParentNode, category=PKG_AS_CATEGORY, section='relations')

--- a/blender/arm/logicnode/object/LN_set_object_property.py
+++ b/blender/arm/logicnode/object/LN_set_object_property.py
@@ -11,6 +11,7 @@ class SetPropertyNode(ArmLogicTreeNode):
     @seeNode Get Object Property"""
     bl_idname = 'LNSetPropertyNode'
     bl_label = 'Set Object Property'
+    arm_section = 'props'
     arm_version = 1
 
     def init(self, context):
@@ -20,5 +21,3 @@ class SetPropertyNode(ArmLogicTreeNode):
         self.add_input('NodeSocketString', 'Property')
         self.add_input('NodeSocketShader', 'Value')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetPropertyNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_set_object_visible.py
+++ b/blender/arm/logicnode/object/LN_set_object_visible.py
@@ -6,6 +6,7 @@ class SetVisibleNode(ArmLogicTreeNode):
     @seeNode Get Object Visible"""
     bl_idname = 'LNSetVisibleNode'
     bl_label = 'Set Object Visible'
+    arm_section = 'props'
     arm_version = 1
 
     property0: EnumProperty(
@@ -25,5 +26,3 @@ class SetVisibleNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(SetVisibleNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/object/LN_spawn_object.py
+++ b/blender/arm/logicnode/object/LN_spawn_object.py
@@ -14,5 +14,3 @@ class SpawnObjectNode(ArmLogicTreeNode):
         self.add_input('NodeSocketBool', 'Children', default_value=True)
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketObject', 'Object')
-
-add_node(SpawnObjectNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_apply_force.py
+++ b/blender/arm/logicnode/physics/LN_apply_force.py
@@ -13,6 +13,7 @@ class ApplyForceNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNApplyForceNode'
     bl_label = 'Apply Force'
+    arm_section = 'force'
     arm_version = 1
 
     def init(self, context):
@@ -22,5 +23,3 @@ class ApplyForceNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'Force')
         self.add_input('NodeSocketBool', 'On Local Axis')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ApplyForceNode, category=PKG_AS_CATEGORY, section='force')

--- a/blender/arm/logicnode/physics/LN_apply_force_at_location.py
+++ b/blender/arm/logicnode/physics/LN_apply_force_at_location.py
@@ -16,6 +16,7 @@ class ApplyForceAtLocationNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNApplyForceAtLocationNode'
     bl_label = 'Apply Force At Location'
+    arm_section = 'force'
     arm_version = 1
 
     def init(self, context):
@@ -27,5 +28,3 @@ class ApplyForceAtLocationNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'Location')
         self.add_input('NodeSocketBool', 'Location On Local Axis')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ApplyForceAtLocationNode, category=PKG_AS_CATEGORY, section='force')

--- a/blender/arm/logicnode/physics/LN_apply_impulse.py
+++ b/blender/arm/logicnode/physics/LN_apply_impulse.py
@@ -13,6 +13,7 @@ class ApplyImpulseNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNApplyImpulseNode'
     bl_label = 'Apply Impulse'
+    arm_section = 'force'
     arm_version = 1
 
     def init(self, context):
@@ -22,5 +23,3 @@ class ApplyImpulseNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'Impulse')
         self.add_input('NodeSocketBool', 'On Local Axis')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ApplyImpulseNode, category=PKG_AS_CATEGORY, section='force')

--- a/blender/arm/logicnode/physics/LN_apply_impulse_at_location.py
+++ b/blender/arm/logicnode/physics/LN_apply_impulse_at_location.py
@@ -16,6 +16,7 @@ class ApplyImpulseAtLocationNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNApplyImpulseAtLocationNode'
     bl_label = 'Apply Impulse At Location'
+    arm_section = 'force'
     arm_version = 1
 
     def init(self, context):
@@ -27,5 +28,3 @@ class ApplyImpulseAtLocationNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'Location')
         self.add_input('NodeSocketBool', 'Location On Local Axis')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ApplyImpulseAtLocationNode, category=PKG_AS_CATEGORY, section='force')

--- a/blender/arm/logicnode/physics/LN_apply_torque.py
+++ b/blender/arm/logicnode/physics/LN_apply_torque.py
@@ -4,6 +4,7 @@ class ApplyTorqueNode(ArmLogicTreeNode):
     """Applies torque to the given rigid body."""
     bl_idname = 'LNApplyTorqueNode'
     bl_label = 'Apply Torque'
+    arm_section = 'force'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class ApplyTorqueNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'RB')
         self.add_input('NodeSocketVector', 'Torque')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ApplyTorqueNode, category=PKG_AS_CATEGORY, section='force')

--- a/blender/arm/logicnode/physics/LN_apply_torque_impulse.py
+++ b/blender/arm/logicnode/physics/LN_apply_torque_impulse.py
@@ -4,6 +4,7 @@ class ApplyTorqueImpulseNode(ArmLogicTreeNode):
     """Applies torque impulse in the given rigid body."""
     bl_idname = 'LNApplyTorqueImpulseNode'
     bl_label = 'Apply Torque Impulse'
+    arm_section = 'force'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class ApplyTorqueImpulseNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'RB')
         self.add_input('NodeSocketVector', 'Torque')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ApplyTorqueImpulseNode, category=PKG_AS_CATEGORY, section='force')

--- a/blender/arm/logicnode/physics/LN_get_rb_contacts.py
+++ b/blender/arm/logicnode/physics/LN_get_rb_contacts.py
@@ -8,11 +8,10 @@ class GetContactsNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNGetContactsNode'
     bl_label = 'Get RB Contacts'
+    arm_section = 'contact'
     arm_version = 1
 
     def init(self, context):
         super(GetContactsNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'RB')
         self.add_output('ArmNodeSocketArray', 'Contacts')
-
-add_node(GetContactsNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_get_rb_data.py
+++ b/blender/arm/logicnode/physics/LN_get_rb_data.py
@@ -4,6 +4,7 @@ class GetRigidBodyDataNode(ArmLogicTreeNode):
     """Returns the data of the given rigid body."""
     bl_idname = 'LNGetRigidBodyDataNode'
     bl_label = 'Get RB Data'
+    arm_section = 'props'
     arm_version = 1
 
     def init(self, context):
@@ -22,5 +23,3 @@ class GetRigidBodyDataNode(ArmLogicTreeNode):
         #self.outputs.new('NodeSocketBool', 'Is Gravity Enabled')
         #self.outputs.new(NodeSocketVector', Angular Factor')
         #self.outputs.new('NodeSocketVector', Linear Factor')
-
-add_node(GetRigidBodyDataNode, category=PKG_AS_CATEGORY, section='props')

--- a/blender/arm/logicnode/physics/LN_get_rb_first_contact.py
+++ b/blender/arm/logicnode/physics/LN_get_rb_first_contact.py
@@ -7,11 +7,10 @@ class GetFirstContactNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNGetFirstContactNode'
     bl_label = 'Get RB First Contact'
+    arm_section = 'contact'
     arm_version = 1
 
     def init(self, context):
         super(GetFirstContactNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'RB')
         self.add_output('ArmNodeSocketObject', 'First Contact')
-
-add_node(GetFirstContactNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_get_rb_velocity.py
+++ b/blender/arm/logicnode/physics/LN_get_rb_velocity.py
@@ -11,5 +11,3 @@ class GetVelocityNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'RB')
         self.add_output('NodeSocketVector', 'Linear')
         self.add_output('NodeSocketVector', 'Angular')
-
-add_node(GetVelocityNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_get_world_gravity.py
+++ b/blender/arm/logicnode/physics/LN_get_world_gravity.py
@@ -12,5 +12,3 @@ class GetGravityNode(ArmLogicTreeNode):
     def init(self, context):
         super(GetGravityNode, self).init(context)
         self.add_output('NodeSocketVector', 'World Gravity')
-
-add_node(GetGravityNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_has_contact.py
+++ b/blender/arm/logicnode/physics/LN_has_contact.py
@@ -4,6 +4,7 @@ class HasContactNode(ArmLogicTreeNode):
     """Returns whether the given rigid body has contact with another given rigid body."""
     bl_idname = 'LNHasContactNode'
     bl_label = 'Has Contact'
+    arm_section = 'contact'
     arm_version = 1
 
     def init(self, context):
@@ -11,5 +12,3 @@ class HasContactNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'RB 1')
         self.add_input('ArmNodeSocketObject', 'RB 2')
         self.add_output('NodeSocketBool', 'Has Contact')
-
-add_node(HasContactNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_has_contact_array.py
+++ b/blender/arm/logicnode/physics/LN_has_contact_array.py
@@ -4,6 +4,7 @@ class HasContactArrayNode(ArmLogicTreeNode):
     """Returns whether the given rigid body has contact with other given rigid bodies."""
     bl_idname = 'LNHasContactArrayNode'
     bl_label = 'Has Contact Array'
+    arm_section = 'contact'
     arm_version = 1
 
     def init(self, context):
@@ -11,5 +12,3 @@ class HasContactArrayNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'RB')
         self.add_input('ArmNodeSocketArray', 'RBs')
         self.add_output('NodeSocketBool', 'Has Contact')
-
-add_node(HasContactArrayNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_on_contact.py
+++ b/blender/arm/logicnode/physics/LN_on_contact.py
@@ -13,6 +13,7 @@ class OnContactNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNOnContactNode'
     bl_label = 'On Contact'
+    arm_section = 'contact'
     arm_version = 1
 
     property0: EnumProperty(
@@ -29,5 +30,3 @@ class OnContactNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(OnContactNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_on_contact_array.py
+++ b/blender/arm/logicnode/physics/LN_on_contact_array.py
@@ -4,7 +4,9 @@ class OnContactArrayNode(ArmLogicTreeNode):
     """Activates the output when the given rigid body make contact with other given rigid bodies."""
     bl_idname = 'LNOnContactArrayNode'
     bl_label = 'On Contact Array'
+    arm_section = 'contact'
     arm_version = 1
+
     property0: EnumProperty(
         items = [('Begin', 'Begin', 'Begin'),
                  ('End', 'End', 'End'),
@@ -19,5 +21,3 @@ class OnContactArrayNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(OnContactArrayNode, category=PKG_AS_CATEGORY, section='contact')

--- a/blender/arm/logicnode/physics/LN_on_volume_trigger.py
+++ b/blender/arm/logicnode/physics/LN_on_volume_trigger.py
@@ -19,5 +19,3 @@ class OnVolumeTriggerNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(OnVolumeTriggerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_pick_rb.py
+++ b/blender/arm/logicnode/physics/LN_pick_rb.py
@@ -5,6 +5,7 @@ class PickObjectNode(ArmLogicTreeNode):
     coordinates (2D)."""
     bl_idname = 'LNPickObjectNode'
     bl_label = 'Pick RB'
+    arm_section = 'ray'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class PickObjectNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'Screen Coords')
         self.add_output('ArmNodeSocketObject', 'RB')
         self.add_output('NodeSocketVector', 'Hit')
-
-add_node(PickObjectNode, category=PKG_AS_CATEGORY, section='ray')

--- a/blender/arm/logicnode/physics/LN_ray_cast.py
+++ b/blender/arm/logicnode/physics/LN_ray_cast.py
@@ -19,6 +19,7 @@ class RayCastNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNCastPhysicsRayNode'
     bl_label = 'Ray Cast'
+    arm_section = 'ray'
     arm_version = 1
 
     def init(self, context):
@@ -29,5 +30,3 @@ class RayCastNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketObject', 'RB')
         self.add_output('NodeSocketVector', 'Hit')
         self.add_output('NodeSocketVector', 'Normal')
-
-add_node(RayCastNode, category=PKG_AS_CATEGORY, section='ray')

--- a/blender/arm/logicnode/physics/LN_remove_rb.py
+++ b/blender/arm/logicnode/physics/LN_remove_rb.py
@@ -14,5 +14,3 @@ class RemovePhysicsNode (ArmLogicTreeNode):
         self.inputs.new('ArmNodeSocketAction', 'In')
         self.inputs.new('ArmNodeSocketObject', 'RB')
         self.outputs.new('ArmNodeSocketAction', 'Out')
-
-add_node(RemovePhysicsNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_set_rb_activation_state.py
+++ b/blender/arm/logicnode/physics/LN_set_rb_activation_state.py
@@ -25,5 +25,3 @@ class SetActivationStateNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(SetActivationStateNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_set_rb_friction.py
+++ b/blender/arm/logicnode/physics/LN_set_rb_friction.py
@@ -16,5 +16,3 @@ class SetFrictionNode (ArmLogicTreeNode):
         self.inputs.new('ArmNodeSocketObject', 'RB')
         self.inputs.new('NodeSocketFloat', 'Friction')
         self.outputs.new('ArmNodeSocketAction', 'Out')
-
-add_node(SetFrictionNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_set_rb_gravity_enabled.py
+++ b/blender/arm/logicnode/physics/LN_set_rb_gravity_enabled.py
@@ -12,5 +12,3 @@ class SetGravityEnabledNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'RB')
         self.add_input('NodeSocketBool', 'Enabled')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetGravityEnabledNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_set_rb_velocity.py
+++ b/blender/arm/logicnode/physics/LN_set_rb_velocity.py
@@ -15,5 +15,3 @@ class SetVelocityNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'Angular')
         self.add_input('NodeSocketVector', 'Angular Factor', default_value=[1.0, 1.0, 1.0])
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetVelocityNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_set_world_gravity.py
+++ b/blender/arm/logicnode/physics/LN_set_world_gravity.py
@@ -14,5 +14,3 @@ class SetGravityNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketVector', 'Gravity')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetGravityNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/physics/LN_volume_trigger.py
+++ b/blender/arm/logicnode/physics/LN_volume_trigger.py
@@ -8,7 +8,9 @@ class VolumeTriggerNode(ArmLogicTreeNode):
     @input Volume: this object is used as the volume"""
     bl_idname = 'LNVolumeTriggerNode'
     bl_label = 'Volume Trigger'
+    arm_section = 'misc'
     arm_version = 1
+
     property0: EnumProperty(
         items = [('Enter', 'Enter', 'Enter'),
                  ('Leave', 'Leave', 'Leave'),
@@ -23,5 +25,3 @@ class VolumeTriggerNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(VolumeTriggerNode, category=PKG_AS_CATEGORY, section='misc')

--- a/blender/arm/logicnode/postprocess/LN_colorgrading_get_global_node.py
+++ b/blender/arm/logicnode/postprocess/LN_colorgrading_get_global_node.py
@@ -4,6 +4,7 @@ class ColorgradingGetGlobalNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNColorgradingGetGlobalNode'
     bl_label = 'Colorgrading Get Global'
+    arm_section = 'colorgrading'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class ColorgradingGetGlobalNode(ArmLogicTreeNode):
         self.add_output('NodeSocketVector', 'Gamma')
         self.add_output('NodeSocketVector', 'Gain')
         self.add_output('NodeSocketVector', 'Offset')
-
-add_node(ColorgradingGetGlobalNode, category=PKG_AS_CATEGORY, section='colorgrading')

--- a/blender/arm/logicnode/postprocess/LN_colorgrading_get_highlight_node.py
+++ b/blender/arm/logicnode/postprocess/LN_colorgrading_get_highlight_node.py
@@ -4,6 +4,7 @@ class ColorgradingGetHighlightNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNColorgradingGetHighlightNode'
     bl_label = 'Colorgrading Get Highlight'
+    arm_section = 'colorgrading'
     arm_version = 1
 
     def init(self, context):
@@ -14,5 +15,3 @@ class ColorgradingGetHighlightNode(ArmLogicTreeNode):
         self.add_output('NodeSocketVector', 'Gamma')
         self.add_output('NodeSocketVector', 'Gain')
         self.add_output('NodeSocketVector', 'Offset')
-
-add_node(ColorgradingGetHighlightNode, category=PKG_AS_CATEGORY, section='colorgrading')

--- a/blender/arm/logicnode/postprocess/LN_colorgrading_get_midtone_node.py
+++ b/blender/arm/logicnode/postprocess/LN_colorgrading_get_midtone_node.py
@@ -4,6 +4,7 @@ class ColorgradingGetMidtoneNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNColorgradingGetMidtoneNode'
     bl_label = 'Colorgrading Get Midtone'
+    arm_section = 'colorgrading'
     arm_version = 1
 
     def init(self, context):
@@ -13,5 +14,3 @@ class ColorgradingGetMidtoneNode(ArmLogicTreeNode):
         self.add_output('NodeSocketVector', 'Gamma')
         self.add_output('NodeSocketVector', 'Gain')
         self.add_output('NodeSocketVector', 'Offset')
-
-add_node(ColorgradingGetMidtoneNode, category=PKG_AS_CATEGORY, section='colorgrading')

--- a/blender/arm/logicnode/postprocess/LN_colorgrading_get_shadow_node.py
+++ b/blender/arm/logicnode/postprocess/LN_colorgrading_get_shadow_node.py
@@ -4,6 +4,7 @@ class ColorgradingGetShadowNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNColorgradingGetShadowNode'
     bl_label = 'Colorgrading Get Shadow'
+    arm_section = 'colorgrading'
     arm_version = 1
 
     def init(self, context):
@@ -14,5 +15,3 @@ class ColorgradingGetShadowNode(ArmLogicTreeNode):
         self.add_output('NodeSocketVector', 'Gamma')
         self.add_output('NodeSocketVector', 'Gain')
         self.add_output('NodeSocketVector', 'Offset')
-
-add_node(ColorgradingGetShadowNode, category=PKG_AS_CATEGORY, section='colorgrading')

--- a/blender/arm/logicnode/postprocess/LN_colorgrading_set_global_node.py
+++ b/blender/arm/logicnode/postprocess/LN_colorgrading_set_global_node.py
@@ -28,6 +28,7 @@ class ColorgradingSetGlobalNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNColorgradingSetGlobalNode'
     bl_label = 'Colorgrading Set Global'
+    arm_section = 'colorgrading'
     arm_version = 1
 
     # TODO: RRESET FILE OPTION FOR THE BELOW
@@ -72,5 +73,3 @@ class ColorgradingSetGlobalNode(ArmLogicTreeNode):
         if (self.property0 == 'Preset File'):
             layout.prop(self, 'filepath')
             layout.prop(self, 'property1')
-
-add_node(ColorgradingSetGlobalNode, category=PKG_AS_CATEGORY, section='colorgrading')

--- a/blender/arm/logicnode/postprocess/LN_colorgrading_set_highlight_node.py
+++ b/blender/arm/logicnode/postprocess/LN_colorgrading_set_highlight_node.py
@@ -28,6 +28,7 @@ class ColorgradingSetHighlightNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNColorgradingSetHighlightNode'
     bl_label = 'Colorgrading Set Highlight'
+    arm_section = 'colorgrading'
     arm_version = 1
 
     # TODO: RRESET FILE OPTION FOR THE BELOW
@@ -70,5 +71,3 @@ class ColorgradingSetHighlightNode(ArmLogicTreeNode):
         if (self.property0 == 'Preset File'):
             layout.prop(self, 'filepath')
             layout.prop(self, 'property1')
-
-add_node(ColorgradingSetHighlightNode, category=PKG_AS_CATEGORY, section='colorgrading')

--- a/blender/arm/logicnode/postprocess/LN_colorgrading_set_midtone_node.py
+++ b/blender/arm/logicnode/postprocess/LN_colorgrading_set_midtone_node.py
@@ -28,6 +28,7 @@ class ColorgradingSetMidtoneNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNColorgradingSetMidtoneNode'
     bl_label = 'Colorgrading Set Midtone'
+    arm_section = 'colorgrading'
     arm_version = 1
 
     # TODO: RRESET FILE OPTION FOR THE BELOW
@@ -69,5 +70,3 @@ class ColorgradingSetMidtoneNode(ArmLogicTreeNode):
         if (self.property0 == 'Preset File'):
             layout.prop(self, 'filepath')
             layout.prop(self, 'property1')
-
-add_node(ColorgradingSetMidtoneNode, category=PKG_AS_CATEGORY, section='colorgrading')

--- a/blender/arm/logicnode/postprocess/LN_colorgrading_set_shadow_node.py
+++ b/blender/arm/logicnode/postprocess/LN_colorgrading_set_shadow_node.py
@@ -28,6 +28,7 @@ class ColorgradingSetShadowNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNColorgradingSetShadowNode'
     bl_label = 'Colorgrading Set Shadow'
+    arm_section = 'colorgrading'
     arm_version = 1
 
     # TODO: RRESET FILE OPTION FOR THE BELOW
@@ -70,5 +71,3 @@ class ColorgradingSetShadowNode(ArmLogicTreeNode):
         if (self.property0 == 'Preset File'):
             layout.prop(self, 'filepath')
             layout.prop(self, 'property1')
-
-add_node(ColorgradingSetShadowNode, category=PKG_AS_CATEGORY, section='colorgrading')

--- a/blender/arm/logicnode/postprocess/LN_get_bloom_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_get_bloom_settings.py
@@ -11,5 +11,3 @@ class BloomGetNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'Threshold')
         self.add_output('NodeSocketFloat', 'Strength')
         self.add_output('NodeSocketFloat', 'Radius')
-
-add_node(BloomGetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_get_ca_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_get_ca_settings.py
@@ -10,5 +10,3 @@ class ChromaticAberrationGetNode(ArmLogicTreeNode):
         super(ChromaticAberrationGetNode, self).init(context)
         self.add_output('NodeSocketFloat', 'Strength')
         self.add_output('NodeSocketFloat', 'Samples')
-
-add_node(ChromaticAberrationGetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
+++ b/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
@@ -18,5 +18,3 @@ class CameraGetNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'DOF Length')
         self.add_output('NodeSocketFloat', 'DOF F-Stop')
         self.add_output('NodeSocketFloat', 'Film Grain')
-
-add_node(CameraGetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_get_lenstexture_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_get_lenstexture_settings.py
@@ -13,5 +13,3 @@ class LenstextureGetNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'Luminance Min')
         self.add_output('NodeSocketFloat', 'Luminance Max')
         self.add_output('NodeSocketFloat', 'Brightness Exponent')
-
-add_node(LenstextureGetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_get_ssao_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_get_ssao_settings.py
@@ -11,5 +11,3 @@ class SSAOGetNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'Radius')
         self.add_output('NodeSocketFloat', 'Strength')
         self.add_output('NodeSocketFloat', 'Max Steps')
-
-add_node(SSAOGetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_get_ssr_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_get_ssr_settings.py
@@ -13,5 +13,3 @@ class SSRGetNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'SSR Search')
         self.add_output('NodeSocketFloat', 'SSR Falloff')
         self.add_output('NodeSocketFloat', 'SSR Jitter')
-
-add_node(SSRGetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_lenstexture_set.py
+++ b/blender/arm/logicnode/postprocess/LN_lenstexture_set.py
@@ -16,5 +16,3 @@ class LenstextureSetNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Brightness Exponent', default_value=2.0)
 
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(LenstextureSetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_set_bloom_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_set_bloom_settings.py
@@ -13,5 +13,3 @@ class BloomSetNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Strength', default_value=3.50)
         self.add_input('NodeSocketFloat', 'Radius', default_value=3.0)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(BloomSetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_set_ca_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_set_ca_settings.py
@@ -12,5 +12,3 @@ class ChromaticAberrationSetNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Strength', default_value=2.0)
         self.add_input('NodeSocketInt', 'Samples', default_value=32)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(ChromaticAberrationSetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
+++ b/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
@@ -21,5 +21,3 @@ class CameraSetNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'Tonemapper', default_value=0.0)
         self.add_input('NodeSocketFloat', 'Film Grain', default_value=2.0)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CameraSetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_set_ssao_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_set_ssao_settings.py
@@ -13,5 +13,3 @@ class SSAOSetNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Strength', default_value=5.0)
         self.add_input('NodeSocketInt', 'Max Steps', default_value=8)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SSAOSetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/postprocess/LN_set_ssr_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_set_ssr_settings.py
@@ -15,5 +15,3 @@ class SSRSetNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'SSR Falloff', default_value=5.0)
         self.add_input('NodeSocketFloat', 'SSR Jitter', default_value=0.6)
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SSRSetNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/random/LN_random_boolean.py
+++ b/blender/arm/logicnode/random/LN_random_boolean.py
@@ -10,6 +10,3 @@ class RandomBooleanNode(ArmLogicTreeNode):
     def init(self, context):
         super(RandomBooleanNode, self).init(context)
         self.add_output('NodeSocketBool', 'Bool')
-
-
-add_node(RandomBooleanNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/random/LN_random_choice.py
+++ b/blender/arm/logicnode/random/LN_random_choice.py
@@ -12,6 +12,3 @@ class RandomChoiceNode(ArmLogicTreeNode):
 
         self.add_input('ArmNodeSocketArray', 'Array')
         self.add_output('NodeSocketShader', 'Value')
-
-
-add_node(RandomChoiceNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/random/LN_random_color.py
+++ b/blender/arm/logicnode/random/LN_random_color.py
@@ -10,6 +10,3 @@ class RandomColorNode(ArmLogicTreeNode):
     def init(self, context):
         super(RandomColorNode, self).init(context)
         self.add_output('NodeSocketColor', 'Color')
-
-
-add_node(RandomColorNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/random/LN_random_float.py
+++ b/blender/arm/logicnode/random/LN_random_float.py
@@ -13,6 +13,3 @@ class RandomFloatNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Max', default_value=1.0)
         # self.add_input('NodeSocketInt', 'Seed')
         self.add_output('NodeSocketFloat', 'Float')
-
-
-add_node(RandomFloatNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/random/LN_random_integer.py
+++ b/blender/arm/logicnode/random/LN_random_integer.py
@@ -12,6 +12,3 @@ class RandomIntegerNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'Min')
         self.add_input('NodeSocketInt', 'Max', default_value=2)
         self.add_output('NodeSocketInt', 'Int')
-
-
-add_node(RandomIntegerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/random/LN_random_output.py
+++ b/blender/arm/logicnode/random/LN_random_output.py
@@ -5,6 +5,7 @@ class RandomOutputNode(ArmLogicTreeNode):
     """Activate a random output when the input is activated."""
     bl_idname = 'LNRandomOutputNode'
     bl_label = 'Random Output'
+    arm_section = 'logic'
     arm_version = 1
 
     def __init__(self):
@@ -23,6 +24,3 @@ class RandomOutputNode(ArmLogicTreeNode):
         op.socket_type = 'ArmNodeSocketAction'
         op2 = row.operator('arm.node_remove_output', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
-
-
-add_node(RandomOutputNode, category=PKG_AS_CATEGORY, section='logic')

--- a/blender/arm/logicnode/random/LN_random_vector.py
+++ b/blender/arm/logicnode/random/LN_random_vector.py
@@ -12,6 +12,3 @@ class RandomVectorNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'Min', default_value=[-1.0, -1.0, -1.0])
         self.add_input('NodeSocketVector', 'Max', default_value=[1.0, 1.0, 1.0])
         self.add_output('NodeSocketVector', 'Vector')
-
-
-add_node(RandomVectorNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/renderpath/LN_set_msaa_quality.py
+++ b/blender/arm/logicnode/renderpath/LN_set_msaa_quality.py
@@ -21,5 +21,3 @@ class RpMSAANode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(RpMSAANode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/renderpath/LN_set_post_process_quality.py
+++ b/blender/arm/logicnode/renderpath/LN_set_post_process_quality.py
@@ -22,5 +22,3 @@ class RpConfigNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(RpConfigNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/renderpath/LN_set_shadows_quality.py
+++ b/blender/arm/logicnode/renderpath/LN_set_shadows_quality.py
@@ -19,5 +19,3 @@ class RpShadowQualityNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(RpShadowQualityNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/renderpath/LN_set_ssaa_quality.py
+++ b/blender/arm/logicnode/renderpath/LN_set_ssaa_quality.py
@@ -20,5 +20,3 @@ class RpSuperSampleNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(RpSuperSampleNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/scene/LN_collection.py
+++ b/blender/arm/logicnode/scene/LN_collection.py
@@ -9,6 +9,7 @@ class GroupNode(ArmLogicTreeNode):
     @seeNode Get Collection"""
     bl_idname = 'LNGroupNode'
     bl_label = 'Collection'
+    arm_section = 'collection'
     arm_version = 1
 
     property0: PointerProperty(name='', type=bpy.types.Collection)
@@ -19,5 +20,3 @@ class GroupNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0', bpy.data, 'collections', icon='NONE', text='')
-
-add_node(GroupNode, category=PKG_AS_CATEGORY, section='collection')

--- a/blender/arm/logicnode/scene/LN_create_collection.py
+++ b/blender/arm/logicnode/scene/LN_create_collection.py
@@ -4,6 +4,7 @@ class CreateCollectionNode(ArmLogicTreeNode):
     """Creates a collection."""
     bl_idname = 'LNAddGroupNode'
     bl_label = 'Create Collection'
+    arm_section = 'collection'
     arm_version = 1
 
     def init(self, context):
@@ -11,5 +12,3 @@ class CreateCollectionNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketString', 'Collection')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(CreateCollectionNode, category=PKG_AS_CATEGORY, section='collection')

--- a/blender/arm/logicnode/scene/LN_get_collection.py
+++ b/blender/arm/logicnode/scene/LN_get_collection.py
@@ -7,11 +7,10 @@ class GetGroupNode(ArmLogicTreeNode):
     @seeNode Collection"""
     bl_idname = 'LNGetGroupNode'
     bl_label = 'Get Collection'
+    arm_section = 'collection'
     arm_version = 1
 
     def init(self, context):
         super(GetGroupNode, self).init(context)
         self.add_input('NodeSocketString', 'Name')
         self.add_output('ArmNodeSocketArray', 'Objects')
-
-add_node(GetGroupNode, category=PKG_AS_CATEGORY, section='collection')

--- a/blender/arm/logicnode/scene/LN_get_scene_active.py
+++ b/blender/arm/logicnode/scene/LN_get_scene_active.py
@@ -9,5 +9,3 @@ class ActiveSceneNode(ArmLogicTreeNode):
     def init(self, context):
         super(ActiveSceneNode, self).init(context)
         self.add_output('NodeSocketShader', 'Scene')
-
-add_node(ActiveSceneNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/scene/LN_get_scene_root.py
+++ b/blender/arm/logicnode/scene/LN_get_scene_root.py
@@ -9,5 +9,3 @@ class SceneRootNode(ArmLogicTreeNode):
     def init(self, context):
         super(SceneRootNode, self).init(context)
         self.add_output('ArmNodeSocketObject', 'Object')
-
-add_node(SceneRootNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/scene/LN_global_object.py
+++ b/blender/arm/logicnode/scene/LN_global_object.py
@@ -10,5 +10,3 @@ class GlobalObjectNode(ArmLogicTreeNode):
     def init(self, context):
         super(GlobalObjectNode, self).init(context)
         self.add_output('ArmNodeSocketObject', 'Object')
-
-add_node(GlobalObjectNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/scene/LN_remove_collection.py
+++ b/blender/arm/logicnode/scene/LN_remove_collection.py
@@ -4,6 +4,7 @@ class RemoveGroupNode(ArmLogicTreeNode):
     """Removes the given collection from the scene."""
     bl_idname = 'LNRemoveGroupNode'
     bl_label = 'Remove Collection'
+    arm_section = 'collection'
     arm_version = 1
 
     def init(self, context):
@@ -11,5 +12,3 @@ class RemoveGroupNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketString', 'Collection')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(RemoveGroupNode, category=PKG_AS_CATEGORY, section='collection')

--- a/blender/arm/logicnode/scene/LN_remove_scene_active.py
+++ b/blender/arm/logicnode/scene/LN_remove_scene_active.py
@@ -10,5 +10,3 @@ class RemoveActiveSceneNode(ArmLogicTreeNode):
         super(RemoveActiveSceneNode, self).init(context)
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(RemoveActiveSceneNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/scene/LN_scene.py
+++ b/blender/arm/logicnode/scene/LN_scene.py
@@ -17,5 +17,3 @@ class SceneNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0_get', bpy.data, 'scenes', icon='NONE', text='')
-
-add_node(SceneNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/scene/LN_set_scene_active.py
+++ b/blender/arm/logicnode/scene/LN_set_scene_active.py
@@ -12,5 +12,3 @@ class SetSceneNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Scene')
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketObject', 'Root')
-
-add_node(SetSceneNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/scene/LN_spawn_collection.py
+++ b/blender/arm/logicnode/scene/LN_spawn_collection.py
@@ -5,8 +5,8 @@ from arm.logicnode.arm_nodes import *
 
 class SpawnCollectionNode(ArmLogicTreeNode):
     """
-    Spawns a new instance of the selected collection. Each spawned instance 
-    has an empty owner object to control the instance as a whole (like Blender 
+    Spawns a new instance of the selected collection. Each spawned instance
+    has an empty owner object to control the instance as a whole (like Blender
     uses it for collection instances).
 
     @input In: activates the node.
@@ -25,6 +25,7 @@ class SpawnCollectionNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNSpawnCollectionNode'
     bl_label = 'Spawn Collection'
+    arm_section = 'collection'
     arm_version = 1
 
     property0: PointerProperty(name='Collection', type=bpy.types.Collection)
@@ -41,6 +42,3 @@ class SpawnCollectionNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0', bpy.data, 'collections', icon='NONE', text='')
-
-
-add_node(SpawnCollectionNode, category=PKG_AS_CATEGORY, section='collection')

--- a/blender/arm/logicnode/scene/LN_spawn_scene.py
+++ b/blender/arm/logicnode/scene/LN_spawn_scene.py
@@ -13,5 +13,3 @@ class SpawnSceneNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Transform')
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketObject', 'Root')
-
-add_node(SpawnSceneNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/sound/LN_pause_speaker.py
+++ b/blender/arm/logicnode/sound/LN_pause_speaker.py
@@ -16,5 +16,3 @@ class PauseSpeakerNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Speaker')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(PauseSpeakerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/sound/LN_play_sound.py
+++ b/blender/arm/logicnode/sound/LN_play_sound.py
@@ -73,5 +73,3 @@ class PlaySoundNode(ArmLogicTreeNode):
         if not self.property3:
             row.enabled = False
         row.prop(self, 'property4')
-
-add_node(PlaySoundNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/sound/LN_play_speaker.py
+++ b/blender/arm/logicnode/sound/LN_play_speaker.py
@@ -16,5 +16,3 @@ class PlaySpeakerNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Speaker')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(PlaySpeakerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/sound/LN_stop_speaker.py
+++ b/blender/arm/logicnode/sound/LN_stop_speaker.py
@@ -16,5 +16,3 @@ class StopSpeakerNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Speaker')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(StopSpeakerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/string/LN_concatenate_string.py
+++ b/blender/arm/logicnode/string/LN_concatenate_string.py
@@ -21,5 +21,3 @@ class ConcatenateStringNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketString'
         op = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op.node_index = str(id(self))
-
-add_node(ConcatenateStringNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/string/LN_parse_float.py
+++ b/blender/arm/logicnode/string/LN_parse_float.py
@@ -4,11 +4,10 @@ class ParseFloatNode(ArmLogicTreeNode):
     """Returns the floats that are in the given string."""
     bl_idname = 'LNParseFloatNode'
     bl_label = 'Parse Float'
+    arm_section = 'parse'
     arm_version = 1
 
     def init(self, context):
         super(ParseFloatNode, self).init(context)
         self.add_output('NodeSocketFloat', 'Float')
         self.add_input('NodeSocketString', 'String')
-
-add_node(ParseFloatNode, category=PKG_AS_CATEGORY, section='parse')

--- a/blender/arm/logicnode/string/LN_split_string.py
+++ b/blender/arm/logicnode/string/LN_split_string.py
@@ -11,5 +11,3 @@ class SplitStringNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketArray', 'Array')
         self.add_input('NodeSocketString', 'String')
         self.add_input('NodeSocketString', 'Split')
-
-add_node(SplitStringNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/string/LN_string.py
+++ b/blender/arm/logicnode/string/LN_string.py
@@ -10,5 +10,3 @@ class StringNode(ArmLogicTreeNode):
         super(StringNode, self).init(context)
         self.add_input('NodeSocketString', 'String In')
         self.add_output('NodeSocketString', 'String Out', is_var=True)
-
-add_node(StringNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/string/LN_string_case.py
+++ b/blender/arm/logicnode/string/LN_string_case.py
@@ -18,5 +18,3 @@ class CaseStringNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(CaseStringNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/string/LN_string_contains.py
+++ b/blender/arm/logicnode/string/LN_string_contains.py
@@ -20,5 +20,3 @@ class ContainsStringNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(ContainsStringNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/string/LN_string_length.py
+++ b/blender/arm/logicnode/string/LN_string_length.py
@@ -10,5 +10,3 @@ class LengthStringNode(ArmLogicTreeNode):
         super(LengthStringNode, self).init(context)
         self.add_output('NodeSocketInt', 'Length')
         self.add_input('NodeSocketString', 'String')
-
-add_node(LengthStringNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/string/LN_sub_string.py
+++ b/blender/arm/logicnode/string/LN_sub_string.py
@@ -12,5 +12,3 @@ class SubStringNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'Start')
         self.add_input('NodeSocketInt', 'End')
         self.add_output('NodeSocketString', 'String Out')
-
-add_node(SubStringNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/trait/LN_add_trait_to_object.py
+++ b/blender/arm/logicnode/trait/LN_add_trait_to_object.py
@@ -12,5 +12,3 @@ class AddTraitNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketShader', 'Trait')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(AddTraitNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/trait/LN_get_object_trait.py
+++ b/blender/arm/logicnode/trait/LN_get_object_trait.py
@@ -12,5 +12,3 @@ class GetTraitNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketString', 'Name')
         self.add_output('NodeSocketShader', 'Trait')
-
-add_node(GetTraitNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/trait/LN_get_object_traits.py
+++ b/blender/arm/logicnode/trait/LN_get_object_traits.py
@@ -10,5 +10,3 @@ class GetObjectTraitsNode(ArmLogicTreeNode):
         super(GetObjectTraitsNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('ArmNodeSocketArray', 'Traits')
-
-add_node(GetObjectTraitsNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/trait/LN_get_trait_name.py
+++ b/blender/arm/logicnode/trait/LN_get_trait_name.py
@@ -11,5 +11,3 @@ class GetTraitNameNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Trait')
         self.add_output('NodeSocketString', 'Name')
         self.add_output('NodeSocketString', 'Class Type')
-
-add_node(GetTraitNameNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/trait/LN_remove_trait.py
+++ b/blender/arm/logicnode/trait/LN_remove_trait.py
@@ -11,5 +11,3 @@ class RemoveTraitNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('NodeSocketShader', 'Trait')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(RemoveTraitNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/trait/LN_self_trait.py
+++ b/blender/arm/logicnode/trait/LN_self_trait.py
@@ -9,5 +9,3 @@ class SelfTraitNode(ArmLogicTreeNode):
     def init(self, context):
         super(SelfTraitNode, self).init(context)
         self.add_output('NodeSocketShader', 'Trait')
-
-add_node(SelfTraitNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/trait/LN_set_trait_paused.py
+++ b/blender/arm/logicnode/trait/LN_set_trait_paused.py
@@ -12,5 +12,3 @@ class SetTraitPausedNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Trait')
         self.add_input('NodeSocketBool', 'Paused')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetTraitPausedNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/trait/LN_trait.py
+++ b/blender/arm/logicnode/trait/LN_trait.py
@@ -16,5 +16,3 @@ class TraitNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(TraitNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/transform/LN_append_transform.py
+++ b/blender/arm/logicnode/transform/LN_append_transform.py
@@ -12,5 +12,3 @@ class AppendTransformNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketShader', 'Transform')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(AppendTransformNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/transform/LN_get_object_location.py
+++ b/blender/arm/logicnode/transform/LN_get_object_location.py
@@ -4,11 +4,10 @@ class GetLocationNode(ArmLogicTreeNode):
     """Returns the current location of the given object in world coordinates."""
     bl_idname = 'LNGetLocationNode'
     bl_label = 'Get Object Location'
+    arm_section = 'location'
     arm_version = 1
 
     def init(self, context):
         super(GetLocationNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('NodeSocketVector', 'Location')
-
-add_node(GetLocationNode, category=PKG_AS_CATEGORY, section='location')

--- a/blender/arm/logicnode/transform/LN_get_object_rotation.py
+++ b/blender/arm/logicnode/transform/LN_get_object_rotation.py
@@ -4,6 +4,7 @@ class GetRotationNode(ArmLogicTreeNode):
     """Returns the current rotation of the given object."""
     bl_idname = 'LNGetRotationNode'
     bl_label = 'Get Object Rotation'
+    arm_section = 'rotation'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class GetRotationNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'Angle (Degrees)')
         self.add_output('NodeSocketVector', 'Quaternion XYZ')
         self.add_output('NodeSocketFloat', 'Quaternion W')
-
-add_node(GetRotationNode, category=PKG_AS_CATEGORY, section='rotation')

--- a/blender/arm/logicnode/transform/LN_get_object_scale.py
+++ b/blender/arm/logicnode/transform/LN_get_object_scale.py
@@ -4,11 +4,10 @@ class GetScaleNode(ArmLogicTreeNode):
     """Returns the scale of the given object."""
     bl_idname = 'LNGetScaleNode'
     bl_label = 'Get Object Scale'
+    arm_section = 'scale'
     arm_version = 1
 
     def init(self, context):
         super(GetScaleNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('NodeSocketVector', 'Scale')
-
-add_node(GetScaleNode, category=PKG_AS_CATEGORY, section='scale')

--- a/blender/arm/logicnode/transform/LN_get_object_transform.py
+++ b/blender/arm/logicnode/transform/LN_get_object_transform.py
@@ -12,5 +12,3 @@ class GetTransformNode(ArmLogicTreeNode):
         super(GetTransformNode, self).init(context)
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_output('NodeSocketShader', 'Transform')
-
-add_node(GetTransformNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/transform/LN_get_world_orientation.py
+++ b/blender/arm/logicnode/transform/LN_get_world_orientation.py
@@ -4,6 +4,7 @@ class GetWorldNode(ArmLogicTreeNode):
     """Returns the world orientation of the given object."""
     bl_idname = 'LNGetWorldNode'
     bl_label = 'Get World Orientation'
+    arm_section = 'rotation'
     arm_version = 1
 
     property0: EnumProperty(
@@ -19,5 +20,3 @@ class GetWorldNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(GetWorldNode, category=PKG_AS_CATEGORY, section='rotation')

--- a/blender/arm/logicnode/transform/LN_look_at.py
+++ b/blender/arm/logicnode/transform/LN_look_at.py
@@ -4,6 +4,7 @@ class LookAtNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNLookAtNode'
     bl_label = 'Look At'
+    arm_section = 'rotation'
     arm_version = 1
 
     property0: EnumProperty(
@@ -23,5 +24,3 @@ class LookAtNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
-add_node(LookAtNode, category=PKG_AS_CATEGORY, section='rotation')

--- a/blender/arm/logicnode/transform/LN_quaternion.py
+++ b/blender/arm/logicnode/transform/LN_quaternion.py
@@ -4,6 +4,7 @@ class QuaternionNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNQuaternionNode'
     bl_label = 'Quaternion'
+    arm_section = 'quaternions'
     arm_version = 1
 
     def init(self, context):
@@ -16,5 +17,3 @@ class QuaternionNode(ArmLogicTreeNode):
         self.add_output('NodeSocketVector', 'Quaternion')
         self.add_output('NodeSocketVector', 'XYZ')
         self.add_output('NodeSocketFloat', 'W')
-
-add_node(QuaternionNode, category=PKG_AS_CATEGORY, section='quaternions')

--- a/blender/arm/logicnode/transform/LN_rotate_object.py
+++ b/blender/arm/logicnode/transform/LN_rotate_object.py
@@ -4,6 +4,7 @@ class RotateObjectNode(ArmLogicTreeNode):
     """Rotates the given object."""
     bl_idname = 'LNRotateObjectNode'
     bl_label = 'Rotate Object'
+    arm_section = 'rotation'
     arm_version = 1
 
     def init(self, context):
@@ -45,5 +46,3 @@ class RotateObjectNode(ArmLogicTreeNode):
                  ('Quaternion', 'Quaternion', 'Quaternion')],
         name='', default='Euler Angles',
         update = on_property_update)
-
-add_node(RotateObjectNode, category=PKG_AS_CATEGORY, section='rotation')

--- a/blender/arm/logicnode/transform/LN_separate_quaternion.py
+++ b/blender/arm/logicnode/transform/LN_separate_quaternion.py
@@ -5,6 +5,7 @@ class SeparateQuaternionNode(ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNSeparateQuaternionNode'
     bl_label = "Separate Quaternion"
+    arm_section = 'quaternions'
     arm_version = 1
 
     def init(self, context):
@@ -14,6 +15,3 @@ class SeparateQuaternionNode(ArmLogicTreeNode):
         self.add_output('NodeSocketFloat', 'Y')
         self.add_output('NodeSocketFloat', 'Z')
         self.add_output('NodeSocketFloat', 'W')
-
-
-add_node(SeparateQuaternionNode, category=PKG_AS_CATEGORY, section='quaternions')

--- a/blender/arm/logicnode/transform/LN_separate_transform.py
+++ b/blender/arm/logicnode/transform/LN_separate_transform.py
@@ -12,5 +12,3 @@ class SeparateTransformNode(ArmLogicTreeNode):
         self.add_output('NodeSocketVector', 'Location')
         self.add_output('NodeSocketVector', 'Rotation')
         self.add_output('NodeSocketVector', 'Scale')
-
-add_node(SeparateTransformNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/transform/LN_set_object_location.py
+++ b/blender/arm/logicnode/transform/LN_set_object_location.py
@@ -4,6 +4,7 @@ class SetLocationNode(ArmLogicTreeNode):
     """Sets the location of the given object."""
     bl_idname = 'LNSetLocationNode'
     bl_label = 'Set Object Location'
+    arm_section = 'location'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class SetLocationNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketVector', 'Location')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetLocationNode, category=PKG_AS_CATEGORY, section='location')

--- a/blender/arm/logicnode/transform/LN_set_object_rotation.py
+++ b/blender/arm/logicnode/transform/LN_set_object_rotation.py
@@ -4,6 +4,7 @@ class SetRotationNode(ArmLogicTreeNode):
     """Sets the rotation of the given object."""
     bl_idname = 'LNSetRotationNode'
     bl_label = 'Set Object Rotation'
+    arm_section = 'rotation'
     arm_version = 1
 
     def init(self, context):
@@ -38,5 +39,3 @@ class SetRotationNode(ArmLogicTreeNode):
                  ('Quaternion', 'Quaternion', 'Quaternion')],
         name='', default='Euler Angles',
         update=on_property_update)
-
-add_node(SetRotationNode, category=PKG_AS_CATEGORY, section='rotation')

--- a/blender/arm/logicnode/transform/LN_set_object_scale.py
+++ b/blender/arm/logicnode/transform/LN_set_object_scale.py
@@ -4,6 +4,7 @@ class SetScaleNode(ArmLogicTreeNode):
     """Sets the scale of the given object."""
     bl_idname = 'LNSetScaleNode'
     bl_label = 'Set Object Scale'
+    arm_section = 'scale'
     arm_version = 1
 
     def init(self, context):
@@ -12,5 +13,3 @@ class SetScaleNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketVector', 'Scale', default_value=[1.0, 1.0, 1.0])
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetScaleNode, category=PKG_AS_CATEGORY, section='scale')

--- a/blender/arm/logicnode/transform/LN_set_object_transform.py
+++ b/blender/arm/logicnode/transform/LN_set_object_transform.py
@@ -12,5 +12,3 @@ class SetTransformNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketShader', 'Transform')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetTransformNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/transform/LN_transform.py
+++ b/blender/arm/logicnode/transform/LN_transform.py
@@ -12,5 +12,3 @@ class TransformNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'Rotation')
         self.add_input('NodeSocketVector', 'Scale', default_value=[1.0, 1.0, 1.0])
         self.add_output('NodeSocketShader', 'Transform')
-
-add_node(TransformNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/transform/LN_transform_math.py
+++ b/blender/arm/logicnode/transform/LN_transform_math.py
@@ -11,5 +11,3 @@ class TransformMathNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Transform 1')
         self.add_input('NodeSocketShader', 'Transform 2')
         self.add_output('NodeSocketShader', 'Result')
-
-add_node(TransformMathNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/transform/LN_translate_object.py
+++ b/blender/arm/logicnode/transform/LN_translate_object.py
@@ -4,6 +4,7 @@ class TranslateObjectNode(ArmLogicTreeNode):
     """Translates (moves) the given object using the given vector in world coordinates."""
     bl_idname = 'LNTranslateObjectNode'
     bl_label = 'Translate Object'
+    arm_section = 'location'
     arm_version = 1
 
     def init(self, context):
@@ -13,5 +14,3 @@ class TranslateObjectNode(ArmLogicTreeNode):
         self.add_input('NodeSocketVector', 'Vector')
         self.add_input('NodeSocketBool', 'On Local Axis')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(TranslateObjectNode, category=PKG_AS_CATEGORY, section='location')

--- a/blender/arm/logicnode/transform/LN_translate_on_local_axis.py
+++ b/blender/arm/logicnode/transform/LN_translate_on_local_axis.py
@@ -5,6 +5,7 @@ class TranslateOnLocalAxisNode(ArmLogicTreeNode):
     """Translates (moves) the given object using the given vector in the local coordinates."""
     bl_idname = 'LNTranslateOnLocalAxisNode'
     bl_label = 'Translate On Local Axis'
+    arm_section = 'location'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class TranslateOnLocalAxisNode(ArmLogicTreeNode):
         self.add_input('NodeSocketInt', 'Forward/Up/Right')
         self.add_input('NodeSocketBool', 'Inverse')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(TranslateOnLocalAxisNode, category=PKG_AS_CATEGORY, section='location')

--- a/blender/arm/logicnode/transform/LN_vector_from_transform.py
+++ b/blender/arm/logicnode/transform/LN_vector_from_transform.py
@@ -37,5 +37,3 @@ class VectorFromTransformNode(ArmLogicTreeNode):
                  ('Quaternion', 'Quaternion', 'Quaternion')],
         name='', default='Look',
         update=on_property_update)
-
-add_node(VectorFromTransformNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/transform/LN_vector_to_object_orientation.py
+++ b/blender/arm/logicnode/transform/LN_vector_to_object_orientation.py
@@ -8,6 +8,7 @@ class VectorToObjectOrientationNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNVectorToObjectOrientationNode'
     bl_label = 'Vector To Object Orientation'
+    arm_section = 'location'
     arm_version = 1
 
     def init(self, context):
@@ -15,5 +16,3 @@ class VectorToObjectOrientationNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketVector', 'World')
         self.add_output('NodeSocketVector', 'Local')
-
-add_node(VectorToObjectOrientationNode, category=PKG_AS_CATEGORY, section='location')

--- a/blender/arm/logicnode/variable/LN_boolean.py
+++ b/blender/arm/logicnode/variable/LN_boolean.py
@@ -11,5 +11,3 @@ class BooleanNode(ArmLogicTreeNode):
         super(BooleanNode, self).init(context)
         self.add_input('NodeSocketBool', 'Bool In')
         self.add_output('NodeSocketBool', 'Bool Out', is_var=True)
-
-add_node(BooleanNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/variable/LN_color.py
+++ b/blender/arm/logicnode/variable/LN_color.py
@@ -10,5 +10,3 @@ class ColorNode(ArmLogicTreeNode):
         super(ColorNode, self).init(context)
         self.add_input('NodeSocketColor', 'Color In', default_value=[1.0, 1.0, 1.0, 1.0])
         self.add_output('NodeSocketColor', 'Color Out', is_var=True)
-
-add_node(ColorNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/variable/LN_dynamic.py
+++ b/blender/arm/logicnode/variable/LN_dynamic.py
@@ -9,5 +9,3 @@ class DynamicNode(ArmLogicTreeNode):
     def init(self, context):
         super(DynamicNode, self).init(context)
         self.add_output('NodeSocketShader', 'Dynamic', is_var=True)
-
-add_node(DynamicNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/variable/LN_float.py
+++ b/blender/arm/logicnode/variable/LN_float.py
@@ -13,5 +13,3 @@ class FloatNode(ArmLogicTreeNode):
         super(FloatNode, self).init(context)
         self.add_input('NodeSocketFloat', 'Float In')
         self.add_output('NodeSocketFloat', 'Float Out', is_var=True)
-
-add_node(FloatNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/variable/LN_integer.py
+++ b/blender/arm/logicnode/variable/LN_integer.py
@@ -10,5 +10,3 @@ class IntegerNode(ArmLogicTreeNode):
         super(IntegerNode, self).init(context)
         self.add_input('NodeSocketInt', 'Int In')
         self.add_output('NodeSocketInt', 'Int Out', is_var=True)
-
-add_node(IntegerNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/variable/LN_mask.py
+++ b/blender/arm/logicnode/variable/LN_mask.py
@@ -13,5 +13,3 @@ class MaskNode(ArmLogicTreeNode):
             self.inputs.new('NodeSocketBool', label)
 
         self.add_output('NodeSocketInt', 'Mask', is_var=True)
-
-add_node(MaskNode, category=PKG_AS_CATEGORY)

--- a/blender/arm/logicnode/variable/LN_set_variable.py
+++ b/blender/arm/logicnode/variable/LN_set_variable.py
@@ -10,6 +10,7 @@ class SetVariableNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNSetVariableNode'
     bl_label = 'Set Variable'
+    arm_section = 'set'
     arm_version = 1
 
     def init(self, context):
@@ -18,5 +19,3 @@ class SetVariableNode(ArmLogicTreeNode):
         self.add_input('NodeSocketShader', 'Variable', is_var=True)
         self.add_input('NodeSocketShader', 'Value')
         self.add_output('ArmNodeSocketAction', 'Out')
-
-add_node(SetVariableNode, category=PKG_AS_CATEGORY, section='set')

--- a/blender/arm/logicnode/variable/LN_vector.py
+++ b/blender/arm/logicnode/variable/LN_vector.py
@@ -13,6 +13,3 @@ class VectorNode(ArmLogicTreeNode):
         self.add_input('NodeSocketFloat', 'Z')
 
         self.add_output('NodeSocketVector', 'Vector', is_var=True)
-
-
-add_node(VectorNode, category=PKG_AS_CATEGORY)


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1961.

Previously, the `array` subpackage for the array category made it impossible to use the python built-in package with the same name. It was a bit tricky to fix it but now the packages are imported correctly.

In addition to that, logic nodes are no longer registered by just importing and executing their modules, but with dedicated `on_register` and `on_unregister` functions that can be overridden if required. This makes it even simpler to register nodes and improves the maintainability.

Previously:
```python
class MyNode(ArmLogicTreeNode).
    ...

add_node(MyNode, category="MyCategory")
```

Now:
```python
class MyNode(ArmLogicTreeNode):
    arm_category = "MyCategory"
```

Or:
```python
class MyNode(ArmLogicTreeNode):
    arm_category = "MyCategory"

    @classmethod
    def on_register(cls):
        do_something()
        super().on_register()

    @classmethod
    def on_unregister(cls):
        do_something_else()
        super().on_unregister()
```