### PR TITLE
Add per-material UI support for driver API

### DIFF
--- a/blender/arm/api.py
+++ b/blender/arm/api.py
@@ -9,14 +9,14 @@ drivers: Dict[str, Dict] = dict()
 
 def add_driver(driver_name: str,
                make_rpass: Callable[[str], Optional[ShaderContext]], make_rpath: Callable[[], None],
-               draw_props: Callable[[UILayout], None], draw_mat_props: Callable[[UILayout, Material], None]) -> None:
+               draw_props: Optional[Callable[[UILayout], None]], draw_mat_props: Optional[Callable[[UILayout, Material], None]]) -> None:
     """Register a new driver. If there already exists a driver with the given name, nothing happens.
 
     @param driver_name Unique name for the new driver that will be displayed in the UI.
     @param make_rpass Function to create render passes. Takes the rpass name as a parameter and may return `None`.
     @param make_rpath Function to setup the render path.
-    @param draw_props Function to draw global driver properties inside the render path panel
-    @param draw_mat_props Function to draw per-material driver properties in the material tab.
+    @param draw_props Function to draw global driver properties inside the render path panel, may be `None`.
+    @param draw_mat_props Function to draw per-material driver properties in the material tab, may be `None`.
     """
     global drivers
 

--- a/blender/arm/api.py
+++ b/blender/arm/api.py
@@ -1,16 +1,30 @@
+from typing import Callable, Dict, Optional
 
-drivers = dict()
+from bpy.types import UILayout
 
-def add_driver(driver_name, draw_props, make_rpass, make_rpath):
-	global drivers
+from arm.material.shader import ShaderContext
 
-	if driver_name in drivers:
-		return
+drivers: Dict[str, Dict] = dict()
 
-	d = {}
-	d['driver_name'] = driver_name
-	d['draw_props'] = draw_props
-	d['make_rpass'] = make_rpass
-	d['make_rpath'] = make_rpath
 
-	drivers[driver_name] = d
+def add_driver(driver_name: str,
+               draw_props: Callable[[UILayout], None],
+               make_rpass: Callable[[str], Optional[ShaderContext]], make_rpath: Callable[[], None]) -> None:
+    """Register a new driver. If there already exists a driver with the given name, nothing happens.
+
+    @param driver_name Unique name for the new driver
+    @param draw_props Function to draw global driver properties inside the render path panel
+    @param make_rpass Function to create render passes. Takes the rpass name as a parameter and may return `None`.
+    @param make_rpath Function to setup the render path.
+    """
+    global drivers
+
+    if driver_name in drivers:
+        return
+
+    drivers[driver_name] = {
+        'driver_name': driver_name,
+        'draw_props': draw_props,
+        'make_rpass': make_rpass,
+        'make_rpath': make_rpath
+    }

--- a/blender/arm/api.py
+++ b/blender/arm/api.py
@@ -1,6 +1,6 @@
 from typing import Callable, Dict, Optional
 
-from bpy.types import UILayout
+from bpy.types import Material, UILayout
 
 from arm.material.shader import ShaderContext
 
@@ -8,14 +8,15 @@ drivers: Dict[str, Dict] = dict()
 
 
 def add_driver(driver_name: str,
-               draw_props: Callable[[UILayout], None],
-               make_rpass: Callable[[str], Optional[ShaderContext]], make_rpath: Callable[[], None]) -> None:
+               make_rpass: Callable[[str], Optional[ShaderContext]], make_rpath: Callable[[], None],
+               draw_props: Callable[[UILayout], None], draw_mat_props: Callable[[UILayout, Material], None]) -> None:
     """Register a new driver. If there already exists a driver with the given name, nothing happens.
 
-    @param driver_name Unique name for the new driver
-    @param draw_props Function to draw global driver properties inside the render path panel
+    @param driver_name Unique name for the new driver that will be displayed in the UI.
     @param make_rpass Function to create render passes. Takes the rpass name as a parameter and may return `None`.
     @param make_rpath Function to setup the render path.
+    @param draw_props Function to draw global driver properties inside the render path panel
+    @param draw_mat_props Function to draw per-material driver properties in the material tab.
     """
     global drivers
 
@@ -24,7 +25,8 @@ def add_driver(driver_name: str,
 
     drivers[driver_name] = {
         'driver_name': driver_name,
-        'draw_props': draw_props,
         'make_rpass': make_rpass,
-        'make_rpath': make_rpath
+        'make_rpath': make_rpath,
+        'draw_props': draw_props,
+        'draw_mat_props': draw_mat_props
     }

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -20,7 +20,7 @@ class ShaderData:
         self.sd['name'] = self.matname + '_data'
         self.sd['contexts'] = []
 
-    def add_context(self, props):
+    def add_context(self, props) -> 'ShaderContext':
         con = ShaderContext(self.material, self.sd, props)
         if con not in self.sd['contexts']:
             for elem in self.global_elems:

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -267,7 +267,7 @@ class ARM_PT_MaterialPropsPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
         mat = bpy.context.material
-        if mat == None:
+        if mat is None:
             return
 
         layout.prop(mat, 'arm_cast_shadow')
@@ -293,6 +293,40 @@ class ARM_PT_MaterialPropsPanel(bpy.types.Panel):
         layout.prop(mat, 'arm_billboard')
 
         layout.operator("arm.invalidate_material_cache")
+
+
+class ARM_PT_MaterialDriverPropsPanel(bpy.types.Panel):
+    """Per-material properties for custom render path drivers"""
+    bl_label = "Armory Driver Properties"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "material"
+
+    @classmethod
+    def poll(cls, context):
+        mat = context.material
+        if mat is None:
+            return False
+
+        wrd = bpy.data.worlds['Arm']
+        if wrd.arm_rplist_index < 0 or len(wrd.arm_rplist) == 0:
+            return False
+
+        if len(arm.api.drivers) == 0:
+            return False
+
+        rpdat = wrd.arm_rplist[wrd.arm_rplist_index]
+        return rpdat.rp_driver != 'Armory' and arm.api.drivers[rpdat.rp_driver]['draw_mat_props'] is not None
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        wrd = bpy.data.worlds['Arm']
+        rpdat = wrd.arm_rplist[wrd.arm_rplist_index]
+        arm.api.drivers[rpdat.rp_driver]['draw_mat_props'](layout, context.material)
+
 
 class ARM_PT_MaterialBlendingPropsPanel(bpy.types.Panel):
     bl_label = "Blending"
@@ -2236,6 +2270,7 @@ def register():
     bpy.utils.register_class(InvalidateMaterialCacheButton)
     bpy.utils.register_class(ARM_PT_MaterialPropsPanel)
     bpy.utils.register_class(ARM_PT_MaterialBlendingPropsPanel)
+    bpy.utils.register_class(ARM_PT_MaterialDriverPropsPanel)
     bpy.utils.register_class(ARM_PT_ArmoryPlayerPanel)
     bpy.utils.register_class(ARM_PT_ArmoryExporterPanel)
     bpy.utils.register_class(ARM_PT_ArmoryExporterAndroidSettingsPanel)
@@ -2308,8 +2343,9 @@ def unregister():
     bpy.utils.unregister_class(ARM_PT_ScenePropsPanel)
     bpy.utils.unregister_class(InvalidateCacheButton)
     bpy.utils.unregister_class(InvalidateMaterialCacheButton)
-    bpy.utils.unregister_class(ARM_PT_MaterialPropsPanel)
+    bpy.utils.unregister_class(ARM_PT_MaterialDriverPropsPanel)
     bpy.utils.unregister_class(ARM_PT_MaterialBlendingPropsPanel)
+    bpy.utils.unregister_class(ARM_PT_MaterialPropsPanel)
     bpy.utils.unregister_class(ARM_PT_ArmoryPlayerPanel)
     bpy.utils.unregister_class(ARM_PT_ArmoryExporterHTML5SettingsPanel)
     bpy.utils.unregister_class(ARM_PT_ArmoryExporterAndroidBuildAPKPanel)


### PR DESCRIPTION
This adds support for a optional panel `Armory Driver Properties` for drivers in the material properties tab (to be used in https://github.com/armory3d/driver_celshade/pull/9). Maybe it makes more sense in the future to register those UI functions via a different API call than the `add_driver` call if we add even more callbacks.