### PR TITLE
Add 'stream' option to Play Sound nodes

### DIFF
--- a/Sources/armory/logicnode/PlaySoundRawNode.hx
+++ b/Sources/armory/logicnode/PlaySoundRawNode.hx
@@ -12,6 +12,8 @@ class PlaySoundRawNode extends LogicNode {
 	public var property3: Bool;
 	/** Playback sample rate */
 	public var property4: Int;
+	/** Whether to stream the sound from disk **/
+	public var property5: Bool;
 
 	var sound: kha.Sound = null;
 	var channel: kha.audio1.AudioChannel = null;
@@ -37,7 +39,7 @@ class PlaySoundRawNode extends LogicNode {
 				// Start
 				else if (sound != null) {
 					if (property3) sound.sampleRate = property4;
-					channel = iron.system.Audio.play(sound, property1);
+					channel = iron.system.Audio.play(sound, property1, property5);
 				}
 
 				tree.notifyOnUpdate(this.onUpdate);

--- a/blender/arm/logicnode/sound/LN_play_sound.py
+++ b/blender/arm/logicnode/sound/LN_play_sound.py
@@ -28,6 +28,7 @@ class PlaySoundNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNPlaySoundRawNode'
     bl_label = 'Play Sound'
+    bl_width_default = 200
     arm_version = 1
 
     property0: PointerProperty(name='', type=bpy.types.Sound)
@@ -48,6 +49,11 @@ class PlaySoundNode(ArmLogicTreeNode):
         description='Set the sample rate used to play this sound',
         default=44100,
         min=0)
+    property5: BoolProperty(
+        name='Stream',
+        description='Stream the sound from disk',
+        default=False
+    )
 
     def init(self, context):
         super(PlaySoundNode, self).init(context)
@@ -63,6 +69,7 @@ class PlaySoundNode(ArmLogicTreeNode):
         layout.prop_search(self, 'property0', bpy.data, 'sounds', icon='NONE', text='')
 
         col = layout.column(align=True)
+        col.prop(self, 'property5')
         col.prop(self, 'property1')
         col.prop(self, 'property2')
 

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -144,7 +144,7 @@ def build_node(node: bpy.types.Node, f):
         f.write('\t\t' + name + '.watch(true);\n')
 
     # Properties
-    for i in range(0, 5):
+    for i in range(0, 10):
         prop_name = 'property' + str(i) + '_get'
         prop_found = hasattr(node, prop_name)
         if not prop_found:


### PR DESCRIPTION
Added a checkbox to Play Sound nodes for selecting whether the sound should be loaded into memory or streamed from disk.

I had to raise the number of allowed node properties to 10 (previously 5) for it to work, but that shouldn't break anything (no other node uses `property5` - `property9`).