### PR TITLE
Checking Blender version for Armory

### DIFF
--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -714,6 +714,10 @@ class ArmoryPlayButton(bpy.types.Operator):
         if state.proc_build != None:
             return {"CANCELLED"}
 
+        # Compare version Blender and Armory (major, minor)
+        if not arm.utils.compare_version_blender_arm():
+            self.report({'INFO'}, 'For Armory to work correctly, you need Blender 2.83 LTS.')
+
         if not arm.utils.check_saved(self):
             return {"CANCELLED"}
 
@@ -749,6 +753,10 @@ class ArmoryBuildProjectButton(bpy.types.Operator):
     bl_label = 'Build'
 
     def execute(self, context):
+        # Compare version Blender and Armory (major, minor)
+        if not arm.utils.compare_version_blender_arm():
+            self.report({'INFO'}, 'For Armory to work correctly, you need Blender 2.83 LTS.')
+
         if not arm.utils.check_saved(self):
             return {"CANCELLED"}
 
@@ -785,6 +793,10 @@ class ArmoryPublishProjectButton(bpy.types.Operator):
     bl_label = 'Publish'
 
     def execute(self, context):
+        # Compare version Blender and Armory (major, minor)
+        if not arm.utils.compare_version_blender_arm():
+            self.report({'INFO'}, 'For Armory to work correctly, you need Blender 2.83 LTS.')
+
         if not arm.utils.check_saved(self):
             return {"CANCELLED"}
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -932,6 +932,9 @@ def get_android_open_build_apk_directory():
     addon_prefs = get_arm_preferences()
     return False if not hasattr(addon_prefs, 'android_open_build_apk_directory') else addon_prefs.android_open_build_apk_directory
 
+def compare_version_blender_arm():
+    return not (bpy.app.version[0] != 2 or bpy.app.version[1] != 83)
+
 def type_name_to_type(name: str) -> bpy.types.bpy_struct:
     """Return the Blender type given by its name, if registered."""
     return bpy.types.bpy_struct.bl_rna_get_subclass_py(name)


### PR DESCRIPTION
- Added compare function to `utils.py` module
- Added check of Blender version and display of a message about incorrectness during `Play`, `Build`, `Publish` operations
![report2](https://user-images.githubusercontent.com/7114353/97810684-d0d8da00-1c86-11eb-8fc9-fcbd76379f0d.jpg)