### PR TITLE
HTML5 Settings

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -8,6 +8,7 @@ import subprocess
 import threading
 import webbrowser
 import shlex
+import errno
 
 import bpy
 
@@ -311,7 +312,6 @@ def compile(assets_only=False):
             cmd.append('--nohaxe')
             cmd.append('--noproject')
         state.proc_build = run_proc(cmd, assets_done if compilation_server else build_done)
-
 
 def build(target, is_play=False, is_publish=False, is_export=False):
     global profile_time
@@ -641,6 +641,25 @@ def build_success():
                         state.proc_publish_build = run_proc(cmd, done_gradlew_build)
                 else:
                     print('\nBuilding APK Warning: ANDROID_SDK_ROOT is not specified in environment variables and "Android SDK Path" setting is not specified in preferences: \n- If you specify an environment variable ANDROID_SDK_ROOT, then you need to restart Blender;\n- If you specify the setting "Android SDK Path" in the preferences, then repeat operation "Publish"')
+        
+        # HTML5 After Publish
+        if (target_name == 'html5'):
+            if len(arm.utils.get_html5_copy_path()) > 0 and (wrd.arm_project_html5_copy):
+                project_name = arm.utils.safestr(wrd.arm_project_name.replace(' ', '-')) + '-' + wrd.arm_project_version
+                dst = os.path.join(arm.utils.get_html5_copy_path(), project_name) 
+                print("\nCopy files to " + dst)
+                if os.path.exists(dst):
+                    shutil.rmtree(dst)
+                try:
+                    shutil.copytree(project_path, dst)
+                except OSError as exc:
+                    if exc.errno == errno.ENOTDIR:
+                        shutil.copy(project_path, dst)
+                    else: raise
+                if len(arm.utils.get_link_web_server()) and (wrd.arm_project_html5_start_browser):
+                    link_html5_app = arm.utils.get_link_web_server() +'/'+ project_name
+                    print("Running a browser with a link " + link_html5_app)
+                    webbrowser.open(link_html5_app)
 
 def done_gradlew_build():
     if state.proc_publish_build == None:

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -11,6 +11,20 @@ import arm.utils
 arm_version = '2020.11'
 arm_commit = '$Id$'
 
+def get_project_html5_copy(self):
+    return self.get('arm_project_html5_copy', False)
+
+def set_project_html5_copy(self, value):
+    self['arm_project_html5_copy'] = value
+    if not value:
+        self['arm_project_html5_start_browser'] = False
+
+def get_project_html5_start_browser(self):
+    return self.get('arm_project_html5_start_browser', False)
+
+def set_project_html5_start_browser(self, value):
+    self['arm_project_html5_start_browser'] = value
+
 def init_properties():
     global arm_version
     bpy.types.World.arm_recompile = BoolProperty(name="Recompile", description="Recompile sources on next play", default=True)
@@ -30,6 +44,8 @@ def init_properties():
     bpy.types.World.arm_project_android_list_avd = EnumProperty(
         items=[(' ', ' ', ' ')],
         name="Emulator", update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_project_html5_copy = BoolProperty(name="Copy Files To Specified Folder", description="Copy files to the folder specified in the settings after publish", default=False, update=assets.invalidate_compiler_cache, set=set_project_html5_copy, get=get_project_html5_copy)
+    bpy.types.World.arm_project_html5_start_browser = BoolProperty(name="Run Browser After Copy", description="Run browser after copy", default=False, update=assets.invalidate_compiler_cache, set=set_project_html5_start_browser, get=get_project_html5_start_browser)
     bpy.types.World.arm_project_icon = StringProperty(name="Icon (PNG)", description="Exported project icon, must be a PNG image", default="", subtype="FILE_PATH", update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_root = StringProperty(name="Root", description="Set root folder for linked assets", default="", subtype="DIR_PATH", update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_physics = EnumProperty(

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -553,6 +553,39 @@ class ARM_PT_ArmoryExporterAndroidBuildAPKPanel(bpy.types.Panel):
             row.prop(wrd, 'arm_project_android_run_avd')
             row.enabled = arm.utils.get_project_android_build_apk() and len(arm.utils.get_android_emulator_name()) > 0
 
+class ARM_PT_ArmoryExporterHTML5SettingsPanel(bpy.types.Panel):
+    bl_label = "HTML5 Settings"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "render"
+    bl_options = { 'DEFAULT_CLOSED' }
+    bl_parent_id = "ARM_PT_ArmoryExporterPanel"
+
+    @classmethod
+    def poll(cls, context):
+        wrd = bpy.data.worlds['Arm']
+        if len(wrd.arm_exporterlist) > 0:
+            item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
+            return item.arm_project_target == 'html5'
+        else:
+            return False
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        wrd = bpy.data.worlds['Arm']
+        if wrd.arm_exporterlist_index >= 0 and len(wrd.arm_exporterlist) > 0:
+            item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
+            layout.enabled = item.arm_project_target == 'html5'
+            # Options
+            row = layout.row()
+            row.prop(wrd, 'arm_project_html5_copy')
+            row.enabled = len(arm.utils.get_html5_copy_path()) > 0
+            row = layout.row()
+            row.prop(wrd, 'arm_project_html5_start_browser')
+            row.enabled = (len(arm.utils.get_html5_copy_path()) > 0) and (wrd.arm_project_html5_copy) and (len(arm.utils.get_link_web_server()) > 0)
+
 class ARM_PT_ArmoryProjectPanel(bpy.types.Panel):
     bl_label = "Armory Project"
     bl_space_type = "PROPERTIES"
@@ -2205,6 +2238,7 @@ def register():
     bpy.utils.register_class(ARM_PT_ArmoryExporterAndroidPermissionsPanel)
     bpy.utils.register_class(ARM_PT_ArmoryExporterAndroidAbiPanel)
     bpy.utils.register_class(ARM_PT_ArmoryExporterAndroidBuildAPKPanel)
+    bpy.utils.register_class(ARM_PT_ArmoryExporterHTML5SettingsPanel)
     bpy.utils.register_class(ARM_PT_ArmoryProjectPanel)
     bpy.utils.register_class(ARM_PT_ProjectFlagsPanel)
     bpy.utils.register_class(ARM_PT_ProjectFlagsDebugConsolePanel)
@@ -2273,6 +2307,7 @@ def unregister():
     bpy.utils.unregister_class(ARM_PT_MaterialPropsPanel)
     bpy.utils.unregister_class(ARM_PT_MaterialBlendingPropsPanel)
     bpy.utils.unregister_class(ARM_PT_ArmoryPlayerPanel)
+    bpy.utils.unregister_class(ARM_PT_ArmoryExporterHTML5SettingsPanel)
     bpy.utils.unregister_class(ARM_PT_ArmoryExporterAndroidBuildAPKPanel)
     bpy.utils.unregister_class(ARM_PT_ArmoryExporterAndroidAbiPanel)
     bpy.utils.unregister_class(ARM_PT_ArmoryExporterAndroidPermissionsPanel)

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -940,6 +940,14 @@ def get_android_open_build_apk_directory():
     addon_prefs = get_arm_preferences()
     return False if not hasattr(addon_prefs, 'android_open_build_apk_directory') else addon_prefs.android_open_build_apk_directory
 
+def get_html5_copy_path():
+    addon_prefs = get_arm_preferences()
+    return '' if not hasattr(addon_prefs, 'html5_copy_path') else addon_prefs.html5_copy_path
+
+def get_link_web_server():
+    addon_prefs = get_arm_preferences()
+    return '' if not hasattr(addon_prefs, 'link_web_server') else addon_prefs.link_web_server
+
 def compare_version_blender_arm():
     return not (bpy.app.version[0] != 2 or bpy.app.version[1] != 83)
 


### PR DESCRIPTION
Added `Armory Exporter` - `HTML5 Settings` panel:
![html5_options](https://user-images.githubusercontent.com/7114353/99109572-1936b700-25fa-11eb-9fa5-10fc9185f42c.jpg)
- `Copy Files To Specified Folder` - copy files to the folder specified in the settings after publish. The name of the folder where the result will be copied is formed based on the name of the project and version. Sample, `test-1.0.5`.
- `Run Browser After Copy` - run browser after copy. The url is formed from the one specified in the settings and the directory with the project where it was copied. Sample, `http://localhost/test-1.0.5`.

Console messages:
```
Copy files to ...
Running a browser with a link ...
```

Added settings in Render: Armory:
![html5_preferences](https://user-images.githubusercontent.com/7114353/99109591-1fc52e80-25fa-11eb-9f6f-06a40d9d5c05.jpg)
- `HTML5 Copy Path` - path to copy project after successfully publish (directory on local web-server).
- `Url To Web Server` - url that runs the local server.
Related to PR: https://github.com/armory3d/armsdk/pull/20