### PR TITLE
Custom nodes + libraries improvements (once more)

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -122,18 +122,19 @@ def on_load_post(context):
     arm.api.drivers = dict()
 
     # Load libraries
-    if os.path.exists(arm.utils.get_fp() + '/Libraries'):
+    lib_path = os.path.join(arm.utils.get_fp(), 'Libraries')
+    if os.path.exists(lib_path):
         # Don't register nodes twice when calling register_nodes()
         arm_nodes.reset_globals()
 
         # Make sure that Armory's categories are registered first (on top of the menu)
         arm.logicnode.init_categories()
 
-        libs = os.listdir(arm.utils.get_fp() + '/Libraries')
+        libs = os.listdir(lib_path)
         for lib in libs:
-            if os.path.isdir(arm.utils.get_fp() + '/Libraries/' + lib):
-                fp = arm.utils.get_fp() + '/Libraries/' + lib
-                if fp not in appended_py_paths and os.path.exists(fp + '/blender.py'):
+            fp = os.path.join(lib_path, lib)
+            if os.path.isdir(fp):
+                if fp not in appended_py_paths and os.path.exists(os.path.join(fp, 'blender.py')):
                     appended_py_paths.append(fp)
                     sys.path.append(fp)
                     import blender

--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -6,7 +6,7 @@ import bpy
 from bpy.app.handlers import persistent
 
 import arm.api
-import arm.logicnode.arm_nodes
+import arm.logicnode.arm_nodes as arm_nodes
 import arm.nodes_logic
 import arm.make as make
 import arm.make_state as state
@@ -124,7 +124,10 @@ def on_load_post(context):
     # Load libraries
     if os.path.exists(arm.utils.get_fp() + '/Libraries'):
         # Don't register nodes twice when calling register_nodes()
-        arm.logicnode.arm_nodes.reset_globals()
+        arm_nodes.reset_globals()
+
+        # Make sure that Armory's categories are registered first (on top of the menu)
+        arm.logicnode.init_categories()
 
         libs = os.listdir(arm.utils.get_fp() + '/Libraries')
         for lib in libs:

--- a/blender/arm/logicnode/__init__.py
+++ b/blender/arm/logicnode/__init__.py
@@ -5,45 +5,47 @@ import pkgutil
 import arm.logicnode.arm_nodes as arm_nodes
 import arm.logicnode.arm_sockets as arm_sockets
 
-# Register node menu categories
-arm_nodes.add_category('Logic', icon='OUTLINER', section="basic",
-                       description="Logic nodes are used to control execution flow using branching, loops, gates etc.")
-arm_nodes.add_category('Event', icon='INFO', section="basic")
-arm_nodes.add_category('Input', icon='GREASEPENCIL', section="basic")
-arm_nodes.add_category('Native', icon='MEMORY', section="basic",
-                       description="The Native category contains nodes which interact with the system (Input/Output functionality, etc.) or Haxe.")
 
-arm_nodes.add_category('Camera', icon='OUTLINER_OB_CAMERA', section="data")
-arm_nodes.add_category('Material', icon='MATERIAL', section="data")
-arm_nodes.add_category('Light', icon='LIGHT', section="data")
-arm_nodes.add_category('Object', icon='OBJECT_DATA', section="data")
-arm_nodes.add_category('Scene', icon='SCENE_DATA', section="data")
-arm_nodes.add_category('Trait', icon='NODETREE', section="data")
+def init_categories():
+    # Register node menu categories
+    arm_nodes.add_category('Logic', icon='OUTLINER', section="basic",
+                           description="Logic nodes are used to control execution flow using branching, loops, gates etc.")
+    arm_nodes.add_category('Event', icon='INFO', section="basic")
+    arm_nodes.add_category('Input', icon='GREASEPENCIL', section="basic")
+    arm_nodes.add_category('Native', icon='MEMORY', section="basic",
+                           description="The Native category contains nodes which interact with the system (Input/Output functionality, etc.) or Haxe.")
 
-arm_nodes.add_category('Animation', icon='SEQUENCE', section="motion")
-arm_nodes.add_category('Navmesh', icon='UV_VERTEXSEL', section="motion")
-arm_nodes.add_category('Transform', icon='TRANSFORM_ORIGINS', section="motion")
-arm_nodes.add_category('Physics', icon='PHYSICS', section="motion")
+    arm_nodes.add_category('Camera', icon='OUTLINER_OB_CAMERA', section="data")
+    arm_nodes.add_category('Material', icon='MATERIAL', section="data")
+    arm_nodes.add_category('Light', icon='LIGHT', section="data")
+    arm_nodes.add_category('Object', icon='OBJECT_DATA', section="data")
+    arm_nodes.add_category('Scene', icon='SCENE_DATA', section="data")
+    arm_nodes.add_category('Trait', icon='NODETREE', section="data")
 
-arm_nodes.add_category('Array', icon='LIGHTPROBE_GRID', section="values")
-arm_nodes.add_category('Math', icon='FORCE_HARMONIC', section="values")
-arm_nodes.add_category('Random', icon='SEQ_HISTOGRAM', section="values")
-arm_nodes.add_category('String', icon='SORTALPHA', section="values")
-arm_nodes.add_category('Variable', icon='OPTIONS', section="values")
+    arm_nodes.add_category('Animation', icon='SEQUENCE', section="motion")
+    arm_nodes.add_category('Navmesh', icon='UV_VERTEXSEL', section="motion")
+    arm_nodes.add_category('Transform', icon='TRANSFORM_ORIGINS', section="motion")
+    arm_nodes.add_category('Physics', icon='PHYSICS', section="motion")
 
-arm_nodes.add_category('Canvas', icon='RENDERLAYERS', section="graphics",
-                       description="Note: To get the canvas, be sure that the node(s) and the canvas (UI) is attached to the same object.")
-arm_nodes.add_category('Postprocess', icon='FREEZE', section="graphics")
-arm_nodes.add_category('Renderpath', icon='STICKY_UVS_LOC', section="graphics")
+    arm_nodes.add_category('Array', icon='LIGHTPROBE_GRID', section="values")
+    arm_nodes.add_category('Math', icon='FORCE_HARMONIC', section="values")
+    arm_nodes.add_category('Random', icon='SEQ_HISTOGRAM', section="values")
+    arm_nodes.add_category('String', icon='SORTALPHA', section="values")
+    arm_nodes.add_category('Variable', icon='OPTIONS', section="values")
 
-arm_nodes.add_category('Sound', icon='OUTLINER_OB_SPEAKER', section="sound")
+    arm_nodes.add_category('Canvas', icon='RENDERLAYERS', section="graphics",
+                           description="Note: To get the canvas, be sure that the node(s) and the canvas (UI) is attached to the same object.")
+    arm_nodes.add_category('Postprocess', icon='FREEZE', section="graphics")
+    arm_nodes.add_category('Renderpath', icon='STICKY_UVS_LOC', section="graphics")
 
-arm_nodes.add_category('Miscellaneous', icon='RESTRICT_COLOR_ON', section="misc")
-arm_nodes.add_category('Layout', icon='SEQ_STRIP_DUPLICATE', section="misc")
+    arm_nodes.add_category('Sound', icon='OUTLINER_OB_SPEAKER', section="sound")
 
-# Make sure that logic node extension packs are displayed at the end
-# of the menu by default unless they declare it otherwise
-arm_nodes.add_category_section('default')
+    arm_nodes.add_category('Miscellaneous', icon='RESTRICT_COLOR_ON', section="misc")
+    arm_nodes.add_category('Layout', icon='SEQ_STRIP_DUPLICATE', section="misc")
+
+    # Make sure that logic node extension packs are displayed at the end
+    # of the menu by default unless they declare it otherwise
+    arm_nodes.add_category_section('default')
 
 
 def init_nodes():

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -474,7 +474,7 @@ def add_node(node_type: Type[bpy.types.Node], category: str, section: str = 'def
     global nodes
 
     if category == PKG_AS_CATEGORY:
-        category = node_type.__module__.rsplit('.', 2)[1].capitalize()
+        category = node_type.__module__.rsplit('.', 2)[-2].capitalize()
 
     nodes.append(node_type)
     node_category = get_category(category)

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -521,10 +521,8 @@ def deprecated(*alternatives: str, message=""):
 def reset_globals():
     global nodes
     global category_items
-    global array_nodes
     nodes = []
     category_items = OrderedDict()
-    array_nodes = dict()
 
 
 bpy.utils.register_class(ArmNodeSearch)

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -525,6 +525,7 @@ def register():
 
     bpy.types.NODE_MT_context_menu.append(draw_custom_logicnode_menu)
 
+    arm.logicnode.init_categories()
     register_nodes()
 
 


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1975

- Custom categories are no longer displayed above Armory's default categories
- Fixed wrong category names when using `PKG_AS_CATEGORY` (default) in custom node libraries
- Fixed a bug with variable socket amounts for custom nodes
- More os.path.join
- Libraries are now also loaded when Armory is registered and the file that references the library is already opened. This will only work if the file uses the new registration system for nodes *or* if it is opened the first time in the current Blender session. This is because all modules that are imported by the libraries aren't reloaded, only the main module. Maybe we're able to improve this, but I don't now how powerful the importlib module is.