### PR TITLE
Fixed logical nodes Vector Math and Quaternion Math

### DIFF
--- a/blender/arm/logicnode/math/LN_quaternion_math.py
+++ b/blender/arm/logicnode/math/LN_quaternion_math.py
@@ -28,10 +28,12 @@ class QuaternionMathNode(ArmLogicTreeNode):
         else:
             if (self.property0 == 'Module') or (self.property0 == 'DotProduct') or (self.property0 == 'ToAxisAngle'):
                 self.outputs.remove(self.outputs.values()[-1]) # Module/DotProduct/ToAxisAngle
-            self.outputs.remove(self.outputs.values()[-1]) # Result X
-            self.outputs.remove(self.outputs.values()[-1]) # Result Y
-            self.outputs.remove(self.outputs.values()[-1]) # Result Z
-            self.outputs.remove(self.outputs.values()[-1]) # Result W
+            # Remove X, Y, Z, W
+            for i in range(4):
+                if len(self.outputs) > 1:
+                    self.outputs.remove(self.outputs.values()[-1])
+                else:
+                    break
             if (self.property0 == 'Module'):
                 self.add_output('NodeSocketFloat', 'Module') # Module
             if (self.property0 == 'DotProduct'):

--- a/blender/arm/logicnode/math/LN_quaternion_math.py
+++ b/blender/arm/logicnode/math/LN_quaternion_math.py
@@ -13,7 +13,7 @@ class QuaternionMathNode(ArmLogicTreeNode):
     def set_bool(self, value):
         self['property1'] = value
         if value:
-            if (self.property0 == 'Module') or (self.property0 == 'DotProduct') or (self.property0 == 'ToAxisAngle'):
+            if ((self.property0 == 'Module') or (self.property0 == 'DotProduct') or (self.property0 == 'ToAxisAngle')) and (len(self.outputs) > 1):
                 self.outputs.remove(self.outputs.values()[-1]) # Module/DotProduct/ToAxisAngle
             self.add_output('NodeSocketFloat', 'X') # Result X
             self.add_output('NodeSocketFloat', 'Y') # Result Y
@@ -26,7 +26,7 @@ class QuaternionMathNode(ArmLogicTreeNode):
             if (self.property0 == 'ToAxisAngle'):
                 self.add_output('NodeSocketFloat', 'To Axis Angle') # ToAxisAngle
         else:
-            if (self.property0 == 'Module') or (self.property0 == 'DotProduct') or (self.property0 == 'ToAxisAngle'):
+            if ((self.property0 == 'Module') or (self.property0 == 'DotProduct') or (self.property0 == 'ToAxisAngle')) and (len(self.outputs) > 1):
                 self.outputs.remove(self.outputs.values()[-1]) # Module/DotProduct/ToAxisAngle
             # Remove X, Y, Z, W
             for i in range(4):

--- a/blender/arm/logicnode/math/LN_vector_math.py
+++ b/blender/arm/logicnode/math/LN_vector_math.py
@@ -29,9 +29,12 @@ class VectorMathNode(ArmLogicTreeNode):
         else:
             if (self.property0 == 'Length') or (self.property0 == 'Distance') or (self.property0 == 'Dot Product'):
                 self.outputs.remove(self.outputs.values()[-1]) # Distance/Length/Scalar
-            self.outputs.remove(self.outputs.values()[-1]) # Result X
-            self.outputs.remove(self.outputs.values()[-1]) # Result Y
-            self.outputs.remove(self.outputs.values()[-1]) # Result Z
+            # Remove X, Y, Z
+            for i in range(3):
+                if len(self.outputs) > 1:
+                    self.outputs.remove(self.outputs.values()[-1])
+                else:
+                    break
             if (self.property0 == 'Length'):
                 self.add_output('NodeSocketFloat', 'Length') # Length
             if (self.property0 == 'Distance'):

--- a/blender/arm/logicnode/math/LN_vector_math.py
+++ b/blender/arm/logicnode/math/LN_vector_math.py
@@ -27,7 +27,7 @@ class VectorMathNode(ArmLogicTreeNode):
             if (self.property0 == 'Dot Product'):
                 self.add_output('NodeSocketFloat', 'Scalar') # Scalar
         else:
-            if (self.property0 == 'Length') or (self.property0 == 'Distance') or (self.property0 == 'Dot Product'):
+            if ((self.property0 == 'Length') or (self.property0 == 'Distance') or (self.property0 == 'Dot Product')) and (len(self.outputs) > 1):
                 self.outputs.remove(self.outputs.values()[-1]) # Distance/Length/Scalar
             # Remove X, Y, Z
             for i in range(3):


### PR DESCRIPTION
The error occurs when updating projects with old nodes. Unfortunately, the node is not completely replaced, but the error with deleting the output parameters has been fixed, the incorrect node will not be in the `Logic Editor`.
The error is written here - https://github.com/armory3d/armory/pull/1994#issuecomment-726988371