### PR TITLE
Revert/fix for traits updating

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -408,6 +408,10 @@ def compilation_server_done():
         return
     result = state.proc_build.poll()
     if result == 0:
+        if os.path.exists('krom/krom.js.temp'):
+            os.chmod('krom/krom.js', stat.S_IWRITE)
+            os.remove('krom/krom.js')
+            os.rename('krom/krom.js.temp', 'krom/krom.js')
         build_done()
     else:
         state.proc_build = None


### PR DESCRIPTION
Changes compilation_server_done() back to before my change.  Updates the path it checks to krom/krom.js.temp, this should prevent it from deleting existing krom.js files on first project launch.