### PR TITLE
Improve handling of deprecated logic nodes

### DIFF
--- a/blender/arm/logicnode/deprecated/LN_get_mouse_lock.py
+++ b/blender/arm/logicnode/deprecated/LN_get_mouse_lock.py
@@ -3,16 +3,16 @@ from bpy.props import *
 from bpy.types import Node, NodeSocket
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Get Cursor State')
 class GetMouseLockNode(ArmLogicTreeNode):
     """Deprecated. It is recommended to use the 'Get Cursor State' node instead."""
     bl_idname = 'LNGetMouseLockNode'
-    bl_label = 'Get Mouse Lock (Deprecated)'
+    bl_label = 'Get Mouse Lock'
     bl_description = "Please use the \"Get Cursor State\" node instead"
-    bl_icon = 'ERROR'
     arm_version = 2
-    arm_category = 'input'
+    arm_category = 'Input'
     arm_section = 'mouse'
-    arm_is_obsolete = True
 
     def init(self, context):
         super(GetMouseLockNode, self).init(context)
@@ -24,5 +24,5 @@ class GetMouseLockNode(ArmLogicTreeNode):
 
         return NodeReplacement(
             'LNGetMouseLockNode', self.arm_version, 'LNGetCursorStateNode', 1,
-            in_socket_mapping = {}, out_socket_mapping={0:2}
+            in_socket_mapping={}, out_socket_mapping={0: 2}
         )

--- a/blender/arm/logicnode/deprecated/LN_get_mouse_visible.py
+++ b/blender/arm/logicnode/deprecated/LN_get_mouse_visible.py
@@ -3,15 +3,15 @@ from bpy.props import *
 from bpy.types import Node, NodeSocket
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Get Cursor State')
 class GetMouseVisibleNode(ArmLogicTreeNode):
     """Deprecated. It is recommended to use the 'Get Cursor State' node instead."""
     bl_idname = 'LNGetMouseVisibleNode'
-    bl_label = 'Get Mouse Visible (Deprecated)'
+    bl_label = 'Get Mouse Visible'
     bl_description = "Please use the \"Get Cursor State\" node instead"
-    bl_icon = 'ERROR'
-    arm_category = 'input'
+    arm_category = 'Input'
     arm_section = 'mouse'
-    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_mouse_coords.py
+++ b/blender/arm/logicnode/deprecated/LN_mouse_coords.py
@@ -1,14 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Get Cursor Location')
 class MouseCoordsNode(ArmLogicTreeNode):
     """Deprecated. It is recommended to use 'Get Cursor Location' node and the 'Get Mouse Movement' node instead."""
     bl_idname = 'LNMouseCoordsNode'
-    bl_label = 'Mouse Coords (Deprecated)'
+    bl_label = 'Mouse Coords'
     bl_description = "Please use the \"Get Cursor Location\" and \"Get Mouse Movement\" nodes instead"
-    bl_icon = 'ERROR'
-    arm_category = 'input'
+    arm_category = 'Input'
     arm_section = 'mouse'
-    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_on_gamepad.py
+++ b/blender/arm/logicnode/deprecated/LN_on_gamepad.py
@@ -1,14 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Gamepad')
 class OnGamepadNode(ArmLogicTreeNode):
     """Deprecated. It is recommended to use the 'Gamepad' node instead."""
     bl_idname = 'LNOnGamepadNode'
-    bl_label = "On Gamepad (Deprecated)"
+    bl_label = "On Gamepad"
     bl_description = "Please use the \"Gamepad\" node instead"
-    bl_icon = 'ERROR'
-    arm_category = 'input'
+    arm_category = 'Input'
     arm_section = 'gamepad'
-    arm_is_obsolete = True
     arm_version = 2
 
     property0: EnumProperty(

--- a/blender/arm/logicnode/deprecated/LN_on_keyboard.py
+++ b/blender/arm/logicnode/deprecated/LN_on_keyboard.py
@@ -1,14 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Keyboard')
 class OnKeyboardNode(ArmLogicTreeNode):
     """Deprecated. It is recommended to use the 'Keyboard' node instead."""
     bl_idname = 'LNOnKeyboardNode'
-    bl_label = "On Keyboard (Deprecated)"
-    bl_descrition = "Please use the \"Keyboard\" node instead"
-    bl_icon = 'ERROR'
-    arm_category = 'input'
+    bl_label = "On Keyboard"
+    bl_description = "Please use the \"Keyboard\" node instead"
+    arm_category = 'Input'
     arm_section = 'keyboard'
-    arm_is_obsolete = True
     arm_version = 2
 
     property0: EnumProperty(

--- a/blender/arm/logicnode/deprecated/LN_on_mouse.py
+++ b/blender/arm/logicnode/deprecated/LN_on_mouse.py
@@ -1,14 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Mouse')
 class OnMouseNode(ArmLogicTreeNode):
     """Deprecated. It is recommended to use the 'Mouse' node instead."""
     bl_idname = 'LNOnMouseNode'
-    bl_label = "On Mouse (Deprecated)"
+    bl_label = "On Mouse"
     bl_description = "Please use the \"Mouse\" node instead"
-    bl_icon = 'ERROR'
-    arm_category = 'input'
+    arm_category = 'Input'
     arm_section = 'mouse'
-    arm_is_obsolete = True
     arm_version = 2
 
     property0: EnumProperty(

--- a/blender/arm/logicnode/deprecated/LN_on_surface.py
+++ b/blender/arm/logicnode/deprecated/LN_on_surface.py
@@ -1,15 +1,16 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Surface')
 class OnSurfaceNode(ArmLogicTreeNode):
-    """Deprecated. Is recommended to use Surface node instead."""
+    """Deprecated. Is recommended to use the 'Surface' node instead."""
     bl_idname = 'LNOnSurfaceNode'
     bl_label = 'On Surface'
     bl_description = "Please use the \"Surface\" node instead"
-    bl_icon = 'ERROR'
-    arm_category = 'input'
+    arm_category = 'Input'
     arm_section = 'surface'
-    arm_is_obsolete = True
     arm_version = 2
+
     property0: EnumProperty(
         items = [('Touched', 'Touched', 'Touched'),
                  ('Started', 'Started', 'Started'),

--- a/blender/arm/logicnode/deprecated/LN_on_virtual_button.py
+++ b/blender/arm/logicnode/deprecated/LN_on_virtual_button.py
@@ -1,14 +1,16 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Virtual Button')
 class OnVirtualButtonNode(ArmLogicTreeNode):
     """Deprecated. Is recommended to use 'Virtual Button' node instead."""
     bl_idname = 'LNOnVirtualButtonNode'
     bl_label = 'On Virtual Button'
     bl_description = "Please use the \"Virtual Button\" node instead"
-    bl_icon = 'ERROR'
+    arm_category = 'Input'
     arm_section = 'virtual'
-    arm_is_obsolete = True
     arm_version = 2
+
     property0: EnumProperty(
         items = [('Down', 'Down', 'Down'),
                  ('Started', 'Started', 'Started'),

--- a/blender/arm/logicnode/deprecated/LN_pause_action.py
+++ b/blender/arm/logicnode/deprecated/LN_pause_action.py
@@ -1,12 +1,13 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Action Paused')
 class PauseActionNode(ArmLogicTreeNode):
     """Pauses the given action."""
     bl_idname = 'LNPauseActionNode'
     bl_label = 'Pause Action'
     bl_description = "Please use the \"Set Action Paused\" node instead"
-    bl_icon = 'ERROR'
-    arm_is_obsolete = True
+    arm_category = 'Animation'
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_pause_tilesheet.py
+++ b/blender/arm/logicnode/deprecated/LN_pause_tilesheet.py
@@ -1,13 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Tilesheet Paused')
 class PauseTilesheetNode(ArmLogicTreeNode):
     """Pauses the given tilesheet action."""
     bl_idname = 'LNPauseTilesheetNode'
     bl_label = 'Pause Tilesheet'
     bl_description = "Please use the \"Set Tilesheet Paused\" node instead"
-    bl_icon = 'ERROR'
+    arm_category = 'Animation'
     arm_section = 'tilesheet'
-    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_pause_trait.py
+++ b/blender/arm/logicnode/deprecated/LN_pause_trait.py
@@ -1,12 +1,13 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Trait Paused')
 class PauseTraitNode(ArmLogicTreeNode):
     """Pauses the given trait."""
     bl_idname = 'LNPauseTraitNode'
     bl_label = 'Pause Trait'
     bl_description = "Please use the \"Set Trait Paused\" node instead"
-    bl_icon = 'ERROR'
-    arm_is_obsolete = True
+    arm_category = 'Trait'
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_play_action.py
+++ b/blender/arm/logicnode/deprecated/LN_play_action.py
@@ -1,12 +1,13 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Play Action From')
 class PlayActionNode(ArmLogicTreeNode):
     """Plays the given action."""
     bl_idname = 'LNPlayActionNode'
     bl_label = 'Play Action'
     bl_description = "Please use the \"Play Action From\" node instead"
-    bl_icon = 'ERROR'
-    arm_is_obsolete = True
+    arm_category = 'Animation'
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_resume_action.py
+++ b/blender/arm/logicnode/deprecated/LN_resume_action.py
@@ -1,12 +1,13 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Action Paused')
 class ResumeActionNode(ArmLogicTreeNode):
     """Resumes the given action."""
     bl_idname = 'LNResumeActionNode'
     bl_label = 'Resume Action'
     bl_description = "Please use the \"Set Action Paused\" node instead"
-    bl_icon = 'ERROR'
-    arm_is_obsolete = True
+    arm_category = 'Animation'
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_resume_tilesheet.py
+++ b/blender/arm/logicnode/deprecated/LN_resume_tilesheet.py
@@ -1,12 +1,13 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Tilesheet Paused')
 class ResumeTilesheetNode(ArmLogicTreeNode):
     """Resumes the given tilesheet action."""
     bl_idname = 'LNResumeTilesheetNode'
     bl_label = 'Resume Tilesheet'
     bl_description = "Please use the \"Set Tilesheet Paused\" node instead"
-    bl_icon = 'ERROR'
-    arm_is_obsolete = True
+    arm_category = 'Animation'
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_resume_trait.py
+++ b/blender/arm/logicnode/deprecated/LN_resume_trait.py
@@ -1,12 +1,13 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Trait Paused')
 class ResumeTraitNode(ArmLogicTreeNode):
     """Resumes the given trait."""
     bl_idname = 'LNResumeTraitNode'
     bl_label = 'Resume Trait'
     bl_description = "Please use the \"Set Trait Paused\" node instead"
-    bl_icon = 'ERROR'
-    arm_is_obsolete = True
+    arm_category = 'Trait'
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_rotate_object_around_axis.py
+++ b/blender/arm/logicnode/deprecated/LN_rotate_object_around_axis.py
@@ -1,14 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Rotate Object')
 class RotateObjectAroundAxisNode(ArmLogicTreeNode):
     """Deprecated. It is recommended to use the 'Rotate Object' node instead."""
     bl_idname = 'LNRotateObjectAroundAxisNode'
-    bl_label = 'Rotate Object Around Axis (Deprecated)'
+    bl_label = 'Rotate Object Around Axis'
     bl_description = "Please use the \"Rotate Object\" node instead"
-    arm_category = 'transform'
+    arm_category = 'Transform'
     arm_section = 'rotation'
-    arm_is_obsolete = True
-    bl_icon = 'ERROR'
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_scale_object.py
+++ b/blender/arm/logicnode/deprecated/LN_scale_object.py
@@ -1,13 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Object Scale')
 class ScaleObjectNode(ArmLogicTreeNode):
     """Deprecated. 'Use Set Object Scale' instead."""
     bl_idname = 'LNScaleObjectNode'
     bl_label = 'Scale Object'
     bl_description = "Please use the \"Set Object Scale\" node instead"
-    bl_icon = 'ERROR'
+    arm_category = 'Transform'
     arm_section = 'scale'
-    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_set_mouse_lock.py
+++ b/blender/arm/logicnode/deprecated/LN_set_mouse_lock.py
@@ -1,14 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Cursor State')
 class SetMouseLockNode(ArmLogicTreeNode):
     """Deprecated. It is recommended to use the 'Set Cursor State' node instead."""
     bl_idname = 'LNSetMouseLockNode'
-    bl_label = 'Set Mouse Lock (Deprecated)'
+    bl_label = 'Set Mouse Lock'
     bl_description = "Please use the \"Set Cursor State\" node instead"
-    bl_icon = 'ERROR'
-    arm_category = 'input'
+    arm_category = 'Input'
     arm_section = 'mouse'
-    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_set_mouse_visible.py
+++ b/blender/arm/logicnode/deprecated/LN_set_mouse_visible.py
@@ -1,14 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Cursor State')
 class ShowMouseNode(ArmLogicTreeNode):
     """Deprecated. It is recommended to use the 'Set Cursor State' node instead."""
     bl_idname = 'LNShowMouseNode'
-    bl_label = "Set Mouse Visible (Deprecated)"
+    bl_label = "Set Mouse Visible"
     bl_description = "Please use the \"Set Cursor State\" node instead"
-    bl_icon = 'ERROR'
-    arm_category = 'input'
+    arm_category = 'Input'
     arm_section = 'mouse'
-    arm_is_obsolete = True
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_set_object_material.py
+++ b/blender/arm/logicnode/deprecated/LN_set_object_material.py
@@ -1,12 +1,13 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Set Object Material Slot')
 class SetMaterialNode(ArmLogicTreeNode):
     """Sets the material of the given object."""
     bl_idname = 'LNSetMaterialNode'
     bl_label = 'Set Object Material'
     bl_description = "Please use the \"Set Object Material Slot\" node instead"
-    bl_icon = 'ERROR'
-    arm_is_obsolete = True
+    arm_category = 'Material'
     arm_version = 2
 
     def init(self, context):

--- a/blender/arm/logicnode/deprecated/LN_surface_coords.py
+++ b/blender/arm/logicnode/deprecated/LN_surface_coords.py
@@ -1,12 +1,13 @@
 from arm.logicnode.arm_nodes import *
 
+
+@deprecated('Get Touch Movement', 'Get Touch Location')
 class SurfaceCoordsNode(ArmLogicTreeNode):
     """Deprecated. Is recommended to use 'Get Touch Location' and 'Get Touch Movement' node instead."""
     bl_idname = 'LNSurfaceCoordsNode'
     bl_label = 'Surface Coords'
     bl_description = "Please use the \"Get Touch Movement\" and \"Get Touch Location\" nodes instead"
-    bl_icon = 'ERROR'
-    arm_category = 'input'
+    arm_category = 'Input'
     arm_section = 'surface'
     arm_is_obsolete = 'is_obsolete'
     arm_version = 2

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -1,3 +1,8 @@
+from typing import Type
+
+import bpy
+from nodeitems_utils import NodeItem
+
 
 def find_node_by_link(node_group, to_node, inp):
     for link in node_group.links:
@@ -5,7 +10,7 @@ def find_node_by_link(node_group, to_node, inp):
             if link.from_node.bl_idname == 'NodeReroute': # Step through reroutes
                 return find_node_by_link(node_group, link.from_node, link.from_node.inputs[0])
             return link.from_node
-    
+
 def find_node_by_link_from(node_group, from_node, outp):
     for link in node_group.links:
         if link.from_node == from_node and link.from_socket == outp:
@@ -39,3 +44,12 @@ def get_output_node(node_group, from_node, output_index):
             if link.to_node.bl_idname == 'NodeReroute': # Step through reroutes
                 return find_node_by_link_from(node_group, link.to_node, link.to_node.inputs[0])
             return link.to_node
+
+
+def nodetype_to_nodeitem(node_type: Type[bpy.types.Node]) -> NodeItem:
+    """Create a NodeItem from a given node class."""
+    # Internal node types seem to have no bl_idname attribute
+    if issubclass(node_type, bpy.types.NodeInternal):
+        return NodeItem(node_type.__name__)
+
+    return NodeItem(node_type.bl_idname)

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -69,8 +69,7 @@ class ARM_OT_AddNodeOverride(bpy.types.Operator):
     def description(cls, context, properties):
         """Show the node's bl_description attribute as a tooltip or, if
         it doesn't exist, its docstring."""
-        # Type name to type
-        nodetype = bpy.types.bpy_struct.bl_rna_get_subclass_py(properties.type)
+        nodetype = arm.utils.type_name_to_type(properties.type)
 
         if hasattr(nodetype, 'bl_description'):
             return nodetype.bl_description.split('.')[0]

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -926,6 +926,10 @@ def get_android_open_build_apk_directory():
     addon_prefs = get_arm_preferences()
     return False if not hasattr(addon_prefs, 'android_open_build_apk_directory') else addon_prefs.android_open_build_apk_directory
 
+def type_name_to_type(name: str) -> bpy.types.bpy_struct:
+    """Return the Blender type given by its name, if registered."""
+    return bpy.types.bpy_struct.bl_rna_get_subclass_py(name)
+
 def register(local_sdk=False):
     global use_local_sdk
     use_local_sdk = local_sdk


### PR DESCRIPTION
Linked to https://github.com/armory3d/armory_tools/pull/5.

- Deprecated logic nodes are now also registered, but not in a menu. This makes it possible to access them for reference generation.
- There is now a `@deprecate()` decorator for the node classes to reduce duplicate code:

  ```python
  @deprecate()
  class MyNode(ArmLogicTreeNode):
     ...

  @deprecate('AlternativeNode 1', 'Alternative Node 2')
  class MyNodeWithAlternatives(ArmLogicTreeNode):
     ...

  @deprecate('AlternativeNode 1', 'Alternative Node 2', message='This node was deprecated because of XYZ')
  class MyNodeWithAlternativesAndMessage(ArmLogicTreeNode):
     ...
  ```

  Using this decorator will automatically deprecate the node ('is_obsolete = True'), set the correct icon (`ERROR`), change the label and add documentation according to the passed parameters. This way we can just keep the nodes as they are (no need to change the label, description or package) and everything will happen automatically.

  The generated reference will look like the following (without a custom message that would be appended):
  
  ![Screenshot of a deprecated node in the reference](https://user-images.githubusercontent.com/17685000/97489185-83472f00-195f-11eb-8186-d7de951098a9.png)

  This does *not* replace the auto-replacement feature, this is something that must still be implemented for each node in question.

- Outsourced some common functionality into `utils.py` and `node_utils.py`