### PR TITLE
Forward renderpath: add support for chromatic aberration

### DIFF
--- a/Shaders/chromatic_aberration_pass/chromatic_aberration_pass.frag.glsl
+++ b/Shaders/chromatic_aberration_pass/chromatic_aberration_pass.frag.glsl
@@ -45,13 +45,14 @@ void main() {
 		int num_iter = compoChromaticSamples;
 	#endif
 
-	float reci_num_iter_f = 1.0 / float(num_iter);
-
+    // Spectral
 	if (compoChromaticType == 1) {
+        float reci_num_iter_f = 1.0 / float(num_iter);
+
 		vec2 resolution = vec2(1,1);
 		vec2 uv = (texCoord.xy/resolution.xy);
 		vec4 sumcol = vec4(0.0);
-		vec4 sumw = vec4(0.0);	
+		vec4 sumw = vec4(0.0);
 		for (int i=0; i < num_iter; ++i)
 		{
 			float t = float(i) * reci_num_iter_f;
@@ -59,17 +60,16 @@ void main() {
 			sumw += w;
 			sumcol += w * texture(tex, barrelDistortion(uv, 0.6 * max_distort * t));
 		}
-			
-		fragColor = sumcol / sumw;
-		
-	} else {
 
+		fragColor = sumcol / sumw;
+	}
+
+    // Simple
+    else {
 		vec3 col = vec3(0.0);
 		col.x = texture(tex, texCoord + ((vec2(0.0, 1.0) * max_distort) / vec2(1000.0))).x;
 		col.y = texture(tex, texCoord + ((vec2(-0.85, -0.5) * max_distort) / vec2(1000.0))).y;
 		col.z = texture(tex, texCoord + ((vec2(0.85, -0.5) * max_distort) / vec2(1000.0))).z;
 		fragColor = vec4(col.x, col.y, col.z, fragColor.w);
-
 	}
-
 }

--- a/Shaders/chromatic_aberration_pass/chromatic_aberration_pass.frag.glsl
+++ b/Shaders/chromatic_aberration_pass/chromatic_aberration_pass.frag.glsl
@@ -45,9 +45,9 @@ void main() {
 		int num_iter = compoChromaticSamples;
 	#endif
 
-    // Spectral
+	// Spectral
 	if (compoChromaticType == 1) {
-        float reci_num_iter_f = 1.0 / float(num_iter);
+		float reci_num_iter_f = 1.0 / float(num_iter);
 
 		vec2 resolution = vec2(1,1);
 		vec2 uv = (texCoord.xy/resolution.xy);
@@ -64,8 +64,8 @@ void main() {
 		fragColor = sumcol / sumw;
 	}
 
-    // Simple
-    else {
+	// Simple
+	else {
 		vec3 col = vec3(0.0);
 		col.x = texture(tex, texCoord + ((vec2(0.0, 1.0) * max_distort) / vec2(1000.0))).x;
 		col.y = texture(tex, texCoord + ((vec2(-0.85, -0.5) * max_distort) / vec2(1000.0))).y;

--- a/Sources/armory/renderpath/RenderPathForward.hx
+++ b/Sources/armory/renderpath/RenderPathForward.hx
@@ -287,6 +287,13 @@ class RenderPathForward {
 			#end
 		}
 		#end
+
+		#if rp_chromatic_aberration
+		{
+			path.loadShader("shader_datas/chromatic_aberration_pass/chromatic_aberration_pass");
+			path.loadShader("shader_datas/copy_pass/copy_pass");
+		}
+		#end
 	}
 
 	public static function commands() {
@@ -488,6 +495,18 @@ class RenderPathForward {
 
 				path.setDepthFrom("lbuffer0", "buf"); // Re-bind depth
 				path.depthToRenderTarget.set("main", path.renderTargets.get("lbuffer0"));
+			}
+			#end
+
+			#if rp_chromatic_aberration
+			{
+				path.setTarget("bufa");
+				path.bindTarget("lbuffer0", "tex");
+				path.drawShader("shader_datas/chromatic_aberration_pass/chromatic_aberration_pass");
+
+				path.setTarget("lbuffer0");
+				path.bindTarget("bufa", "tex");
+				path.drawShader("shader_datas/copy_pass/copy_pass");
 			}
 			#end
 

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -107,6 +107,8 @@ def build():
     assets_path = arm.utils.get_sdk_path() + '/armory/Assets/'
     wrd = bpy.data.worlds['Arm']
 
+    wrd.compo_defs = ''
+
     add_world_defs()
 
     mobile_mat = rpdat.arm_material_model == 'Mobile' or rpdat.arm_material_model == 'Solid'

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -144,7 +144,7 @@ def build():
             assets.add(assets_path + 'clouds_map.png')
             assets.add_embedded_data('clouds_map.png')
 
-    if rpdat.rp_renderer == 'Deferred' and not rpdat.rp_compositornodes:
+    if rpdat.rp_renderer == 'Deferred':
         assets.add_shader_pass('copy_pass')
 
     if rpdat.rp_render_to_texture:

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -608,18 +608,14 @@ const float compoBrightnessExponent = """ + str(round(rpdat.arm_lens_texture_mas
 
         if rpdat.rp_chromatic_aberration:
             f.write(
-"""const float compoChromaticStrength = """ + str(round(rpdat.arm_chromatic_aberration_strength * 100) / 100) + """;
-const int compoChromaticSamples = """ + str(rpdat.arm_chromatic_aberration_samples) + """;
+f"""const float compoChromaticStrength = {round(rpdat.arm_chromatic_aberration_strength * 100) / 100};
+const int compoChromaticSamples = {rpdat.arm_chromatic_aberration_samples};
 """)
 
-        if rpdat.arm_chromatic_aberration_type == "Spectral":
-            f.write(
-"""const int compoChromaticType = """ + str(1) + """;
-""")
-        else:
-            f.write(
-"""const int compoChromaticType = """ + str(0) + """;
-""")
+            if rpdat.arm_chromatic_aberration_type == "Spectral":
+                f.write("const int compoChromaticType = 1;")
+            else:
+                f.write("const int compoChromaticType = 0;")
 
         focus_distance = 0.0
         fstop = 0.0


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1398

This PR adds support for chromatic aberration in the forward renderpath, before this the setting would only work on deferred rendering. Also the compositor flags weren't reset between builds, so until now disabling the `Realtime postprocess` flag for example wasn't taken into account until restarting Blender.