### PR TITLE
Implement optional profiling for export

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -30,6 +30,7 @@ import arm.material.cycles as cycles
 import arm.material.make as make_material
 import arm.material.mat_batch as mat_batch
 import arm.utils
+import arm.profiler
 
 
 @unique
@@ -127,7 +128,6 @@ class ArmoryExporter:
         self.world_array = []
         self.particle_system_array = {}
 
-
         # `True` if there is at least one spawned camera in the scene
         self.camera_spawned = False
 
@@ -150,7 +150,8 @@ class ArmoryExporter:
         """Exports the given scene to the given file path. This is the
         function that is called in make.py and the entry point of the
         exporter."""
-        cls(context, filepath, scene, depsgraph).execute()
+        with arm.profiler.Profile('profile_exporter.prof', arm.utils.get_pref_or_default('profile_exporter', False)):
+            cls(context, filepath, scene, depsgraph).execute()
 
     @classmethod
     def preprocess(cls):

--- a/blender/arm/profiler.py
+++ b/blender/arm/profiler.py
@@ -1,0 +1,35 @@
+import cProfile
+import os
+import pstats
+
+import arm.log as log
+import arm.utils as utils
+
+
+class Profile:
+    """Context manager for profiling the enclosed code when the given condition is true.
+    The output file is stored in the SDK directory and can be opened by tools such as SnakeViz.
+    """
+    def __init__(self, filename_out: str, condition: bool):
+        self.filename_out = filename_out
+        self.condition = condition
+        self.pr = cProfile.Profile()
+
+    def __enter__(self):
+        if self.condition:
+            self.pr.enable()
+            log.debug("Profiling started")
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.condition:
+            self.pr.disable()
+            log.debug("Profiling finished")
+
+            profile_path = os.path.join(utils.get_sdk_path(), self.filename_out)
+            with open(profile_path, 'w') as profile_file:
+                stats = pstats.Stats(self.pr, stream=profile_file)
+                stats.dump_stats(profile_path)
+
+        return False

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -4,6 +4,7 @@ import os
 import platform
 import re
 import subprocess
+from typing import Any
 import webbrowser
 import shlex
 
@@ -225,6 +226,11 @@ def get_relative_paths():
     """Whether to convert absolute paths to relative"""
     addon_prefs = get_arm_preferences()
     return False if not hasattr(addon_prefs, 'relative_paths') else addon_prefs.relative_paths
+
+def get_pref_or_default(prop_name: str, default: Any) -> Any:
+    """Return the preference setting for prop_name, or the value given as default if the property does not exist."""
+    addon_prefs = get_arm_preferences()
+    return default if not hasattr(addon_prefs, prop_name) else getattr(addon_prefs, prop_name)
 
 def get_node_path():
     if get_os() == 'win':

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -230,7 +230,7 @@ def get_relative_paths():
 def get_pref_or_default(prop_name: str, default: Any) -> Any:
     """Return the preference setting for prop_name, or the value given as default if the property does not exist."""
     addon_prefs = get_arm_preferences()
-    return default if not hasattr(addon_prefs, prop_name) else getattr(addon_prefs, prop_name)
+    return getattr(addon_prefs, prop_name, default)
 
 def get_node_path():
     if get_os() == 'win':


### PR DESCRIPTION
Linked to https://github.com/armory3d/armsdk/pull/16.

Combined with the PR above, you can now choose to run [cProfile](https://docs.python.org/3.7/library/profile.html#module-cProfile) when exporting the scene. This will generate a file called `profile_exporter.prof` in the SDK directory with detailed information about the number of calls and the time taken by the functions called during export. This file can then be opened by tools such as [SnakeViz](https://jiffyclub.github.io/snakeviz/) to get a graphical representation of whats happening during export:

----
**Example use case:** 

![snakeviz_exporter](https://user-images.githubusercontent.com/17685000/97766651-a4eb1680-1b17-11eb-94cc-1bfd48af2ef2.png)

This is the result when compiling the celshade example project, which takes a huge amount of time. About 3/4 of the time are taken away for the export of individual objects (and analyzing the results a bit more leads to the conclusion that [the way bone animations are exported](https://github.com/armory3d/armory/blob/master/blender/arm/exporter.py#L487-L500) is horrendously slow because for each bone the entire scene is set to each frame resulting in a complete redrawing and recalculation of the scene).

This is a very small step for the Python side of things towards https://github.com/armory3d/armory/issues/870. The new `Profile` context manager can be used for other occasions as well and can even be nested, although it will mess a bit with the results. It should always be opt-in due to performance reasons.

I've also added a new util function to get a preference setting or a default value if it doesn't exist, which makes many of the current `get_[something]()` functions obsolete (they are still used though, that's not part of this PR).