### PR TITLE
Windows Settings – Publish and action after

### DIFF
--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -7,6 +7,7 @@ import subprocess
 from typing import Any
 import webbrowser
 import shlex
+import locale
 
 import numpy as np
 
@@ -106,6 +107,20 @@ def get_os():
 
 def get_os_is_windows():
     return True if get_os() == 'win' else False
+
+def get_os_is_windows_64():
+    if platform.machine().endswith('64'):
+        return True
+    # Checks if Python (32 bit) is running on Windows (64 bit)
+    if 'PROCESSOR_ARCHITEW6432' in os.environ:
+        return True
+    if os.environ['PROCESSOR_ARCHITECTURE'].endswith('64'):
+        return True
+    if 'PROGRAMFILES(X86)' in os.environ:
+        if os.environ['PROGRAMW6432'] is not None:
+            return True
+    else:
+        return False
 
 def get_gapi():
     wrd = bpy.data.worlds['Arm']
@@ -965,6 +980,116 @@ def change_version_project(version: str) -> str:
             version += '.'
         version += i
     return version
+
+def get_visual_studio_from_version(version: str) -> str:
+    vs = [('10', '2010', 'Visual Studio 2010 (version 10)', 'vs2010'),
+          ('11', '2012', 'Visual Studio 2012 (version 11)', 'vs2012'),
+          ('12', '2013', 'Visual Studio 2013 (version 12)', 'vs2013'),
+          ('14', '2015', 'Visual Studio 2015 (version 14)', 'vs2015'),
+          ('15', '2017', 'Visual Studio 2017 (version 15)', 'vs2017'),
+          ('16', '2019', 'Visual Studio 2019 (version 16)', 'vs2019')]
+    for item in vs:
+        if item[0] == version.strip():
+            return item[0], item[1], item[2], item[3]
+
+def get_list_installed_vs(get_version: bool, get_name: bool, get_path: bool) -> []:
+    err = ''
+    items = []
+    path_file = os.path.join(get_sdk_path(), 'Kha', 'Kinc', 'Tools', 'kincmake', 'Data', 'windows', 'vswhere.exe')  
+    if not os.path.isfile(path_file):
+        err = 'File "'+ path_file +'" not found.'
+        return items, err
+    
+    if (not get_version) and (not get_name) and (not get_path):
+        return items, err
+
+    items_ver = []
+    items_name = []
+    items_path = []
+    count = 0
+
+    if get_version:
+        items_ver, err = get_list_installed_vs_version()
+        count_items = len(items_ver)
+    if len(err) > 0:
+        return items, err
+    if get_name:
+        items_name, err = get_list_installed_vs_name()
+        count_items = len(items_name)
+    if len(err) > 0:
+        return items, err
+    if get_path:
+        items_path, err = get_list_installed_vs_path()
+        count_items = len(items_path)
+    if len(err) > 0:
+        return items, err
+
+    for i in range(count_items):
+        v = items_ver[i][0] if len(items_ver) > i else '' 
+        v_full = items_ver[i][1] if len(items_ver) > i else '' 
+        n = items_name[i] if len(items_name) > i else ''
+        p = items_path[i] if len(items_path) > i else ''
+        items.append((v, n, p, v_full))
+    return items, err
+
+def get_list_installed_vs_version() -> []:
+    err = ''
+    items = []
+    path_file = os.path.join(get_sdk_path(), 'Kha', 'Kinc', 'Tools', 'kincmake', 'Data', 'windows', 'vswhere.exe')
+    if os.path.isfile(path_file):
+        # Set arguments
+        cmd = path_file + ' -nologo -property installationVersion'
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        while True:
+            output = process.stdout.readline().decode("utf-8")
+            if len(output.strip()) == 0 and process.poll() is not None:
+                break
+            if output:
+                version_all = output.strip().replace(' ', '')
+                version_parse = version_all.split('.')
+                version_major = version_parse[0]
+                items.append((version_major, version_all))
+    else:
+        err = 'File "'+ path_file +'" not found.'
+    return items, err
+
+def get_list_installed_vs_name() -> []:
+    err = ''
+    items = []
+    path_file = os.path.join(get_sdk_path(), 'Kha', 'Kinc', 'Tools', 'kincmake', 'Data', 'windows', 'vswhere.exe')
+    if os.path.isfile(path_file):
+        # Set arguments
+        cmd = path_file + ' -nologo -property displayName'
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        while True:
+            output = process.stdout.readline().decode(locale.getpreferredencoding())
+            if len(output.strip()) == 0 and process.poll() is not None:
+                break
+            if output:
+                name = safestr(output).replace('_', ' ').strip()
+                items.append(name)
+    else:
+        err = 'File "'+ path_file +'" not found.'
+    return items, err
+
+def get_list_installed_vs_path() -> []:
+    err = ''
+    items = []
+    path_file = os.path.join(get_sdk_path(), 'Kha', 'Kinc', 'Tools', 'kincmake', 'Data', 'windows', 'vswhere.exe')
+    if os.path.isfile(path_file):
+        # Set arguments
+        cmd = path_file + ' -nologo -property installationPath'
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        while True:
+            output = process.stdout.readline().decode("utf-8")
+            if len(output.strip()) == 0 and process.poll() is not None:
+                break
+            if output:
+                path = output.strip()
+                items.append(path)
+    else:
+        err = 'File "'+ path_file +'" not found.'
+    return items, err
 
 def register(local_sdk=False):
     global use_local_sdk

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -46,7 +46,7 @@ def write_khafilejs(is_play, export_physics, export_navigation, export_ui, is_pu
     with open('khafile.js', 'w', encoding="utf-8") as khafile:
         khafile.write(
 """// Auto-generated
-let project = new Project('""" + arm.utils.safestr(wrd.arm_project_name) + """');
+let project = new Project('""" + arm.utils.safesrc(wrd.arm_project_name +'-'+ wrd.arm_project_version) + """');
 
 project.addSources('Sources');
 """)


### PR DESCRIPTION
1. Added a project version to the project name.
2. Windows Settings
![win_settings_v2](https://user-images.githubusercontent.com/7114353/100131832-9b926700-2e95-11eb-8baf-32115712ec0c.jpg)
- `Visual Studio Version` - select the studio version for which the project will be exported. Options: _2010, 2012, 2013, 2015, 2017, 2019_. Default: _2019_.
- `Update` - checks the installed versions of _Visual Studio_ on the PC and adds `(installed)` to the version in the list if available (for information). Example:
![sample_vs_2](https://user-images.githubusercontent.com/7114353/100131880-ad740a00-2e95-11eb-8d2a-c4804a660444.jpg)
- `Action After Publishing` - select an action after a successful publication. Options:
   - `Nothing` - do nothing. Default value;
   - `Open In Visual Studio` - open the project in the corresponding studio version;
   - `Compile` - compilation of the project;
   - `Compile and Run` - compile and run the project. Then the executable file will be copied to the windows-hl folder (where the resources are located).
- `Mode` - compilation mode. Options: _Debug, Release_. Default: _Debug_.
- `Architecture` - the architecture for which the application will be built. Options: _x86, x64_. Default: _version of the user’s PC architecture_.
- `Compile Log Parameter` - setting the output of messages during compilation:
   - `Summary` - show the error and warning summary at the end. Default value;
   - `No Summary` - don \ 't show the error and warning summary at the end;
   - `Warnings and Errors Only` - show only warnings and errors;
   - `Warnings Only` - show only warnings;
   - `Errors Only` - show only errors.
More details can be found here - [MSBuild command-line reference](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2019) (I took only part of the settings).
- `Count CPU` - specifies the maximum number of concurrent processes to use when building. More details can be found here - [MSBuild command-line reference](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2019). The default is _1_. Maximum value: _the number of CPUs in the system (function multiprocessing.cpu_count())_.
- `Open Build Directory` - open the folder with the application after a successful build. Default, _False_. If the `Compile and Run` option is selected, then the executable file will be copied to the `windows-hl` folder (where the resources are located) and this folder will open. Otherwise, the folder where the given _Visual Studio_ file is going will open.

The user will also receive a message if the studio version selected for export and for opening in the studio or compilation is not on the PC. And a list of installed ones will be issued. Example:
```
Visual Studio 2017 (version 15) not found.
The following are installed on the PC:
- Visual Studio Community 2019 (version 16.8.30711.63)
```
To obtain information about the installed versions of _Visual Studio_, use the `vswhere.exe` utility ([open source](https://github.com/microsoft/vswhere)) included in `Kha` (located in the _…\ArmorySDK\Kha\Kinc\Tools\kincmake\Data\windows_).