### PR TITLE
Some more (late) fixes to the node upgrading

### DIFF
--- a/blender/arm/logicnode/array/LN_array_add.py
+++ b/blender/arm/logicnode/array/LN_array_add.py
@@ -12,6 +12,7 @@ class ArrayAddNode(ArmLogicTreeNode):
     arm_version = 1
 
     def __init__(self):
+        super(ArrayAddNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/array/LN_array_boolean.py
+++ b/blender/arm/logicnode/array/LN_array_boolean.py
@@ -8,6 +8,7 @@ class BooleanArrayNode(ArmLogicTreeNode):
     arm_section = 'variable'
 
     def __init__(self):
+        super(BooleanArrayNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/array/LN_array_color.py
+++ b/blender/arm/logicnode/array/LN_array_color.py
@@ -8,6 +8,7 @@ class ColorArrayNode(ArmLogicTreeNode):
     arm_section = 'variable'
 
     def __init__(self):
+        super(ColorArrayNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/array/LN_array_float.py
+++ b/blender/arm/logicnode/array/LN_array_float.py
@@ -8,6 +8,7 @@ class FloatArrayNode(ArmLogicTreeNode):
     arm_section = 'variable'
 
     def __init__(self):
+        super(FloatArrayNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/array/LN_array_integer.py
+++ b/blender/arm/logicnode/array/LN_array_integer.py
@@ -8,6 +8,7 @@ class IntegerArrayNode(ArmLogicTreeNode):
     arm_section = 'variable'
 
     def __init__(self):
+        super(IntegerArrayNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/array/LN_array_object.py
+++ b/blender/arm/logicnode/array/LN_array_object.py
@@ -8,6 +8,7 @@ class ObjectArrayNode(ArmLogicTreeNode):
     arm_section = 'variable'
 
     def __init__(self):
+        super(ObjectArrayNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/array/LN_array_string.py
+++ b/blender/arm/logicnode/array/LN_array_string.py
@@ -8,6 +8,7 @@ class StringArrayNode(ArmLogicTreeNode):
     arm_section = 'variable'
 
     def __init__(self):
+        super(StringArrayNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/array/LN_array_vector.py
+++ b/blender/arm/logicnode/array/LN_array_vector.py
@@ -8,6 +8,7 @@ class VectorArrayNode(ArmLogicTreeNode):
     arm_section = 'variable'
 
     def __init__(self):
+        super(VectorArrayNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/input/LN_on_swipe.py
+++ b/blender/arm/logicnode/input/LN_on_swipe.py
@@ -54,6 +54,7 @@ class OnSwipeNode(ArmLogicTreeNode):
     max_outputs = 12
 
     def __init__(self):
+        super(OnSwipeNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/logic/LN_call_function.py
+++ b/blender/arm/logicnode/logic/LN_call_function.py
@@ -10,6 +10,7 @@ class CallFunctionNode(ArmLogicTreeNode):
     min_inputs = 3
 
     def __init__(self):
+        super(CallFunctionNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/logic/LN_function.py
+++ b/blender/arm/logicnode/logic/LN_function.py
@@ -12,6 +12,7 @@ class FunctionNode(ArmLogicTreeNode):
     min_outputs = 1
 
     def __init__(self):
+        super(FunctionNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/logic/LN_gate.py
+++ b/blender/arm/logicnode/logic/LN_gate.py
@@ -34,6 +34,7 @@ class GateNode(ArmLogicTreeNode):
     property1: FloatProperty(name='Tolerance', description='Precision for float compare', default=0.0001)
 
     def __init__(self):
+        super(GateNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/logic/LN_merge.py
+++ b/blender/arm/logicnode/logic/LN_merge.py
@@ -11,6 +11,7 @@ class MergeNode(ArmLogicTreeNode):
     arm_version = 1
 
     def __init__(self):
+        super(MergeNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/logic/LN_sequence.py
+++ b/blender/arm/logicnode/logic/LN_sequence.py
@@ -8,6 +8,7 @@ class SequenceNode(ArmLogicTreeNode):
     arm_version = 1
 
     def __init__(self):
+        super(SequenceNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/logic/LN_switch_output.py
+++ b/blender/arm/logicnode/logic/LN_switch_output.py
@@ -12,6 +12,7 @@ class SwitchNode(ArmLogicTreeNode):
     min_outputs = 1
 
     def __init__(self):
+        super(SwitchNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/math/LN_compare.py
+++ b/blender/arm/logicnode/math/LN_compare.py
@@ -25,6 +25,7 @@ class CompareNode(ArmLogicTreeNode):
     property1: FloatProperty(name='Tolerance', description='Precision for float compare', default=0.0001)
 
     def __init__(self):
+        super(CompareNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):

--- a/blender/arm/logicnode/string/LN_concatenate_string.py
+++ b/blender/arm/logicnode/string/LN_concatenate_string.py
@@ -7,6 +7,7 @@ class ConcatenateStringNode(ArmLogicTreeNode):
     arm_version = 1
 
     def __init__(self):
+        super(ConcatenateStringNode, self).__init__()
         array_nodes[str(id(self))] = self
 
     def init(self, context):


### PR DESCRIPTION
turns out, some of the nodes's `__init__` functions didn't call their superclass's `__init__`
Also, I had to make `NodeReplacement.Identity` more generic for the detection of node properties. Not perfect, but until there's a way to track what node attributes are properties used in haxe, this might have to do.