### PR TITLE
Fix some node docstrings

### DIFF
--- a/blender/arm/logicnode/logic/LN_is_not_null.py
+++ b/blender/arm/logicnode/logic/LN_is_not_null.py
@@ -4,7 +4,7 @@ class IsNotNoneNode(ArmLogicTreeNode):
     """Passes through its activation only if the plugged-in value is
     not `null`.
 
-    @seeNode Is None"""
+    @seeNode Is Null"""
     bl_idname = 'LNIsNotNoneNode'
     bl_label = 'Is Not Null'
     arm_version = 1

--- a/blender/arm/logicnode/logic/LN_is_null.py
+++ b/blender/arm/logicnode/logic/LN_is_null.py
@@ -5,7 +5,7 @@ class IsNoneNode(ArmLogicTreeNode):
     """Passes through its activation only if the plugged-in value is
     `null` (no value).
 
-    @seeNode Is Not None"""
+    @seeNode Is Not Null"""
     bl_idname = 'LNIsNoneNode'
     bl_label = 'Is Null'
     arm_version = 1


### PR DESCRIPTION
Fixes a few wiki links for renamed nodes.

I think it's better to change the references to `bl_idname` in the future (node labels were only used to quickly get the doc generation system working) but this might require a bit of rewrite of the category system in order to expose this information to the reference generation script.