### PR TITLE
Improve `Get Mouse Movement` node

### DIFF
--- a/Sources/armory/logicnode/GetMouseMovementNode.hx
+++ b/Sources/armory/logicnode/GetMouseMovementNode.hx
@@ -1,10 +1,8 @@
 package armory.logicnode;
 
-import iron.math.Vec4;
+import kha.FastFloat;
 
 class GetMouseMovementNode extends LogicNode {
-
-	var coords = new Vec4();
 
 	public function new(tree: LogicTree) {
 		super(tree);
@@ -12,18 +10,19 @@ class GetMouseMovementNode extends LogicNode {
 
 	override function get(from: Int): Dynamic {
 		var mouse = iron.system.Input.getMouse();
-		var multX: Float = inputs[0].get();
-		var multY: Float = inputs[1].get();
-		var multDelta: Float = inputs[2].get();
+
+		var multX: FastFloat = inputs[0].get();
+		var multY: FastFloat = inputs[1].get();
+		var multWheelDelta: FastFloat = inputs[2].get();
 
 		return switch (from) {
 			case 0: mouse.movementX;
 			case 1: mouse.movementY;
-			case 2: mouse.wheelDelta;
-			case 3: mouse.movementX * multX;
-			case 4: mouse.movementY * multY;
-			case 5: mouse.wheelDelta * multDelta;
-			default: null;
+			case 2: mouse.movementX * multX;
+			case 3: mouse.movementY * multY;
+			case 4: mouse.wheelDelta;
+			case 5: mouse.wheelDelta * multWheelDelta;
+			default: 0;
 		}
 	}
 }

--- a/blender/arm/logicnode/input/LN_get_mouse_movement.py
+++ b/blender/arm/logicnode/input/LN_get_mouse_movement.py
@@ -1,7 +1,9 @@
 from arm.logicnode.arm_nodes import *
 
+
 class GetMouseMovementNode(ArmLogicTreeNode):
-    """Returns the movement coordinates of the mouse."""
+    """Get the movement coordinates of the mouse and the mouse wheel delta.
+    The multiplied output variants default to -1 to invert the values."""
     bl_idname = 'LNGetMouseMovementNode'
     bl_label = 'Get Mouse Movement'
     arm_section = 'mouse'
@@ -9,13 +11,14 @@ class GetMouseMovementNode(ArmLogicTreeNode):
 
     def init(self, context):
         super(GetMouseMovementNode, self).init(context)
-        self.add_input('NodeSocketFloat', 'X Multiplier' , default_value=-1.0)
+
+        self.add_input('NodeSocketFloat', 'X Multiplier', default_value=-1.0)
         self.add_input('NodeSocketFloat', 'Y Multiplier', default_value=-1.0)
-        self.add_input('NodeSocketFloat', 'Delta Multiplier', default_value=-1.0)
+        self.add_input('NodeSocketFloat', 'Wheel Delta Multiplier', default_value=-1.0)
 
         self.add_output('NodeSocketFloat', 'X')
         self.add_output('NodeSocketFloat', 'Y')
-        self.add_output('NodeSocketInt', 'Delta')
         self.add_output('NodeSocketFloat', 'Multiplied X')
         self.add_output('NodeSocketFloat', 'Multiplied Y')
-        self.add_output('NodeSocketFloat', 'Multiplied Delta')
+        self.add_output('NodeSocketInt', 'Wheel Delta')
+        self.add_output('NodeSocketFloat', 'Multiplied Wheel Delta')


### PR DESCRIPTION
- Rename misleading `Delta` socket to `Wheel Delta` (on the Discord channel there was someone asking about how to get the mouse wheel rotation, this is the main reason for this PR)
- Reordered the sockets to make a bit more sense (movement and delta values are now grouped together)
- Node output defaults to `0` now instead of `null` for unsupported operations. This prevents errors on other places
- Better docstring

![getmousemovementnode](https://user-images.githubusercontent.com/17685000/100329655-43ab4b80-2fce-11eb-9088-281a7b557c7e.png)

I'm not even sure if `Mouse Delta` makes sense in this node or if it should get it's own node (it is not per se a "movement" of the mouse I would say?), but I don't know. We should at least keep it for compatibility reasons.