### PR TITLE
Further improve handling of nodes/menu registration

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -123,6 +123,9 @@ def on_load_post(context):
 
     # Load libraries
     if os.path.exists(arm.utils.get_fp() + '/Libraries'):
+        # Don't register nodes twice when calling register_nodes()
+        arm.logicnode.arm_nodes.reset_globals()
+
         libs = os.listdir(arm.utils.get_fp() + '/Libraries')
         for lib in libs:
             if os.path.isdir(arm.utils.get_fp() + '/Libraries/' + lib):
@@ -136,7 +139,6 @@ def on_load_post(context):
                     sys.path.remove(fp)
 
         # Register newly added nodes and node categories
-        arm.logicnode.arm_nodes.reset_globals()
         arm.nodes_logic.register_nodes()
 
     # Show trait users as collections

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -26,13 +26,14 @@ class ARM_MT_NodeAddOverride(bpy.types.Menu):
     Overrides the `Add node` menu. If called from the logic node
     editor, the custom menu is drawn, otherwise the default one is drawn.
 
-    Todo: Find a better solution to custom menus, this will conflict
-    with other add-ons overriding this menu.
+    TODO: Find a better solution to custom menus, this will conflict
+     with other add-ons overriding this menu.
     """
     bl_idname = "NODE_MT_add"
     bl_label = "Add"
     bl_translation_context = bpy.app.translations.contexts.operator_default
 
+    overridden_menu: bpy.types.Menu = None
     overridden_draw: Callable = None
 
     def draw(self, context):
@@ -517,6 +518,7 @@ def register():
     bpy.utils.register_class(ARM_PT_Variables)
     bpy.utils.register_class(ARMAddVarNode)
     bpy.utils.register_class(ARMAddSetVarNode)
+    ARM_MT_NodeAddOverride.overridden_menu = bpy.types.NODE_MT_add
     ARM_MT_NodeAddOverride.overridden_draw = bpy.types.NODE_MT_add.draw
     bpy.utils.register_class(ARM_MT_NodeAddOverride)
     bpy.utils.register_class(ARM_OT_AddNodeOverride)
@@ -529,6 +531,9 @@ def register():
 def unregister():
     unregister_nodes()
 
+    # Ensure that globals are reset if the addon is enabled again in the same Blender session
+    arm_nodes.reset_globals()
+
     bpy.utils.unregister_class(ReplaceNodesOperator)
     bpy.utils.unregister_class(ArmLogicTree)
     bpy.utils.unregister_class(ARM_PT_LogicNodePanel)
@@ -540,6 +545,7 @@ def unregister():
     bpy.utils.unregister_class(ARMAddSetVarNode)
     bpy.utils.unregister_class(ARM_OT_AddNodeOverride)
     bpy.utils.unregister_class(ARM_MT_NodeAddOverride)
+    bpy.utils.register_class(ARM_MT_NodeAddOverride.overridden_menu)
 
     bpy.types.NODE_MT_context_menu.remove(draw_custom_logicnode_menu)
 


### PR DESCRIPTION
Just smaller fixes:
- Libraries still weren't handled correctly
- Fixed duplicate node registration resulting in errors when Armory was disabled and enabled in one Blender session.
- The regular/Blender add node menu (also for shaders) wouldn't work anymore after disabling Armory until restarting Blender (thanks @knowledgenude for reporting)