### PR TITLE
LN Vector Math Fix

### DIFF
--- a/Sources/armory/logicnode/VectorMathNode.hx
+++ b/Sources/armory/logicnode/VectorMathNode.hx
@@ -104,7 +104,6 @@ class VectorMathNode extends LogicNode {
 				var i = 1;
 				while (i < inputs.length) {
 					p2_f = inputs[i].get();
-					if (p2_f == null) return null;
 					res_v.mult(p2_f);
 					i++;
 				}


### PR DESCRIPTION
Fixed error:
`On static platforms, null can't be used as basic type Float`