### PR TITLE
Map Range node

### DIFF
--- a/Sources/armory/logicnode/MapRangeNode.hx
+++ b/Sources/armory/logicnode/MapRangeNode.hx
@@ -1,0 +1,20 @@
+package armory.logicnode;
+
+class MapRangeNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var value: kha.FastFloat = inputs[0].get();
+		var fromMin: kha.FastFloat = inputs[1].get();
+		var fromMax: kha.FastFloat = inputs[2].get();
+		var toMin: kha.FastFloat = inputs[3].get();
+		var toMax: kha.FastFloat = inputs[4].get();
+
+		if (value == null || fromMin == null || fromMax == null || toMin == null || toMax == null) return null;
+
+		return (value / fromMax - fromMin) * toMax - toMin;
+	}
+}

--- a/blender/arm/logicnode/math/LN_map_range.py
+++ b/blender/arm/logicnode/math/LN_map_range.py
@@ -1,0 +1,16 @@
+from arm.logicnode.arm_nodes import *
+
+class MapRangeNode(ArmLogicTreeNode):
+    """Converts the value between the given range to another range."""
+    bl_idname = 'LNMapRangeNode'
+    bl_label = 'Map Range'
+    arm_version = 1
+
+    def init(self, context):
+        super(MapRangeNode, self).init(context)
+        self.add_input('NodeSocketFloat', 'Value', default_value=1.0)
+        self.add_input('NodeSocketFloat', 'From Min')
+        self.add_input('NodeSocketFloat', 'From Max', default_value=1.0)
+        self.add_input('NodeSocketFloat', 'To Min')
+        self.add_input('NodeSocketFloat', 'To Max', default_value=1.0)
+        self.add_output('NodeSocketFloat', 'Result')


### PR DESCRIPTION
I guess it  is the same but without clamp checkbox: https://docs.blender.org/manual/en/latest/compositing/types/vector/map_range.html

Use: you have the vertical rotation of the camera axis object and you need to get it in camera FOV to increase the sense of depth when the player looks up or down.

This nodes takes the vertical rotation value (i.e. from -1.5 to 1.5) and changes it to FOV value (i.e. from 1 to 2).