### PR TITLE
Value Changed node

### DIFF
--- a/Sources/armory/logicnode/ValueChangedNode.hx
+++ b/Sources/armory/logicnode/ValueChangedNode.hx
@@ -1,0 +1,25 @@
+package armory.logicnode;
+
+class ValueChangedNode extends LogicNode {
+
+	var initial: Dynamic;
+	var value: Dynamic;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		if (initial == null) {
+			initial = inputs[1].get();
+			value = initial;
+		}
+
+		else if (value != inputs[1].get()) {
+			value = inputs[1].get();
+			value != initial ? runOutput(0) : runOutput(1);
+		}
+
+	}
+
+}

--- a/blender/arm/logicnode/logic/LN_value_changed.py
+++ b/blender/arm/logicnode/logic/LN_value_changed.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class ValueChangedNode(ArmLogicTreeNode):
+    """Sends a signal to `Changed` output whether the connected value is changed and a signal to `Unchanged` if the connected value returns to initial. Does not works with `null` value."""
+    bl_idname = 'LNValueChangedNode'
+    bl_label = 'Value Changed'
+    arm_version = 1
+
+    def init(self, context):
+        super(ValueChangedNode, self).init(context)
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('NodeSocketShader', 'Value')
+        self.add_output('ArmNodeSocketAction', 'Changed')
+        self.add_output('ArmNodeSocketAction', 'Unchanged')
+
+add_node(ValueChangedNode, category=PKG_AS_CATEGORY)


### PR DESCRIPTION
* `Changed output`: is activated when the connected value is changed.
* `Unchanged output`: is activated when the connected value returns to the initial.

Does not works with `null`, because the initial value will be defined every time until it is not null. I found this https://lib.haxe.org/p/notifier/ but i don't have the required knowledge to implement (and i don't even know if this is related to the purpose of this node).

Also does not works right for vectors in the test i do:
```
vec = inputs[1].get();
vec == inputs[1].get(); // prints false. I would need to use almostEqual here, but why?
```

Linked issue: https://github.com/armory3d/armory/issues/1009

Example: [TestNode.zip](https://github.com/armory3d/armory/files/5507150/TestNode.zip)

![Captura de tela de 2020-11-08 17-46-42](https://user-images.githubusercontent.com/63247726/98483884-68d84580-21ea-11eb-8a44-633a0dedd3ee.png)
