### PR TITLE
Fix usage of normals in shaders + smaller shader improvements

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -365,7 +365,7 @@ def parse_normal_map_color_input(inp, strength_input=None):
         frag.write('mat3 TBN = cotangentFrame(n, -vVec, texCoord);')
         frag.write('n = TBN * normalize(texn);')
     else:
-        frag.write('vec3 n = ({0}) * 2.0 - 1.0;'.format(parse_vector_input(inp)))
+        frag.write('n = ({0}) * 2.0 - 1.0;'.format(parse_vector_input(inp)))
         if strength_input is not None:
             strength = parse_value_input(strength_input)
             if strength != '1.0':

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -235,7 +235,7 @@ def parse_tex_musgrave(node: bpy.types.ShaderNodeTexMusgrave, out_socket: bpy.ty
     else:
         co = 'bposition'
 
-    scale = c.parse_value_input(node.inputs[1])
+    scale = c.parse_value_input(node.inputs['Scale'])
     # detail = c.parse_value_input(node.inputs[2])
     # distortion = c.parse_value_input(node.inputs[3])
 

--- a/blender/arm/material/cycles_nodes/nodes_vector.py
+++ b/blender/arm/material/cycles_nodes/nodes_vector.py
@@ -31,9 +31,9 @@ def parse_bump(node: bpy.types.ShaderNodeBump, out_socket: bpy.types.NodeSocket,
     nor = c.parse_vector_input(node.inputs[3])
     if state.sample_bump_res != '':
         if node.invert:
-            ext = ['1', '2', '3', '4']
+            ext = ('1', '2', '3', '4')
         else:
-            ext = ['2', '1', '4', '3']
+            ext = ('2', '1', '4', '3')
         state.curshader.write('float {0}_fh1 = {0}_{1} - {0}_{2}; float {0}_fh2 = {0}_{3} - {0}_{4};'.format(state.sample_bump_res, ext[0], ext[1], ext[2], ext[3]))
         state.curshader.write('{0}_fh1 *= ({1}) * 3.0; {0}_fh2 *= ({1}) * 3.0;'.format(state.sample_bump_res, strength))
         state.curshader.write('vec3 {0}_a = normalize(vec3(2.0, 0.0, {0}_fh1));'.format(state.sample_bump_res))

--- a/blender/arm/material/make_attrib.py
+++ b/blender/arm/material/make_attrib.py
@@ -1,9 +1,11 @@
+import arm.material.cycles as cycles
 import arm.material.mat_state as mat_state
 import arm.material.make_skin as make_skin
 import arm.material.make_particle as make_particle
 import arm.material.make_inst as make_inst
+import arm.material.shader as shader
 import arm.utils
-import arm.material.cycles as cycles
+
 
 def write_vertpos(vert):
     billboard = mat_state.material.arm_billboard
@@ -30,7 +32,8 @@ def write_vertpos(vert):
             vert.add_uniform('mat4 WVP', '_worldViewProjectionMatrix')
         vert.write('gl_Position = WVP * spos;')
 
-def write_norpos(con_mesh, vert, declare=False, write_nor=True):
+
+def write_norpos(con_mesh: shader.ShaderContext, vert: shader.Shader, declare=False, write_nor=True):
     prep = ''
     if declare:
         prep = 'vec3 '
@@ -42,7 +45,7 @@ def write_norpos(con_mesh, vert, declare=False, write_nor=True):
         if is_bone:
             make_skin.skin_nor(vert, prep)
         else:
-            vert.write(prep + 'wnormal = normalize(N * vec3(nor.xy, pos.w));')
+            vert.write_attrib(prep + 'wnormal = normalize(N * vec3(nor.xy, pos.w));')
     if con_mesh.is_elem('ipos'):
         make_inst.inst_pos(con_mesh, vert)
     vert.write_pre = False

--- a/blender/arm/material/make_depth.py
+++ b/blender/arm/material/make_depth.py
@@ -89,7 +89,7 @@ def make(context_id, rpasses, shadowmap=False):
             vert.add_out('vec3 wnormal')
             vert.add_uniform('mat3 N', '_normalMatrix')
             vert.write('wnormal = normalize(N * vec3(nor.xy, pos.w));')
-            
+
             make_tess.tesc_levels(tesc, rpdat.arm_tess_shadows_inner, rpdat.arm_tess_shadows_outer)
             make_tess.interpolate(tese, 'wposition', 3)
             make_tess.interpolate(tese, 'wnormal', 3, normalize=True)

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -140,7 +140,7 @@ def make_base(con_mesh, parse_opacity):
         else:
             vert.write_attrib('texCoord = tex * texUnpack;')
 
-        if tese != None:
+        if tese is not None:
             tese.write_pre = True
             make_tess.interpolate(tese, 'texCoord', 2, declare_out=frag.contains('texCoord'))
             tese.write_pre = False
@@ -149,7 +149,7 @@ def make_base(con_mesh, parse_opacity):
         vert.add_out('vec2 texCoord1')
         vert.add_uniform('float texUnpack', link='_texUnpack')
         vert.write_attrib('texCoord1 = tex1 * texUnpack;')
-        if tese != None:
+        if tese is not None:
             tese.write_pre = True
             make_tess.interpolate(tese, 'texCoord1', 2, declare_out=frag.contains('texCoord1'))
             tese.write_pre = False
@@ -157,28 +157,25 @@ def make_base(con_mesh, parse_opacity):
     if con_mesh.is_elem('col'):
         vert.add_out('vec3 vcolor')
         vert.write_attrib('vcolor = col.rgb;')
-        if tese != None:
+        if tese is not None:
             tese.write_pre = True
             make_tess.interpolate(tese, 'vcolor', 3, declare_out=frag.contains('vcolor'))
             tese.write_pre = False
 
+    vert.add_out('vec3 wnormal')
+    make_attrib.write_norpos(con_mesh, vert)
+    frag.write_attrib('vec3 n = normalize(wnormal);')
+
     if con_mesh.is_elem('tang'):
-        if tese != None:
-            vert.add_out('vec3 wnormal')
-            make_attrib.write_norpos(con_mesh, vert)
+        if tese is not None:
             tese.add_out('mat3 TBN')
-            tese.write('vec3 wbitangent = normalize(cross(wnormal, wtangent));')
-            tese.write('TBN = mat3(wtangent, wbitangent, wnormal);')
+            tese.write_attrib('vec3 wbitangent = normalize(cross(wnormal, wtangent));')
+            tese.write_attrib('TBN = mat3(wtangent, wbitangent, wnormal);')
         else:
             vert.add_out('mat3 TBN')
-            make_attrib.write_norpos(con_mesh, vert, declare=True)
-            vert.write('vec3 tangent = normalize(N * tang.xyz);')
-            vert.write('vec3 bitangent = normalize(cross(wnormal, tangent));')
-            vert.write('TBN = mat3(tangent, bitangent, wnormal);')
-    else:
-        vert.add_out('vec3 wnormal')
-        make_attrib.write_norpos(con_mesh, vert)
-        frag.write_attrib('vec3 n = normalize(wnormal);')
+            vert.write_attrib('vec3 tangent = normalize(N * tang.xyz);')
+            vert.write_attrib('vec3 bitangent = normalize(cross(wnormal, tangent));')
+            vert.write_attrib('TBN = mat3(tangent, bitangent, wnormal);')
 
     if is_displacement:
         if rpdat.arm_rp_displacement == 'Vertex':

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -595,9 +595,8 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
         # TODO: Fade out fragments near depth buffer here
         return
 
-    frag.write_init("""vec3 vVec = normalize(eyeDir);
-\tfloat dotNV = max(dot(n, vVec), 0.0);
-""")
+    frag.write_attrib('vec3 vVec = normalize(eyeDir);')
+    frag.write_attrib('float dotNV = max(dot(n, vVec), 0.0);')
 
     sh = tese if tese is not None else vert
     sh.add_out('vec3 eyeDir')

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -306,7 +306,7 @@ class Shader:
         self.header += s + '\n'
 
     def write_attrib(self, s):
-        self.main_attribs += s + '\n'
+        self.main_attribs += '\t' + s + '\n'
 
     def is_equal(self, sh):
         self.vstruct_to_vsin()


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1990.

Previously it could happen that normals or other attributes like `vVec` were accessed in shaders before they were declared. Also, the w coordinate socket was mistakenly used as the scale in the musgrave texture node.

This PR was tested with various example files including normal mapping, bump mapping, displacement, etc., tangent export on/off and in forward and deferred render paths.

@luboslenco I'm interested in implementing normal map blending when I get some more time again, do you recommend one certain method? I wrote a bit about it here: https://github.com/armory3d/armory/issues/1968#issuecomment-718766196.