### PR TITLE
Add option to compile with khamake --debug flag

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -274,6 +274,9 @@ def compile(assets_only=False):
         cmd.append('--vr')
         cmd.append('webvr')
 
+    if arm.utils.get_pref_or_default('khamake_debug', False):
+        cmd.append('--debug')
+
     if arm.utils.get_rp().rp_renderer == 'Raytracer':
         cmd.append('--raytrace')
         cmd.append('dxr')


### PR DESCRIPTION
Requires https://github.com/armory3d/armsdk/pull/18 and https://github.com/Kode/khamake/pull/235.

This makes it possible to pass the `--debug` flag to krafix as well, in order to compile HLSL shaders with debug information. It is then possible to access the .hlsl source code in RenderDoc for easier step debugging.