### PR TITLE
Add SetShaderUniform node

### DIFF
--- a/Sources/armory/logicnode/SetShaderUniformNode.hx
+++ b/Sources/armory/logicnode/SetShaderUniformNode.hx
@@ -1,0 +1,65 @@
+package armory.logicnode;
+
+import iron.data.MaterialData;
+import iron.object.Object;
+
+class SetShaderUniformNode extends LogicNode {
+
+	static var registered = false;
+	static var intMap = new Map<String, Null<Int>>();
+	static var floatMap = new Map<String, Null<kha.FastFloat>>();
+	static var vec2Map = new Map<String, iron.math.Vec4>();
+	static var vec3Map = new Map<String, iron.math.Vec4>();
+	static var vec4Map = new Map<String, iron.math.Vec4>();
+
+	/** Uniform type **/
+	public var property0: String;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+		if (!registered) {
+			registered = true;
+			iron.object.Uniforms.externalIntLinks.push(intLink);
+			iron.object.Uniforms.externalFloatLinks.push(floatLink);
+			iron.object.Uniforms.externalVec2Links.push(vec2Link);
+			iron.object.Uniforms.externalVec3Links.push(vec3Link);
+			iron.object.Uniforms.externalVec4Links.push(vec4Link);
+		}
+	}
+
+	override function run(from: Int) {
+		var uniformName: String = inputs[1].get();
+		if (uniformName == null) return;
+
+		switch (property0) {
+			case "int": intMap.set(uniformName, inputs[2].get());
+			case "float": floatMap.set(uniformName, inputs[2].get());
+			case "vec2": vec2Map.set(uniformName, inputs[2].get());
+			case "vec3": vec3Map.set(uniformName, inputs[2].get());
+			case "vec4": vec4Map.set(uniformName, inputs[2].get());
+			default:
+		}
+
+		runOutput(0);
+	}
+
+	static function intLink(object: Object, mat: MaterialData, link: String): Null<Int> {
+		return intMap.get(link);
+	}
+
+	static function floatLink(object: Object, mat: MaterialData, link: String): Null<kha.FastFloat> {
+		return floatMap.get(link);
+	}
+
+	static function vec2Link(object: Object, mat: MaterialData, link: String): iron.math.Vec4 {
+		return vec2Map.get(link);
+	}
+
+	static function vec3Link(object: Object, mat: MaterialData, link: String): iron.math.Vec4 {
+		return vec3Map.get(link);
+	}
+
+	static function vec4Link(object: Object, mat: MaterialData, link: String): iron.math.Vec4 {
+		return vec4Map.get(link);
+	}
+}

--- a/Sources/armory/object/Uniforms.hx
+++ b/Sources/armory/object/Uniforms.hx
@@ -11,8 +11,11 @@ class Uniforms {
 
 	public static function register() {
 		iron.object.Uniforms.externalTextureLinks = [textureLink];
+		iron.object.Uniforms.externalVec2Links = [];
 		iron.object.Uniforms.externalVec3Links = [vec3Link];
+		iron.object.Uniforms.externalVec4Links = [];
 		iron.object.Uniforms.externalFloatLinks = [floatLink];
+		iron.object.Uniforms.externalIntLinks = [];
 	}
 
 	public static function textureLink(object: Object, mat: MaterialData, link: String): kha.Image {

--- a/blender/arm/logicnode/renderpath/LN_set_shader_uniform.py
+++ b/blender/arm/logicnode/renderpath/LN_set_shader_uniform.py
@@ -1,0 +1,46 @@
+from bpy.props import EnumProperty
+
+from arm.logicnode.arm_nodes import *
+
+
+class SetShaderUniformNode(ArmLogicTreeNode):
+    """Set a global shader uniform value."""
+    bl_idname = 'LNSetShaderUniformNode'
+    bl_label = 'Set Shader Uniform'
+    bl_width_default = 200
+    arm_section = 'shaders'
+    arm_version = 1
+
+    def on_update_uniform_type(self, _):
+        self.inputs.remove(self.inputs[2])
+
+        if self.property0 == 'int':
+            self.add_input('NodeSocketInt', 'Int')
+        elif self.property0 == 'float':
+            self.add_input('NodeSocketFloat', 'Float')
+        elif self.property0 in ('vec2', 'vec3', 'vec4'):
+            self.add_input('NodeSocketVector', 'Vector')
+
+    property0: EnumProperty(
+        items = [('int', 'int', 'int'),
+                 ('float', 'float', 'float'),
+                 ('vec2', 'vec2', 'vec2'),
+                 ('vec3', 'vec3', 'vec3'),
+                 ('vec4', 'vec4', 'vec4')],
+        name='Uniform Type',
+        default='float',
+        description="The type of the uniform",
+        update=on_update_uniform_type)
+
+    def init(self, context):
+        super().init(context)
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('NodeSocketString', 'Uniform Name')
+        self.add_input('NodeSocketFloat', 'Float')
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+    def draw_buttons(self, context, layout):
+        split = layout.split(factor=0.5, align=True)
+
+        split.label(text="Type")
+        split.prop(self, "property0", text="")


### PR DESCRIPTION
![ShaderUniform](https://user-images.githubusercontent.com/17685000/102024777-54144200-3d94-11eb-96c1-16b2668c353a.png)

This is an addition to the already existing material param nodes with a more generalized way of setting uniforms for all kinds of shaders (the currently existing nodes require a parameter node in the material). This allows for example to also control world shaders (weather, lightning etc.), it works best in combination with Armory's `Shader Data` material node.

I put the node into the renderpath category because it is not related to materials only.

