### PR TITLE
Android Settings More

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -604,7 +604,9 @@ def build_success():
             project_path = files_path + '-build'
             print('Exported Visual Studio 2017 project to ' + project_path)
         elif target_name.startswith('android'):
-            project_path = os.path.join(files_path + '-build', arm.utils.safestr(wrd.arm_project_name))
+            project_name = arm.utils.safestr(wrd.arm_project_name)
+            project_name = project_name.replace('.', '-').replace('_', '-').replace(' ', '-')
+            project_path = os.path.join(files_path + '-build', project_name)
             print('Exported Android Studio project to ' + project_path)
         elif target_name.startswith('krom'):
             project_path = files_path
@@ -617,28 +619,29 @@ def build_success():
             arm.utils.open_folder(project_path)
 
         # Android build APK
-        if (arm.utils.get_project_android_build_apk()) and (len(arm.utils.get_android_sdk_root_path()) > 0):
-            print("\nBuilding APK")
-            # Check settings
-            path_sdk = arm.utils.get_android_sdk_root_path()
-            if len(path_sdk) > 0:
-                # Check Environment Variables - ANDROID_SDK_ROOT
-                if os.getenv('ANDROID_SDK_ROOT') == None:
-                    # Set value from settings
-                    os.environ['ANDROID_SDK_ROOT'] = path_sdk
-            else:
-                project_path = ''
-
-            # Build start
-            if len(project_path) > 0:
-                os.chdir(project_path) # set work folder
-                if arm.utils.get_os_is_windows():
-                    state.proc_publish_build = run_proc(os.path.join(project_path, "gradlew.bat assembleDebug"), done_gradlew_build)
+        if (target_name.startswith('android')):
+            if (arm.utils.get_project_android_build_apk()) and (len(arm.utils.get_android_sdk_root_path()) > 0):
+                print("\nBuilding APK")
+                # Check settings
+                path_sdk = arm.utils.get_android_sdk_root_path()
+                if len(path_sdk) > 0:
+                    # Check Environment Variables - ANDROID_SDK_ROOT
+                    if os.getenv('ANDROID_SDK_ROOT') == None:
+                        # Set value from settings
+                        os.environ['ANDROID_SDK_ROOT'] = path_sdk
                 else:
-                    cmd = shlex.split(os.path.join(project_path, "gradlew assembleDebug"))
-                    state.proc_publish_build = run_proc(cmd, done_gradlew_build)
-            else:
-                print('\nBuilding APK Warning: ANDROID_SDK_ROOT is not specified in environment variables and "Android SDK Path" setting is not specified in preferences: \n- If you specify an environment variable ANDROID_SDK_ROOT, then you need to restart Blender;\n- If you specify the setting "Android SDK Path" in the preferences, then repeat operation "Publish"')
+                    project_path = ''
+
+                # Build start
+                if len(project_path) > 0:
+                    os.chdir(project_path) # set work folder
+                    if arm.utils.get_os_is_windows():
+                        state.proc_publish_build = run_proc(os.path.join(project_path, "gradlew.bat assembleDebug"), done_gradlew_build)
+                    else:
+                        cmd = shlex.split(os.path.join(project_path, "gradlew assembleDebug"))
+                        state.proc_publish_build = run_proc(cmd, done_gradlew_build)
+                else:
+                    print('\nBuilding APK Warning: ANDROID_SDK_ROOT is not specified in environment variables and "Android SDK Path" setting is not specified in preferences: \n- If you specify an environment variable ANDROID_SDK_ROOT, then you need to restart Blender;\n- If you specify the setting "Android SDK Path" in the preferences, then repeat operation "Publish"')
 
 def done_gradlew_build():
     if state.proc_publish_build == None:
@@ -648,13 +651,33 @@ def done_gradlew_build():
         state.proc_publish_build = None
 
         wrd = bpy.data.worlds['Arm']
+        project_name = arm.utils.safestr(arm.utils.blend_name()).replace('.', '-').replace('_', '-').replace(' ', '-')
+        if project_name[0].isdigit():
+            project_name = '_' + s
         path_apk = os.path.join(arm.utils.get_fp_build(), arm.utils.get_kha_target(state.target))
-        path_apk = os.path.join(path_apk + '-build', arm.utils.safestr(wrd.arm_project_name), "app", "build", "outputs", "apk", "debug")
+        project_name = arm.utils.safestr(wrd.arm_project_name)
+        project_name = project_name.replace('.', '-').replace('_', '-').replace(' ', '-')
+        path_apk = os.path.join(path_apk + '-build', project_name, 'app', 'build', 'outputs', 'apk', 'debug')
 
         print("\nBuild APK to " + path_apk)
+        # Rename APK
+        apk_name = 'app-debug.apk'
+        file_name = os.path.join(path_apk, apk_name)
+        if wrd.arm_project_android_rename_apk:
+            apk_name = project_name + '-' + arm.utils.safestr(wrd.arm_project_version.replace(' ', '_')) + '.apk'
+            os.rename(file_name, os.path.join(path_apk, apk_name))
+            file_name = os.path.join(path_apk, apk_name)
+            print("\nRename APK to " + apk_name)
+        # Copy APK
+        if wrd.arm_project_android_copy_apk:
+            shutil.copyfile(file_name, os.path.join(arm.utils.get_android_apk_copy_path(), apk_name))
+            print("Copy APK to " + arm.utils.get_android_apk_copy_path())
         # Open directory with APK
         if arm.utils.get_android_open_build_apk_directory():
             arm.utils.open_folder(path_apk)
+        # Open directory after copy APK
+        if arm.utils.get_android_apk_copy_open_directory():
+            arm.utils.open_folder(arm.utils.get_android_apk_copy_path())
         # Running emulator
         if wrd.arm_project_android_run_avd:
             run_android_emulators(arm.utils.get_android_emulator_name())

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -604,8 +604,7 @@ def build_success():
             project_path = files_path + '-build'
             print('Exported Visual Studio 2017 project to ' + project_path)
         elif target_name.startswith('android'):
-            project_name = arm.utils.safestr(wrd.arm_project_name)
-            project_name = project_name.replace('.', '-').replace('_', '-').replace(' ', '-')
+            project_name = arm.utils.safestr(wrd.arm_project_name).replace(' ', '-')
             project_path = os.path.join(files_path + '-build', project_name)
             print('Exported Android Studio project to ' + project_path)
         elif target_name.startswith('krom'):
@@ -651,12 +650,8 @@ def done_gradlew_build():
         state.proc_publish_build = None
 
         wrd = bpy.data.worlds['Arm']
-        project_name = arm.utils.safestr(arm.utils.blend_name()).replace('.', '-').replace('_', '-').replace(' ', '-')
-        if project_name[0].isdigit():
-            project_name = '_' + s
         path_apk = os.path.join(arm.utils.get_fp_build(), arm.utils.get_kha_target(state.target))
-        project_name = arm.utils.safestr(wrd.arm_project_name)
-        project_name = project_name.replace('.', '-').replace('_', '-').replace(' ', '-')
+        project_name = arm.utils.safestr(wrd.arm_project_name).replace(' ', '-')
         path_apk = os.path.join(path_apk + '-build', project_name, 'app', 'build', 'outputs', 'apk', 'debug')
 
         print("\nBuild APK to " + path_apk)
@@ -664,7 +659,7 @@ def done_gradlew_build():
         apk_name = 'app-debug.apk'
         file_name = os.path.join(path_apk, apk_name)
         if wrd.arm_project_android_rename_apk:
-            apk_name = project_name + '-' + arm.utils.safestr(wrd.arm_project_version.replace(' ', '_')) + '.apk'
+            apk_name = project_name + '-' + wrd.arm_project_version + '.apk'
             os.rename(file_name, os.path.join(path_apk, apk_name))
             file_name = os.path.join(path_apk, apk_name)
             print("\nRename APK to " + apk_name)

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -24,6 +24,8 @@ def init_properties():
     bpy.types.World.arm_project_android_sdk_min = IntProperty(name="Minimal Version SDK", description="Minimal Version Android SDK", default=14, min=14, max=30, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_android_sdk_target = IntProperty(name="Target Version SDK", description="Target Version Android SDK", default=29, min=26, max=30, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_android_build_apk = BoolProperty(name="Building APK After Publishing", description="Starting APK build after publishing", default=False, update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_project_android_rename_apk = BoolProperty(name="Rename APK To Project Name", description="Rename APK file to project name + version after build", default=False, update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_project_android_copy_apk = BoolProperty(name="Copy APK To Specified Folder", description="Copy the APK file to the folder specified in the settings after build", default=False, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_android_run_avd = BoolProperty(name="Run Emulator After Building APK", description="Starting android emulator after APK build", default=False, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_android_list_avd = EnumProperty(
         items=[(' ', ' ', ' ')],

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -430,12 +430,8 @@ class ARM_PT_ArmoryExporterAndroidSettingsPanel(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         wrd = bpy.data.worlds['Arm']
-        is_check = False
-        for item in wrd.arm_exporterlist:
-            is_check = item.arm_project_target == 'android-hl'
-            if is_check:
-                break
-        return is_check
+        item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
+        return item.arm_project_target == 'android-hl'
 
     def draw(self, context):
         layout = self.layout
@@ -449,7 +445,7 @@ class ARM_PT_ArmoryExporterAndroidSettingsPanel(bpy.types.Panel):
             row = layout.row()
             row.prop(wrd, 'arm_winorient')
             row = layout.row()
-            row.prop(wrd, 'arm_project_android_sdk_compile')          
+            row.prop(wrd, 'arm_project_android_sdk_compile')
             row = layout.row()
             row.prop(wrd, 'arm_project_android_sdk_min')
             row = layout.row()
@@ -462,16 +458,6 @@ class ARM_PT_ArmoryExporterAndroidPermissionsPanel(bpy.types.Panel):
     bl_context = "render"
     bl_options = { 'DEFAULT_CLOSED' }
     bl_parent_id = "ARM_PT_ArmoryExporterAndroidSettingsPanel"
-
-    @classmethod
-    def poll(cls, context):
-        wrd = bpy.data.worlds['Arm']
-        is_check = False
-        for item in wrd.arm_exporterlist:
-            is_check = item.arm_project_target == 'android-hl'
-            if is_check:
-                break
-        return is_check
 
     def draw(self, context):
         layout = self.layout
@@ -505,16 +491,6 @@ class ARM_PT_ArmoryExporterAndroidAbiPanel(bpy.types.Panel):
     bl_options = { 'DEFAULT_CLOSED'}
     bl_parent_id = "ARM_PT_ArmoryExporterAndroidSettingsPanel"
 
-    @classmethod
-    def poll(cls, context):
-        wrd = bpy.data.worlds['Arm']
-        is_check = False
-        for item in wrd.arm_exporterlist:
-            is_check = item.arm_project_target == 'android-hl'
-            if is_check:
-                break
-        return is_check
-
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
@@ -524,7 +500,7 @@ class ARM_PT_ArmoryExporterAndroidAbiPanel(bpy.types.Panel):
             item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
             layout.enabled = item.arm_project_target == 'android-hl'
             # ABIs
-            row = layout.row()            
+            row = layout.row()
             rows = 2
             if len(wrd.arm_exporter_android_abi_list) > 1:
                 rows = 4
@@ -547,16 +523,6 @@ class ARM_PT_ArmoryExporterAndroidBuildAPKPanel(bpy.types.Panel):
     bl_options = { 'DEFAULT_CLOSED'}
     bl_parent_id = "ARM_PT_ArmoryExporterAndroidSettingsPanel"
 
-    @classmethod
-    def poll(cls, context):
-        wrd = bpy.data.worlds['Arm']
-        is_check = False
-        for item in wrd.arm_exporterlist:
-            is_check = item.arm_project_target == 'android-hl'
-            if is_check:
-                break
-        return is_check
-
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
@@ -569,6 +535,12 @@ class ARM_PT_ArmoryExporterAndroidBuildAPKPanel(bpy.types.Panel):
             row.prop(wrd, 'arm_project_android_build_apk')
             path = arm.utils.get_android_sdk_root_path()
             row.enabled = len(path) > 0
+            row = layout.row()
+            row.prop(wrd, 'arm_project_android_rename_apk')
+            row.enabled = wrd.arm_project_android_build_apk
+            row = layout.row()
+            row.prop(wrd, 'arm_project_android_copy_apk')
+            row.enabled = (wrd.arm_project_android_build_apk) and (len(arm.utils.get_android_apk_copy_path()) > 0)
             row = layout.row()
             row.prop(wrd, 'arm_project_android_list_avd')
             col = row.column(align=True)

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -892,6 +892,14 @@ def get_android_sdk_root_path():
     else:
         return os.getenv('ANDROID_SDK_ROOT')
 
+def get_android_apk_copy_path():
+    addon_prefs = get_arm_preferences()
+    return '' if not hasattr(addon_prefs, 'android_apk_copy_path') else addon_prefs.android_apk_copy_path
+
+def get_android_apk_copy_open_directory():
+    addon_prefs = get_arm_preferences()
+    return False if not hasattr(addon_prefs, 'android_apk_copy_open_directory') else addon_prefs.android_apk_copy_open_directory
+
 def get_android_emulators_list():
     err = ''
     items = []


### PR DESCRIPTION
Panel `Armory Exporter` - `Android Settings` - `Building APK`:
![new_option_v2](https://user-images.githubusercontent.com/7114353/98985020-078adc00-2534-11eb-9315-028494dc6b2d.jpg)

1. `Rename APK To Project Name`
Renames the APK file from app-debug.apk to [project-name]-[version] .apk. Example, for the project example_ball, the result will be the name example-ball-1.0.5.apk.
2. `Copy APK To Specified Folder`
Copies the final file to the folder specified in Preferences.

Preferences `Render: Armory`:
![new_preference_v2](https://user-images.githubusercontent.com/7114353/98985099-25584100-2534-11eb-9d7e-5983844f43ff.jpg)

1. `Copy APK To Folder`
The path to the folder where the final APK file will be copied.
2. `Open Directory After Copy`
Open this folder after copying.

Console messages:
```
Rename APK to example-ball-1.0.5.apk
Copy APK to C:\IDE\Test
```
Related to PR: https://github.com/armory3d/armsdk/pull/19

Use-case:
These settings will allow you to have unique names for files, as well as copy them to the required folder for uploading to the device or to the cloud.