### PR TITLE
Added option for HTML5 Settings

### DIFF
--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -143,6 +143,7 @@ def init_properties():
     # HTML5 Settings
     bpy.types.World.arm_project_html5_copy = BoolProperty(name="Copy Files To Specified Folder", description="Copy files to the folder specified in the settings after publish", default=False, update=assets.invalidate_compiler_cache, set=set_project_html5_copy, get=get_project_html5_copy)
     bpy.types.World.arm_project_html5_start_browser = BoolProperty(name="Run Browser After Copy", description="Run browser after copy", default=False, update=assets.invalidate_compiler_cache, set=set_project_html5_start_browser, get=get_project_html5_start_browser)
+    bpy.types.World.arm_project_html5_popupmenu_in_browser = BoolProperty(name="Disable Browser Context Menu", description="Disable the browser context menu for the canvas element on the page", default=False, update=assets.invalidate_compiler_cache)
     # Windows Settings
     bpy.types.World.arm_project_win_list_vs = EnumProperty(
         items=[('10', '2010', 'Visual Studio 2010 (version 10)'),

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -633,6 +633,8 @@ class ARM_PT_ArmoryExporterHTML5SettingsPanel(bpy.types.Panel):
         # Options
         layout.label(text='HTML5 Settings', icon='SETTINGS')
         row = layout.row()
+        row.prop(wrd, 'arm_project_html5_popupmenu_in_browser')
+        row = layout.row()
         row.prop(wrd, 'arm_project_html5_copy')
         row.enabled = len(arm.utils.get_html5_copy_path()) > 0
         row = layout.row()

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -442,6 +442,9 @@ def write_indexhtml(w, h, is_publish):
     dest = '/html5' if is_publish else '/debug/html5'
     if not os.path.exists(arm.utils.build_dir() + dest):
         os.makedirs(arm.utils.build_dir() + dest)
+    popupmenu_in_browser = ''
+    if wrd.arm_project_html5_popupmenu_in_browser:
+        popupmenu_in_browser = ' oncontextmenu="return false"'
     with open(arm.utils.build_dir() + dest + '/index.html', 'w') as f:
         f.write(
 """<!DOCTYPE html>
@@ -464,11 +467,11 @@ def write_indexhtml(w, h, is_publish):
 """)
         if rpdat.rp_stereo or wrd.arm_winmode == 'Fullscreen':
             f.write("""
-    <canvas style="width: 100vw; height: 100vh; display: block;" id='khanvas' tabindex='-1'></canvas>
+    <canvas style="width: 100vw; height: 100vh; display: block;" id='khanvas' tabindex='-1'""" + str(popupmenu_in_browser) + """></canvas>
 """)
         else:
             f.write("""
-    <p align="center"><canvas align="center" style="outline: none;" id='khanvas' width='""" + str(w) + """' height='""" + str(h) + """' tabindex='-1'></canvas></p>
+    <p align="center"><canvas align="center" style="outline: none;" id='khanvas' width='""" + str(w) + """' height='""" + str(h) + """' tabindex='-1'""" + str(popupmenu_in_browser) + """></canvas></p>
 """)
         f.write("""
     <script src='kha.js'></script>


### PR DESCRIPTION
- `Disable browser context menu` - disable the browser context menu for the canvas element on the page (_index.html_).
Default value `False`.
![image](https://user-images.githubusercontent.com/7114353/100912259-4aabef80-34e1-11eb-90ca-f3b4ff749ac8.png)

