### PR TITLE
Exporter Panel - Project Settings

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -216,6 +216,10 @@ def export_data(fp, sdk_path):
     import_logic = not state.is_publish and arm.utils.logic_editor_space() != None
     write_data.write_khafilejs(state.is_play, export_physics, export_navigation, export_ui, state.is_publish, enable_dce, ArmoryExporter.import_traits, import_logic)
 
+    # Change project version (Build, Publish)
+    if (not state.is_play) and (wrd.arm_project_version_autoinc):
+        wrd.arm_project_version = arm.utils.arm.utils.change_version_project(wrd.arm_project_version)
+
     # Write Main.hx - depends on write_khafilejs for writing number of assets
     scene_name = arm.utils.get_project_scene_name()
     write_data.write_mainhx(scene_name, resx, resy, state.is_play, state.is_publish)
@@ -311,7 +315,6 @@ def compile(assets_only=False):
             cmd.append('--nohaxe')
             cmd.append('--noproject')
         state.proc_build = run_proc(cmd, assets_done if compilation_server else build_done)
-
 
 def build(target, is_play=False, is_publish=False, is_export=False):
     global profile_time

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -411,6 +411,7 @@ class ARM_PT_ArmoryExporterPanel(bpy.types.Panel):
         col.prop(wrd, 'arm_project_package')
         col.prop(wrd, 'arm_project_bundle')
         col.prop(wrd, 'arm_project_version')
+        col.prop(wrd, 'arm_project_version_autoinc')
         col.prop(wrd, 'arm_project_icon')
         col.prop(wrd, 'arm_dce')
         col.prop(wrd, 'arm_compiler_inline')
@@ -430,8 +431,11 @@ class ARM_PT_ArmoryExporterAndroidSettingsPanel(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         wrd = bpy.data.worlds['Arm']
-        item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
-        return item.arm_project_target == 'android-hl'
+        if len(wrd.arm_exporterlist) > 0:
+            item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
+            return item.arm_project_target == 'android-hl'
+        else:
+            return False
 
     def draw(self, context):
         layout = self.layout

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -947,6 +947,17 @@ def type_name_to_type(name: str) -> bpy.types.bpy_struct:
     """Return the Blender type given by its name, if registered."""
     return bpy.types.bpy_struct.bl_rna_get_subclass_py(name)
 
+def change_version_project(version: str) -> str:
+    ver = version.strip().replace(' ', '').split('.')
+    v_i = int(ver[len(ver) - 1]) + 1
+    ver[len(ver) - 1] = str(v_i)
+    version = ''
+    for i in ver:
+        if len(version) > 0:
+            version += '.'
+        version += i
+    return version
+
 def register(local_sdk=False):
     global use_local_sdk
     use_local_sdk = local_sdk


### PR DESCRIPTION
1. Processing data entry into fields:
![v2](https://user-images.githubusercontent.com/7114353/99103097-18992300-25f0-11eb-8b0f-3551eed305cd.jpg)
- `Name` - the field must not be empty. If the user tries to set an empty value, then this field specifies the name of the blend file (this is how it is implemented during assembly). The default is `untitled`.
- `Package` - the field must not be empty, it must not consist only of numbers and start with a number. The `.` symbol is replaced with `_`. The default is `arm`.
- `Bundle` - the field must be filled in according to the mask `[string].[string]`. Each part must not be empty, contain numbers, or start with a number. The default is `org.armory3d`. Previously, this field was blank, in which case the current default was used.
- `Version`. The default is `1.0.0`.
Input in the `Version` field is processed and only allows input by masks:
   - 0.0
   - 0.0.0
   - 0.0.0.0
In any case, the value is ignored and the previous value remains.

If the (`Auto-increment Build Number`) checkbox is checked and when performing the operation, `Build` and `Publish` will be automatically incremented by one after the version value.
Examples:
it was 1.0 - it is 1.1,
it was 1.9 - it is 1.10,
it was 1.0.1 - it is 1.0.2,
it was 0.1.1.2 - it is 0.1.1.3.
The default is `enabled`.

For all fields, special characters `([] / \ ;,> <& *:% = + @! # ^ () |? ^)` Are also replaced with `_`.

2. Fixed display of Android Settings panel.