### PR TITLE
New Physics Constraint nodes. Improve Bullet Physics constraint trait

### DIFF
--- a/Sources/armory/logicnode/AddPhysicsConstraintNode.hx
+++ b/Sources/armory/logicnode/AddPhysicsConstraintNode.hx
@@ -1,0 +1,135 @@
+package armory.logicnode;
+
+import armory.trait.physics.PhysicsConstraint;
+#if arm_physics
+import armory.trait.physics.bullet.PhysicsConstraint.ConstraintType;
+import armory.trait.physics.bullet.PhysicsConstraint.ConstraintAxis;
+#end
+import iron.object.Object;
+import armory.trait.physics.RigidBody;
+import armory.logicnode.PhysicsConstraintNode;
+
+class AddPhysicsConstraintNode extends LogicNode {
+
+	public var property0: String;//Type
+	public var object: Object;
+	public var rb1: Object;
+	public var rb2: Object;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var pivotObject:Object = inputs[1].get();
+		rb1 = inputs[2].get();
+		rb2 = inputs[3].get();
+		var disableCollisions: Bool = inputs[4].get();
+		var breakable: Bool = inputs[5].get();
+		var breakingThreshold: Float = inputs[6].get();
+		var type: ConstraintType = 0;
+
+		if (pivotObject == null || rb1 == null || rb2 == null) return;
+
+#if arm_physics
+
+		var con: PhysicsConstraint = pivotObject.getTrait(PhysicsConstraint);
+		if(con == null)			
+		{
+			switch(property0)
+			{
+				case 'Fixed':
+					type = Fixed;
+				case 'Point':
+					type = Point;
+				case 'Hinge':
+					type = Hinge;
+				case 'Slider':
+					type = Slider;
+				case 'Piston':
+					type = Piston;
+				case 'Generic Spring':
+					type = Generic;
+			}
+
+			if(! breakable) breakingThreshold = 0.0;
+
+			if(type != Generic) {
+				
+				con = new PhysicsConstraint(rb1, rb2, type, disableCollisions, breakingThreshold);
+
+				switch (type)
+				{
+					case Hinge:
+						var setLimit:Bool = inputs[7].get();
+						var low:Float = inputs[8].get();
+						var up:Float = inputs[9].get();
+						con.setHingeConstraintLimits(setLimit, low, up);
+
+					case Slider:
+						var setLimit:Bool = inputs[7].get();
+						var low:Float = inputs[8].get();
+						var up:Float = inputs[9].get();	
+						con.setSliderConstraintLimits(setLimit, low, up);
+
+					case Piston:
+						var setLinLimit:Bool = inputs[7].get();
+						var linLow:Float = inputs[8].get();
+						var linUp:Float = inputs[9].get();
+						var setAngLimit:Bool = inputs[10].get();
+						var angLow:Float = inputs[11].get();
+						var angUp:Float = inputs[12].get();
+						con.setPistonConstraintLimits(setLinLimit, linLow, linUp, setAngLimit, angLow, angUp);
+
+					default: 
+				}
+			}
+			else 
+			{
+				var spring: Bool = false;
+				var prop: PhysicsConstraintNode;
+				for(inp in 7...inputs.length)
+				{
+					prop = inputs[inp].get();
+					if(prop == null) continue;
+					if(prop.isSpring)
+					{
+						spring = true;
+						break;
+					}
+				}
+
+				if(spring) {
+					con = new PhysicsConstraint(rb1, rb2, GenericSpring, disableCollisions, breakingThreshold);
+				} 
+				else {
+					con = new PhysicsConstraint(rb1, rb2, Generic, disableCollisions, breakingThreshold);
+				}
+
+				for(inp in 7...inputs.length)
+				{
+					prop = inputs[inp].get();
+					if(prop == null) continue;
+					(inp + ': ');
+
+					if(prop.isSpring)
+					{
+						con.setSpringParams(prop.isSpring, prop.value1, prop.value2, prop.axis, prop.isAngular);
+					}
+					else 
+					{
+						con.setGenericConstraintLimits(true, prop.value1, prop.value2, prop.axis, prop.isAngular);
+					}
+				}
+
+
+			}
+
+			pivotObject.addTrait(con);
+
+		}
+#end
+
+		runOutput(0);
+	}
+}

--- a/Sources/armory/logicnode/AddRigidBodyNode.hx
+++ b/Sources/armory/logicnode/AddRigidBodyNode.hx
@@ -90,8 +90,7 @@ class AddRigidBodyNode extends LogicNode {
 				rb.angularDamping = angDamp;
 				if(margin) rb.collisionMargin = marginLen;
 				if(useDeactiv) {
-					rb.setDeactivation(true);
-					rb.setDeactivationParams(linearVelThreshold, angVelThreshold, 0.0);
+					rb.setUpDeactivation(true, linearVelThreshold, angVelThreshold, 0.0);
 				}
 
 			}

--- a/Sources/armory/logicnode/PhysicsConstraintNode.hx
+++ b/Sources/armory/logicnode/PhysicsConstraintNode.hx
@@ -1,0 +1,52 @@
+package armory.logicnode;
+
+#if arm_physics
+import armory.trait.physics.bullet.PhysicsConstraint.ConstraintAxis;
+#end
+import iron.object.Object;
+
+class PhysicsConstraintNode extends LogicNode {
+
+	public var property0: String;//Linear or Angular
+	public var property1: String;//Axis
+	public var property2: String;//Is a spring
+	public var value1: Float;//Lower limit or Spring Stiffness
+	public var value2: Float;//Upper limit or Spring Damping
+	public var isAngular: Bool;
+	public var axis: ConstraintAxis;
+	public var isSpring: Bool;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): PhysicsConstraintNode {
+		value1 = inputs[0].get();
+		value2 = inputs[1].get();
+
+		if(property0 == 'Linear') {
+			isAngular = false;
+		}
+		else{
+			isAngular = true;
+		}
+
+		if(property2 == 'true'){
+			isSpring = true;
+		}
+		else {
+			isSpring = false;
+		}
+
+		switch (property1){
+			case 'X':
+				axis = X;			
+			case 'Y':
+				axis = Y;
+			case 'Z':
+				axis = Z;
+		}
+
+		return this;
+	}
+}

--- a/Sources/armory/trait/physics/bullet/PhysicsConstraintExportHelper.hx
+++ b/Sources/armory/trait/physics/bullet/PhysicsConstraintExportHelper.hx
@@ -4,7 +4,11 @@ import iron.Scene;
 import iron.object.Object;
 #if arm_bullet
 
-
+/**
+ * A helper trait to add physics constraints when exporting via Blender. 
+ * This trait will be automatically removed once the constraint is added. Note that this trait
+ * uses object names instead of object reference.
+ **/
 class PhysicsConstraintExportHelper extends iron.Trait {
 
 	var body1: String;

--- a/Sources/armory/trait/physics/bullet/PhysicsConstraintExportHelper.hx
+++ b/Sources/armory/trait/physics/bullet/PhysicsConstraintExportHelper.hx
@@ -1,0 +1,37 @@
+package armory.trait.physics.bullet;
+
+import iron.Scene;
+import iron.object.Object;
+#if arm_bullet
+
+
+class PhysicsConstraintExportHelper extends iron.Trait {
+
+	var body1: String;
+	var body2: String;
+	var type: Int;
+	var disableCollisions: Bool;
+	var breakingThreshold: Float;
+	var limits: Array<Float>;
+
+	public function new(body1: String, body2: String, type: Int, disableCollisions: Bool, breakingThreshold: Float, limits: Array<Float> = null) {
+		super();
+
+		this.body1 = body1;
+		this.body2 = body2;
+		this.type = type;
+		this.disableCollisions = disableCollisions;
+		this.breakingThreshold = breakingThreshold;
+		this.limits = limits;
+		notifyOnInit(init);
+	}
+
+	function init() {
+		var target1 = Scene.active.getChild(body1);
+		var target2 = Scene.active.getChild(body2);
+		object.addTrait(new PhysicsConstraint(target1, target2, type, disableCollisions, breakingThreshold, limits));
+		this.remove();
+	}
+}
+
+#end

--- a/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
+++ b/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
@@ -51,6 +51,7 @@ class PhysicsWorld extends Trait {
 	var contacts: Array<ContactPair>;
 	var preUpdates: Array<Void->Void> = null;
 	public var rbMap: Map<Int, RigidBody>;
+	public var conMap: Map<Int, PhysicsConstraint>;
 	public var timeScale = 1.0;
 	var timeStep = 1 / 60;
 	var maxSteps = 1;
@@ -97,6 +98,7 @@ class PhysicsWorld extends Trait {
 
 		contacts = [];
 		rbMap = new Map();
+		conMap = new Map();
 		active = this;
 
 		// Ensure physics are updated first in the lateUpdate list
@@ -164,12 +166,23 @@ class PhysicsWorld extends Trait {
 		rbMap.set(body.id, body);
 	}
 
+	public function addPhysicsConstraint(constraint: PhysicsConstraint) {
+		world.addConstraint(constraint.con, constraint.disableCollisions);
+		conMap.set(constraint.id, constraint);
+	}
+
 	public function removeRigidBody(body: RigidBody) {
 		if (body.destroyed) return;
 		body.destroyed = true;
 		if (world != null) world.removeRigidBody(body.body);
 		rbMap.remove(body.id);
 		body.delete();
+	}
+
+	public function removePhysicsConstraint(constraint: PhysicsConstraint) {
+		if(world != null) world.removeConstraint(constraint.con);
+		conMap.remove(constraint.id);
+		constraint.delete();
 	}
 
 	// public function addKinematicCharacterController(controller:KinematicCharacterController) {

--- a/Sources/armory/trait/physics/bullet/RigidBody.hx
+++ b/Sources/armory/trait/physics/bullet/RigidBody.hx
@@ -392,8 +392,11 @@ class RigidBody extends iron.Trait {
 		// body.setDeactivationTime(time); // not available in ammo
 	}
 
-	public function setDeactivation(useDeactivation: Bool) {
+	public function setUpDeactivation(useDeactivation: Bool, linearThreshold: Float, angularThreshold: Float, time: Float) {
 		this.useDeactivation = useDeactivation;
+		this.deactivationParams[0] = linearThreshold;
+		this.deactivationParams[1] = angularThreshold;
+		this.deactivationParams[2] = time;
 	}
 
 	public function isTriggerObject(isTrigger: Bool) {

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2710,6 +2710,8 @@ class ArmoryExporter:
         rb2 = rbc.object2
         if rb1 is None or rb2 is None:
             return
+        if rbc.type == "MOTOR":
+            return
 
         ArmoryExporter.export_physics = True
         phys_pkg = 'bullet' if bpy.data.worlds['Arm'].arm_physics_engine == 'Bullet' else 'oimo'
@@ -2717,16 +2719,18 @@ class ArmoryExporter:
 
         trait = {
             'type': 'Script',
-            'class_name': 'armory.trait.physics.' + phys_pkg + '.PhysicsConstraint',
+            'class_name': 'armory.trait.physics.' + phys_pkg + '.PhysicsConstraintExportHelper',
             'parameters': [
                 "'" + rb1.name + "'",
                 "'" + rb2.name + "'",
-                "'" + rbc.type + "'",
                 str(rbc.disable_collisions).lower(),
                 str(breaking_threshold)
             ]
         }
-
+        if rbc.type == "FIXED":
+            trait['parameters'].insert(2,str(0))
+        if rbc.type == "POINT":
+            trait['parameters'].insert(2,str(1))
         if rbc.type == "GENERIC":
             limits = [
                 1 if rbc.use_limit_lin_x else 0,
@@ -2748,6 +2752,7 @@ class ArmoryExporter:
                 rbc.limit_ang_z_lower,
                 rbc.limit_ang_z_upper
             ]
+            trait['parameters'].insert(2,str(5))
             trait['parameters'].append(str(limits))
         if rbc.type == "GENERIC_SPRING":
             limits = [
@@ -2788,6 +2793,7 @@ class ArmoryExporter:
                 rbc.spring_stiffness_ang_z,
                 rbc.spring_damping_ang_z
             ]
+            trait['parameters'].insert(2,str(6))
             trait['parameters'].append(str(limits))
         if rbc.type == "HINGE":
             limits = [
@@ -2795,6 +2801,7 @@ class ArmoryExporter:
                 rbc.limit_ang_z_lower,
                 rbc.limit_ang_z_upper
             ]
+            trait['parameters'].insert(2,str(2))
             trait['parameters'].append(str(limits))
         if rbc.type == "SLIDER":
             limits = [
@@ -2802,6 +2809,7 @@ class ArmoryExporter:
                 rbc.limit_lin_x_lower,
                 rbc.limit_lin_x_upper
             ]
+            trait['parameters'].insert(2,str(3))
             trait['parameters'].append(str(limits))
         if rbc.type == "PISTON":
             limits = [
@@ -2812,6 +2820,7 @@ class ArmoryExporter:
                 rbc.limit_ang_x_lower,
                 rbc.limit_ang_x_upper
             ]
+            trait['parameters'].insert(2,str(4))
             trait['parameters'].append(str(limits))
         o['traits'].append(trait)
 

--- a/blender/arm/logicnode/physics/LN_add_physics_constraint.py
+++ b/blender/arm/logicnode/physics/LN_add_physics_constraint.py
@@ -1,7 +1,50 @@
 from arm.logicnode.arm_nodes import *
 
 class AddPhysicsConstraintNode(ArmLogicTreeNode):
-    """Add a physics constraint to an object"""
+    """
+    Add a physics constraint to constrain two rigid bodies if not already present.
+    
+    @option Fixed: No fredom of movement. Relative positions and rotations of rigid bodies are fixed
+
+    @option Point: Both rigid bodies are constrained at the pivot object.
+    
+    @option Hinge: Constrained objects can move only along angular Z axis of the pivot object.
+
+    @option Slider: Constrained objects can move only along linear X axis of the pivot object.
+
+    @option Piston: Constrained objects can move only and rotate along X axis of the pivot object.
+
+    @option GenericSpring: Fully custimizable generic 6 degree of freedom constraint with optional springs. All liner and angular axes can be constrained
+    along with spring options. Use `Physics Constraint Node` to set a combination of constraints and springs.
+
+    @seeNode Physics Constraint
+
+    @input Pivot object: The object to which the physics constraint traint is applied. This object will not be affected by the constraint
+    but is necessary to specify the constraint axes and location. Hence, the pivot object need not be a rigid body. Typically an `Empty`
+    object may be used. Each pivot object can have only one constraint trait applied. Moving/rotating/parenting the pivot object after the constraint
+    is applied has no effect. However, removig the pivot object removes the constraint and `RB 1` and `RB 2` are no longer constrained.
+
+    @input RB 1: The first rigid body to be constrained. Must be a rigid body. This object can be constrained by more than one constraint.
+
+    @input RB 2: The second rigid body to be constrained. Must be a rigid body. This object can be constrained by more than one constraint.
+
+    @input Disable Collisions: Disable collisions between `RB 1` and `RB 2`
+
+    @input Breakable: Constraint can break if stress on the constraint is more than the set threshold. Disable this option to disable breaking.
+
+    @input Breaking threshold: Stress on the constraint above which the constraint breaks. Depends on the mass, velocity of rigid bodies and type of constraint.
+
+    @input Limit Lower: Lower limit of the consraint in that particular axis
+
+    @input Limit Upper: Upper limit of the constraint in that particular axis. (`lower limit` = `upper limit`) --> Fully constrained. (`lower limit` < `upper limit`) --> Partially constrained
+    (`lower limit` > `upper limit`) --> Full freedom.
+
+    @input Angular limits: Limits to constarin rotation. Specified in degrees. Range (-360 to +360)
+
+    @input Add Constarint: Option to add custom constraint to `Generic Spring` type.
+    """
+
+
     bl_idname = 'LNAddPhysicsConstraintNode'
     bl_label = 'Add Physics Constraint'
     arm_sction = 'add'
@@ -19,8 +62,7 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
             'Hinge': 2, 
             'Slider': 3,
             'Piston': 4, 
-            'Generic': 5, 
-            'Spring': 6, 
+            'Generic Spring': 5
         }.get(type_name, 0)
 
     def get_enum(self):   
@@ -30,6 +72,7 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
         # Checking the selection of another type
         select_current = self.get_enum_id_value(self, 'property0', value)
         select_prev = self.property0
+
         #Check if a different type is selected
         if select_prev != select_current:
             print('New value selected')
@@ -37,10 +80,12 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
             if (self.get_count_in(select_current) == 0):
                 while (len(self.inputs) > 7):
                     self.inputs.remove(self.inputs.values()[-1])
+
             # Arguements for type Point
             if (self.get_count_in(select_current) == 1):
                 while (len(self.inputs) > 7):
                     self.inputs.remove(self.inputs.values()[-1])
+
             #Arguements for type Hinge
             if (self.get_count_in(select_current) == 2):
                 while (len(self.inputs) > 7):
@@ -49,6 +94,7 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
                 self.add_input('NodeSocketBool', 'Z angle')
                 self.add_input('NodeSocketFloat', 'Z ang lower', -45.0)
                 self.add_input('NodeSocketFloat', 'Z ang upper', 45.0)
+
             #Arguements for type Slider
             if (self.get_count_in(select_current) == 3):
                 while (len(self.inputs) > 7):
@@ -57,6 +103,7 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
                 self.add_input('NodeSocketBool', 'X linear')
                 self.add_input('NodeSocketFloat', 'X lin lower')
                 self.add_input('NodeSocketFloat', 'X lin upper')
+
             #Arguements for type Piston
             if (self.get_count_in(select_current) == 4):
                 while (len(self.inputs) > 7):
@@ -69,54 +116,12 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
                 self.add_input('NodeSocketBool', 'X angle')
                 self.add_input('NodeSocketFloat', 'X ang lower', -45.0)
                 self.add_input('NodeSocketFloat', 'X ang upper', 45.0)
-            #Arguements for type Generic
+
+            #Arguements for type GenericSpring
             if (self.get_count_in(select_current) == 5):
                 while (len(self.inputs) > 7):
                     self.inputs.remove(self.inputs.values()[-1])
-                #X lin limits
-                self.add_input('NodeSocketBool', 'X linear')
-                #Y lin limits
-                self.add_input('NodeSocketBool', 'Y linear')
-                #Z lin limits
-                self.add_input('NodeSocketBool', 'Z linear')
-                #X ang limits
-                self.add_input('NodeSocketBool', 'X angle')
-                #Y ang limits
-                self.add_input('NodeSocketBool', 'Y angle')
-                #Z ang limits
-                self.add_input('NodeSocketBool', 'Z angle')
-                #limits
-                self.add_input('ArmNodeSocketArray', 'Limits')
-            #Arguements for type GenericSpring
-            if (self.get_count_in(select_current) == 6):
-                while (len(self.inputs) > 7):
-                    self.inputs.remove(self.inputs.values()[-1])
-                #X lin limits
-                self.add_input('NodeSocketBool', 'X linear')
-                #Y lin limits
-                self.add_input('NodeSocketBool', 'Y linear')
-                #Z lin limits
-                self.add_input('NodeSocketBool', 'Z linear')
-                #X ang limits
-                self.add_input('NodeSocketBool', 'X angle')
-                #Y ang limits
-                self.add_input('NodeSocketBool', 'Y angle')
-                #Z ang limits
-                self.add_input('NodeSocketBool', 'Z angle')
-                #X lin spring
-                self.add_input('NodeSocketBool', 'X linear')
-                #Y lin spring
-                self.add_input('NodeSocketBool', 'Y linear')
-                #Z lin spring
-                self.add_input('NodeSocketBool', 'Z linear')
-                #X ang spring
-                self.add_input('NodeSocketBool', 'X angle')
-                #Y ang spring
-                self.add_input('NodeSocketBool', 'Y angle')
-                #Z ang spring
-                self.add_input('NodeSocketBool', 'Z angle')
-                #limits
-                self.add_input('ArmNodeSocketArray', 'Limits')
+
         self['property0'] = value
 
     property0: EnumProperty(
@@ -125,8 +130,7 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
                  ('Hinge', 'Hinge', 'Hinge'),
                  ('Slider', 'Slider', 'Slider'),
                  ('Piston', 'Piston', 'Piston'),
-                 ('Generic', 'Generic', 'Generic'),
-                 ('Spring', 'Spring', 'Spring')],
+                 ('Generic Spring', 'Generic Spring', 'Generic Spring')],
         name='Type', default='Fixed', set=set_enum, get=get_enum)
     
     def __init__(self):
@@ -145,79 +149,28 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-
+        
+        #GenericSpring:
         if (self.get_count_in(self.property0) == 5):
             grid0 = layout.grid_flow(row_major=True, columns=1, align=True)
-            grid0.label(text="Limits:")
-            grid0.label(text="Linear lower [X, Y, Z]")
-            grid0.label(text="Linear upper [X, Y, Z]")
-            grid0.label(text="Angular lower [X, Y, Z]")
-            grid0.label(text="Angular upper [X, Y, Z]")
-            row00 = layout.row()
-            row10 = row00.column()
-            row00.alignment = 'CENTER'
-            row00.label(text = "")
-            row01 = row00.split()
-            row01.alignment = 'CENTER'
-            row01.label(text = "Limits")
-            row02 = row01.split()
-            row02.alignment = 'CENTER'
-            row02.label(text = "Springs")
-            #row1
-            row10.alignment = 'CENTER'
-            row10.label(text = 'X')
-
-            #row11 = row01.column()
-            #row11.alignment = 'CENTER'
-            #row11.label(text = "Linear X")
-            #row12 = row11.split()
-            #row12.alignment = 'CENTER'
-            #row12.label(text = "Angular X")
-
-            #row13 = row02.column()
-            #row13.alignment = 'CENTER'
-            #row13.label(text = "Linear X")
-            #row14 = row13.split()
-            #row14.alignment = 'CENTER'
-            #row14.label(text = "Angular X")
-
-
-            grid1 = layout.grid_flow(row_major=True, columns=5, align=True)
-            ##row 1
-            grid1.label(text="")
-            grid1.label(text="Linear")
-            grid1.label(text="Angular")
-            grid1.label(text="Linear")
-            grid1.label(text="Angular")
-            ##row 2
-            grid1.label(text="X")
-            grid1.label(text="Linear X")
-            grid1.label(text="Angular X")
-            grid1.label(text="Linear X")
-            grid1.label(text="Angular X")
-            ##row 2
-            grid1.label(text="Y")
-            grid1.label(text="Linear Y")
-            grid1.label(text="Angular Y")
-            grid1.label(text="Linear Y")
-            grid1.label(text="Angular Y")
-            ##row 3
-            grid1.label(text="Z")
-            grid1.label(text="Linear Z")
-            grid1.label(text="Angular Z")
-            grid1.label(text="Linear Z")
-            grid1.label(text="Angular Z")
-
-        
-        if (self.get_count_in(self.property0) == 6):
-            grid0 = layout.grid_flow(row_major=True, columns=1, align=True)
-            grid0.label(text="Limits:")
-            grid0.label(text="Linear lower [X, Y, Z]")
-            grid0.label(text="Linear upper [X, Y, Z]")
-            grid0.label(text="Angular lower [X, Y, Z]")
-            grid0.label(text="Angular upper [X, Y, Z]")
-            grid0.label(text="Linear Stiffness [X, Y, Z]")
-            grid0.label(text="Linear Damping [X, Y, Z]")
-            grid0.label(text="Angular Stiffness [X, Y, Z]")
-            grid0.label(text="Angular Damping [X, Y, Z]")
+            grid0.label(text="Possible Constraints:")
+            grid0.label(text="Linear [X, Y, Z]")
+            grid0.label(text="Angular [X, Y, Z]")
+            grid0.label(text="Spring Linear [X, Y, Z]")
+            grid0.label(text="Spring Angular [X, Y, Z]")
+            row = layout.row(align=True)
+            column = row.column(align=True)
+            op = column.operator('arm.node_add_input', text='Add Constraint', icon='PLUS', emboss=True)
+            op.node_index = str(id(self))
+            op.socket_type = 'NodeSocketShader'
+            op.name_format = 'Constraint {0}'.format(len(self.inputs) - 6)
+            column1 = row.column(align=True)
+            op = column1.operator('arm.node_remove_input', text='', icon='X', emboss=True)
+            op.node_index = str(id(self))
+            #Static inputs
+            if len(self.inputs) < 8:
+                column1.enabled = False
+            #Max Possible inputs
+            if len(self.inputs) > 18:
+                column.enabled = False
 

--- a/blender/arm/logicnode/physics/LN_add_physics_constraint.py
+++ b/blender/arm/logicnode/physics/LN_add_physics_constraint.py
@@ -1,0 +1,167 @@
+from arm.logicnode.arm_nodes import *
+
+class AddPhysicsConstraintNode(ArmLogicTreeNode):
+    """Add a physics constraint to an object"""
+    bl_idname = 'LNAddPhysicsConstraintNode'
+    bl_label = 'Add Physics Constraint'
+    arm_sction = 'add'
+    arm_version = 1
+
+    @staticmethod
+    def get_enum_id_value(obj, prop_name, value):
+        return obj.bl_rna.properties[prop_name].enum_items[value].identifier
+
+    @staticmethod
+    def get_count_in(type_name):
+        return {
+            'Fixed': 0, 
+            'Point': 1, 
+            'Hinge': 2, 
+            'Slider': 3,
+            'Piston': 4, 
+            'Generic': 5, 
+            'Spring': 6, 
+        }.get(type_name, 0)
+
+    def get_enum(self):   
+        return self.get('property0', 0)
+
+    def set_enum(self, value):
+        # Checking the selection of another type
+        select_current = self.get_enum_id_value(self, 'property0', value)
+        select_prev = self.property0
+        #Check if a different type is selected
+        if select_prev != select_current:
+            print('New value selected')
+            # Arguements for type Fixed
+            if (self.get_count_in(select_current) == 0):
+                while (len(self.inputs) > 7):
+                    self.inputs.remove(self.inputs.values()[-1])
+            # Arguements for type Point
+            if (self.get_count_in(select_current) == 1):
+                while (len(self.inputs) > 7):
+                    self.inputs.remove(self.inputs.values()[-1])
+            #Arguements for type Hinge
+            if (self.get_count_in(select_current) == 2):
+                while (len(self.inputs) > 7):
+                    self.inputs.remove(self.inputs.values()[-1])
+                #Z ang limits
+                self.add_input('NodeSocketBool', 'Z angle')
+                self.add_input('NodeSocketFloat', 'Z ang lower', -45.0)
+                self.add_input('NodeSocketFloat', 'Z ang upper', 45.0)
+            #Arguements for type Slider
+            if (self.get_count_in(select_current) == 3):
+                while (len(self.inputs) > 7):
+                    self.inputs.remove(self.inputs.values()[-1])
+                #X lin limits
+                self.add_input('NodeSocketBool', 'X linear')
+                self.add_input('NodeSocketFloat', 'X lin lower')
+                self.add_input('NodeSocketFloat', 'X lin upper')
+            #Arguements for type Piston
+            if (self.get_count_in(select_current) == 4):
+                while (len(self.inputs) > 7):
+                    self.inputs.remove(self.inputs.values()[-1])
+                #X lin limits
+                self.add_input('NodeSocketBool', 'X linear')
+                self.add_input('NodeSocketFloat', 'X lin lower')
+                self.add_input('NodeSocketFloat', 'X lin upper')
+                #X ang limits
+                self.add_input('NodeSocketBool', 'X angle')
+                self.add_input('NodeSocketFloat', 'X ang lower', -45.0)
+                self.add_input('NodeSocketFloat', 'X ang upper', 45.0)
+            #Arguements for type Generic
+            if (self.get_count_in(select_current) == 5):
+                while (len(self.inputs) > 7):
+                    self.inputs.remove(self.inputs.values()[-1])
+                #X lin limits
+                self.add_input('NodeSocketBool', 'X linear')
+                #Y lin limits
+                self.add_input('NodeSocketBool', 'Y linear')
+                #Z lin limits
+                self.add_input('NodeSocketBool', 'Z linear')
+                #lower limits
+                self.add_input('NodeSocketVector', 'lin lower')
+                #upper limits
+                self.add_input('NodeSocketVector', 'lin upper')
+                #X ang limits
+                self.add_input('NodeSocketBool', 'X angle')
+                #Y ang limits
+                self.add_input('NodeSocketBool', 'Y angle')
+                #Z ang limits
+                self.add_input('NodeSocketBool', 'Z angle')
+                #lower limits
+                self.add_input('NodeSocketVector', 'ang lower', [-45.0, -45.0, -45.0])
+                #upper limits
+                self.add_input('NodeSocketVector', 'ang upper', [45.0, 45.0, 45.0])
+            #Arguements for type GenericSpring
+            if (self.get_count_in(select_current) == 6):
+                while (len(self.inputs) > 7):
+                    self.inputs.remove(self.inputs.values()[-1])
+                #X lin limits
+                self.add_input('NodeSocketBool', 'X linear')
+                #Y lin limits
+                self.add_input('NodeSocketBool', 'Y linear')
+                #Z lin limits
+                self.add_input('NodeSocketBool', 'Z linear')
+                #lower limits
+                self.add_input('NodeSocketVector', 'lin lower')
+                #upper limits
+                self.add_input('NodeSocketVector', 'lin upper')
+                #X ang limits
+                self.add_input('NodeSocketBool', 'X angle')
+                #Y ang limits
+                self.add_input('NodeSocketBool', 'Y angle')
+                #Z ang limits
+                self.add_input('NodeSocketBool', 'Z angle')
+                #lower limits
+                self.add_input('NodeSocketVector', 'ang lower', [-45.0, -45.0, -45.0])
+                #upper limits
+                self.add_input('NodeSocketVector', 'ang upper', [45.0, 45.0, 45.0])
+                #X lin spring
+                self.add_input('NodeSocketBool', 'X linear')
+                #Y lin spring
+                self.add_input('NodeSocketBool', 'Y linear')
+                #Z lin spring
+                self.add_input('NodeSocketBool', 'Z linear')
+                #linear stiffness
+                self.add_input('NodeSocketVector', 'lin stiffness', [10.0, 10.0, 10.0])
+                #linear damping
+                self.add_input('NodeSocketVector', 'lin damping', [0.5, 0.5, 0.5])
+                #X ang spring
+                self.add_input('NodeSocketBool', 'X angle')
+                #Y ang spring
+                self.add_input('NodeSocketBool', 'Y angle')
+                #Z ang spring
+                self.add_input('NodeSocketBool', 'Z angle')
+                #angular stiffness
+                self.add_input('NodeSocketVector', 'ang stiffness', [10.0, 10.0, 10.0])
+                #angular damping
+                self.add_input('NodeSocketVector', 'ang damping', [0.5, 0.5, 0.5])
+        self['property0'] = value
+
+    property0: EnumProperty(
+        items = [('Fixed', 'Fixed', 'Fixed'),
+                 ('Point', 'Point', 'Point'),
+                 ('Hinge', 'Hinge', 'Hinge'),
+                 ('Slider', 'Slider', 'Slider'),
+                 ('Piston', 'Piston', 'Piston'),
+                 ('Generic', 'Generic', 'Generic'),
+                 ('Spring', 'Spring', 'Spring')],
+        name='Type', default='Fixed', set=set_enum, get=get_enum)
+    
+    def __init__(self):
+        array_nodes[str(id(self))] = self
+
+    def init(self, context):
+        super(AddPhysicsConstraintNode, self).init(context)
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Pivot Object')
+        self.add_input('ArmNodeSocketObject', 'RB 1')
+        self.add_input('ArmNodeSocketObject', 'RB 2')
+        self.add_input('NodeSocketBool', 'Disable Collissions')
+        self.add_input('NodeSocketBool', 'Breakable')
+        self.add_input('NodeSocketFloat', 'Breaking Threshold')
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')

--- a/blender/arm/logicnode/physics/LN_add_physics_constraint.py
+++ b/blender/arm/logicnode/physics/LN_add_physics_constraint.py
@@ -79,20 +79,14 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
                 self.add_input('NodeSocketBool', 'Y linear')
                 #Z lin limits
                 self.add_input('NodeSocketBool', 'Z linear')
-                #lower limits
-                self.add_input('NodeSocketVector', 'lin lower')
-                #upper limits
-                self.add_input('NodeSocketVector', 'lin upper')
                 #X ang limits
                 self.add_input('NodeSocketBool', 'X angle')
                 #Y ang limits
                 self.add_input('NodeSocketBool', 'Y angle')
                 #Z ang limits
                 self.add_input('NodeSocketBool', 'Z angle')
-                #lower limits
-                self.add_input('NodeSocketVector', 'ang lower', [-45.0, -45.0, -45.0])
-                #upper limits
-                self.add_input('NodeSocketVector', 'ang upper', [45.0, 45.0, 45.0])
+                #limits
+                self.add_input('ArmNodeSocketArray', 'Limits')
             #Arguements for type GenericSpring
             if (self.get_count_in(select_current) == 6):
                 while (len(self.inputs) > 7):
@@ -103,40 +97,26 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
                 self.add_input('NodeSocketBool', 'Y linear')
                 #Z lin limits
                 self.add_input('NodeSocketBool', 'Z linear')
-                #lower limits
-                self.add_input('NodeSocketVector', 'lin lower')
-                #upper limits
-                self.add_input('NodeSocketVector', 'lin upper')
                 #X ang limits
                 self.add_input('NodeSocketBool', 'X angle')
                 #Y ang limits
                 self.add_input('NodeSocketBool', 'Y angle')
                 #Z ang limits
                 self.add_input('NodeSocketBool', 'Z angle')
-                #lower limits
-                self.add_input('NodeSocketVector', 'ang lower', [-45.0, -45.0, -45.0])
-                #upper limits
-                self.add_input('NodeSocketVector', 'ang upper', [45.0, 45.0, 45.0])
                 #X lin spring
                 self.add_input('NodeSocketBool', 'X linear')
                 #Y lin spring
                 self.add_input('NodeSocketBool', 'Y linear')
                 #Z lin spring
                 self.add_input('NodeSocketBool', 'Z linear')
-                #linear stiffness
-                self.add_input('NodeSocketVector', 'lin stiffness', [10.0, 10.0, 10.0])
-                #linear damping
-                self.add_input('NodeSocketVector', 'lin damping', [0.5, 0.5, 0.5])
                 #X ang spring
                 self.add_input('NodeSocketBool', 'X angle')
                 #Y ang spring
                 self.add_input('NodeSocketBool', 'Y angle')
                 #Z ang spring
                 self.add_input('NodeSocketBool', 'Z angle')
-                #angular stiffness
-                self.add_input('NodeSocketVector', 'ang stiffness', [10.0, 10.0, 10.0])
-                #angular damping
-                self.add_input('NodeSocketVector', 'ang damping', [0.5, 0.5, 0.5])
+                #limits
+                self.add_input('ArmNodeSocketArray', 'Limits')
         self['property0'] = value
 
     property0: EnumProperty(
@@ -165,3 +145,79 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
+
+        if (self.get_count_in(self.property0) == 5):
+            grid0 = layout.grid_flow(row_major=True, columns=1, align=True)
+            grid0.label(text="Limits:")
+            grid0.label(text="Linear lower [X, Y, Z]")
+            grid0.label(text="Linear upper [X, Y, Z]")
+            grid0.label(text="Angular lower [X, Y, Z]")
+            grid0.label(text="Angular upper [X, Y, Z]")
+            row00 = layout.row()
+            row10 = row00.column()
+            row00.alignment = 'CENTER'
+            row00.label(text = "")
+            row01 = row00.split()
+            row01.alignment = 'CENTER'
+            row01.label(text = "Limits")
+            row02 = row01.split()
+            row02.alignment = 'CENTER'
+            row02.label(text = "Springs")
+            #row1
+            row10.alignment = 'CENTER'
+            row10.label(text = 'X')
+
+            #row11 = row01.column()
+            #row11.alignment = 'CENTER'
+            #row11.label(text = "Linear X")
+            #row12 = row11.split()
+            #row12.alignment = 'CENTER'
+            #row12.label(text = "Angular X")
+
+            #row13 = row02.column()
+            #row13.alignment = 'CENTER'
+            #row13.label(text = "Linear X")
+            #row14 = row13.split()
+            #row14.alignment = 'CENTER'
+            #row14.label(text = "Angular X")
+
+
+            grid1 = layout.grid_flow(row_major=True, columns=5, align=True)
+            ##row 1
+            grid1.label(text="")
+            grid1.label(text="Linear")
+            grid1.label(text="Angular")
+            grid1.label(text="Linear")
+            grid1.label(text="Angular")
+            ##row 2
+            grid1.label(text="X")
+            grid1.label(text="Linear X")
+            grid1.label(text="Angular X")
+            grid1.label(text="Linear X")
+            grid1.label(text="Angular X")
+            ##row 2
+            grid1.label(text="Y")
+            grid1.label(text="Linear Y")
+            grid1.label(text="Angular Y")
+            grid1.label(text="Linear Y")
+            grid1.label(text="Angular Y")
+            ##row 3
+            grid1.label(text="Z")
+            grid1.label(text="Linear Z")
+            grid1.label(text="Angular Z")
+            grid1.label(text="Linear Z")
+            grid1.label(text="Angular Z")
+
+        
+        if (self.get_count_in(self.property0) == 6):
+            grid0 = layout.grid_flow(row_major=True, columns=1, align=True)
+            grid0.label(text="Limits:")
+            grid0.label(text="Linear lower [X, Y, Z]")
+            grid0.label(text="Linear upper [X, Y, Z]")
+            grid0.label(text="Angular lower [X, Y, Z]")
+            grid0.label(text="Angular upper [X, Y, Z]")
+            grid0.label(text="Linear Stiffness [X, Y, Z]")
+            grid0.label(text="Linear Damping [X, Y, Z]")
+            grid0.label(text="Angular Stiffness [X, Y, Z]")
+            grid0.label(text="Angular Damping [X, Y, Z]")
+

--- a/blender/arm/logicnode/physics/LN_physics_constraint.py
+++ b/blender/arm/logicnode/physics/LN_physics_constraint.py
@@ -1,0 +1,87 @@
+from arm.logicnode.arm_nodes import *
+
+class PhysicsConstraintNode(ArmLogicTreeNode):
+    """
+    Custom physics constraint to add to `Add Physics Constarint` node.
+
+    @option Linear/Angualr: Select if constrint is applied along linear or angular axis.
+
+    @option Axis: Local axis of the pivot object along which the constraint is applied.
+
+    @option Spring: Constraint is a Spring along the selected axis.
+
+    @input Limit Lower: Lower limit of the consraint in that particular axis
+
+    @input Limit Upper: Upper limit of the constraint in that particular axis. (`lower limit` = `upper limit`) --> Fully constrained. (`lower limit` < `upper limit`) --> Partially constrained
+    (`lower limit` > `upper limit`) --> Full freedom.
+
+    @seeNode Add Physics Constraint
+    """
+
+    bl_idname = 'LNPhysicsConstraintNode'
+    bl_label = 'Physics Constraint'
+    arm_sction = 'add'
+    arm_version = 1
+
+    def update_spring(self, context):
+        self.update_sockets(context)
+
+    property0: EnumProperty(
+        items = [('Linear', 'Linear', 'Linear'),
+                 ('Angular', 'Angular', 'Angular')],
+        name='Type', default='Linear')
+    
+    @property
+    def property1(self):
+        if(self.property1_ == 'X'):
+            return 'X'
+        if(self.property1_ == 'Y'):
+            return 'Y'
+        if(self.property1_ == 'Z'):
+            return 'Z'
+
+    property1_: EnumProperty(
+        items = [('X', 'X', 'X'),
+                 ('Y', 'Y', 'Y'),
+                 ('Z', 'Z', 'Z')],
+        name='Axis', default='X')
+
+    @property
+    def property2(self):
+        if(self.property2_):
+            return 'true' if self.property2_ else 'false'
+
+    property2_: BoolProperty(
+        name="Spring",
+        description="Is a spring constraint",
+        default=False,
+        update=update_spring
+    )
+    
+    def __init__(self):
+        array_nodes[str(id(self))] = self
+
+    def init(self, context):
+        super(PhysicsConstraintNode, self).init(context)
+        self.add_input('NodeSocketFloat', 'Lower limit')
+        self.add_input('NodeSocketFloat', 'Upper limit')
+        self.add_output('NodeSocketShader', 'Constraint')
+    
+    def update_sockets(self, context):
+
+        while (len(self.inputs) > 0):
+            self.inputs.remove(self.inputs.values()[-1])
+
+        # Add dynamic input sockets
+        if self.property2_:
+            self.add_input('NodeSocketFloat', 'Stiffness', 10.0)
+            self.add_input('NodeSocketFloat', 'Damping', 0.5)
+        else:
+            self.add_input('NodeSocketFloat', 'Lower limit')
+            self.add_input('NodeSocketFloat', 'Upper limit')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
+        layout.prop(self, 'property1_')
+        layout.prop(self, 'property2_')
+


### PR DESCRIPTION
- Two new nodes to add physics constraints during runtime.
- Improve the Physics Constraint trait. Now the trait uses `objects` instead of object names, making it more reliable.
- Added support functions to handle the setting of constraint parameters.
- Added a new helper trait to help export constraints from Blender.
- Added some descriptive documentation.

Requires [Haxebullet #39](https://github.com/armory3d/haxebullet/pull/39#issue-532862113).

![image](https://user-images.githubusercontent.com/55564981/101228342-8ee2ef80-369b-11eb-8b98-96c9a676a807.png)


