### PR TITLE
Add dynamic node labels

### DIFF
--- a/blender/arm/logicnode/array/LN_array.py
+++ b/blender/arm/logicnode/array/LN_array.py
@@ -23,3 +23,9 @@ class ArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketShader'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
+
+    def draw_label(self) -> str:
+        if len(self.inputs) == 0:
+            return self.bl_label
+
+        return f'{self.bl_label}: [{len(self.inputs)}]'

--- a/blender/arm/logicnode/array/LN_array_boolean.py
+++ b/blender/arm/logicnode/array/LN_array_boolean.py
@@ -24,3 +24,9 @@ class BooleanArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketBool'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
+
+    def draw_label(self) -> str:
+        if len(self.inputs) == 0:
+            return self.bl_label
+
+        return f'{self.bl_label}: [{len(self.inputs)}]'

--- a/blender/arm/logicnode/array/LN_array_color.py
+++ b/blender/arm/logicnode/array/LN_array_color.py
@@ -24,3 +24,9 @@ class ColorArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketColor'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
+
+    def draw_label(self) -> str:
+        if len(self.inputs) == 0:
+            return self.bl_label
+
+        return f'{self.bl_label}: [{len(self.inputs)}]'

--- a/blender/arm/logicnode/array/LN_array_float.py
+++ b/blender/arm/logicnode/array/LN_array_float.py
@@ -24,3 +24,9 @@ class FloatArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketFloat'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
+
+    def draw_label(self) -> str:
+        if len(self.inputs) == 0:
+            return self.bl_label
+
+        return f'{self.bl_label}: [{len(self.inputs)}]'

--- a/blender/arm/logicnode/array/LN_array_integer.py
+++ b/blender/arm/logicnode/array/LN_array_integer.py
@@ -24,3 +24,9 @@ class IntegerArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketInt'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
+
+    def draw_label(self) -> str:
+        if len(self.inputs) == 0:
+            return self.bl_label
+
+        return f'{self.bl_label}: [{len(self.inputs)}]'

--- a/blender/arm/logicnode/array/LN_array_object.py
+++ b/blender/arm/logicnode/array/LN_array_object.py
@@ -24,3 +24,9 @@ class ObjectArrayNode(ArmLogicTreeNode):
         op.socket_type = 'ArmNodeSocketObject'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
+
+    def draw_label(self) -> str:
+        if len(self.inputs) == 0:
+            return self.bl_label
+
+        return f'{self.bl_label}: [{len(self.inputs)}]'

--- a/blender/arm/logicnode/array/LN_array_string.py
+++ b/blender/arm/logicnode/array/LN_array_string.py
@@ -24,3 +24,9 @@ class StringArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketString'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
+
+    def draw_label(self) -> str:
+        if len(self.inputs) == 0:
+            return self.bl_label
+
+        return f'{self.bl_label}: [{len(self.inputs)}]'

--- a/blender/arm/logicnode/array/LN_array_vector.py
+++ b/blender/arm/logicnode/array/LN_array_vector.py
@@ -24,3 +24,9 @@ class VectorArrayNode(ArmLogicTreeNode):
         op.socket_type = 'NodeSocketVector'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
+
+    def draw_label(self) -> str:
+        if len(self.inputs) == 0:
+            return self.bl_label
+
+        return f'{self.bl_label}: [{len(self.inputs)}]'

--- a/blender/arm/logicnode/input/LN_gamepad.py
+++ b/blender/arm/logicnode/input/LN_gamepad.py
@@ -54,3 +54,10 @@ class GamepadNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
+
+    def draw_label(self) -> str:
+        inp_gamepad = self.inputs['Gamepad']
+        if inp_gamepad.is_linked:
+            return f'{self.bl_label}: {self.property1}'
+
+        return f'{self.bl_label} {inp_gamepad.default_value}: {self.property1}'

--- a/blender/arm/logicnode/input/LN_keyboard.py
+++ b/blender/arm/logicnode/input/LN_keyboard.py
@@ -77,3 +77,5 @@ class KeyboardNode(ArmLogicTreeNode):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
 
+    def draw_label(self) -> str:
+        return f'{self.bl_label}: {self.property1}'

--- a/blender/arm/logicnode/input/LN_mouse.py
+++ b/blender/arm/logicnode/input/LN_mouse.py
@@ -27,3 +27,6 @@ class MouseNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
+
+    def draw_label(self) -> str:
+        return f'{self.bl_label}: {self.property1}'

--- a/blender/arm/logicnode/input/LN_touch.py
+++ b/blender/arm/logicnode/input/LN_touch.py
@@ -21,3 +21,6 @@ class SurfaceNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
+
+    def draw_label(self) -> str:
+        return f'{self.bl_label}: {self.property0}'

--- a/blender/arm/logicnode/input/LN_virtual_button.py
+++ b/blender/arm/logicnode/input/LN_virtual_button.py
@@ -22,3 +22,6 @@ class VirtualButtonNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
+
+    def draw_label(self) -> str:
+        return f'{self.bl_label}: {self.property1}'

--- a/blender/arm/logicnode/logic/LN_loop.py
+++ b/blender/arm/logicnode/logic/LN_loop.py
@@ -29,3 +29,14 @@ class LoopNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketAction', 'Loop')
         self.add_output('NodeSocketInt', 'Index')
         self.add_output('ArmNodeSocketAction', 'Done')
+
+    def draw_label(self) -> str:
+        inp_from = self.inputs['From']
+        inp_to = self.inputs['To']
+        if inp_from.is_linked and inp_to.is_linked:
+            return self.bl_label
+
+        val_from = 'x' if inp_from.is_linked else inp_from.default_value
+        val_to = 'y' if inp_to.is_linked else inp_to.default_value
+
+        return f'{self.bl_label}: {val_from}...{val_to}'

--- a/blender/arm/logicnode/logic/LN_merge.py
+++ b/blender/arm/logicnode/logic/LN_merge.py
@@ -26,3 +26,9 @@ class MergeNode(ArmLogicTreeNode):
         op.socket_type = 'ArmNodeSocketAction'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
         op2.node_index = str(id(self))
+
+    def draw_label(self) -> str:
+        if len(self.inputs) == 0:
+            return self.bl_label
+
+        return f'{self.bl_label}: [{len(self.inputs)}]'

--- a/blender/arm/logicnode/math/LN_math.py
+++ b/blender/arm/logicnode/math/LN_math.py
@@ -5,7 +5,7 @@ class MathNode(ArmLogicTreeNode):
     bl_idname = 'LNMathNode'
     bl_label = 'Math'
     arm_version = 1
-    
+
     @staticmethod
     def get_enum_id_value(obj, prop_name, value):
         return obj.bl_rna.properties[prop_name].enum_items[value].identifier
@@ -13,34 +13,34 @@ class MathNode(ArmLogicTreeNode):
     @staticmethod
     def get_count_in(operation_name):
         return {
-            'Add': 0, 
-            'Subtract': 0, 
-            'Multiply': 0, 
+            'Add': 0,
+            'Subtract': 0,
+            'Multiply': 0,
             'Divide': 0,
-            'Sine': 1, 
-            'Cosine': 1, 
-            'Abs': 1, 
-            'Tangent': 1, 
-            'Arcsine': 1, 
-            'Arccosine': 1, 
-            'Arctangent': 1, 
-            'Logarithm': 1, 
-            'Round': 1, 
-            'Floor': 1, 
-            'Ceil': 1, 
-            'Square Root': 1, 
-            'Fract': 1, 
+            'Sine': 1,
+            'Cosine': 1,
+            'Abs': 1,
+            'Tangent': 1,
+            'Arcsine': 1,
+            'Arccosine': 1,
+            'Arctangent': 1,
+            'Logarithm': 1,
+            'Round': 1,
+            'Floor': 1,
+            'Ceil': 1,
+            'Square Root': 1,
+            'Fract': 1,
             'Exponent': 1,
-            'Max': 2, 
-            'Min': 2, 
-            'Power': 2, 
-            'Arctan2': 2, 
-            'Modulo': 2, 
-            'Less Than': 2, 
+            'Max': 2,
+            'Min': 2,
+            'Power': 2,
+            'Arctan2': 2,
+            'Modulo': 2,
+            'Less Than': 2,
             'Greater Than': 2
         }.get(operation_name, 0)
 
-    def get_enum(self):   
+    def get_enum(self):
         return self.get('property0', 0)
 
     def set_enum(self, value):
@@ -124,3 +124,6 @@ class MathNode(ArmLogicTreeNode):
             op.node_index = str(id(self))
             if len(self.inputs) == 2:
                 column.enabled = False
+
+    def draw_label(self) -> str:
+        return f'{self.bl_label}: {self.property0}'

--- a/blender/arm/logicnode/math/LN_vector_math.py
+++ b/blender/arm/logicnode/math/LN_vector_math.py
@@ -148,3 +148,6 @@ class VectorMathNode(ArmLogicTreeNode):
             op.node_index = str(id(self))
             if len(self.inputs) == 2:
                 column.enabled = False
+
+    def draw_label(self) -> str:
+        return f'{self.bl_label}: {self.property0}'

--- a/blender/arm/logicnode/miscellaneous/LN_timer.py
+++ b/blender/arm/logicnode/miscellaneous/LN_timer.py
@@ -21,3 +21,11 @@ class TimerNode(ArmLogicTreeNode):
         self.add_output('NodeSocketInt', 'Time Left')
         self.add_output('NodeSocketFloat', 'Progress')
         self.add_output('NodeSocketFloat', 'Repetitions')
+
+    def draw_label(self) -> str:
+        inp_duration = self.inputs['Duration']
+        inp_repeat = self.inputs['Repeat']
+        if inp_duration.is_linked or inp_repeat.is_linked:
+            return self.bl_label
+
+        return f'{self.bl_label}: {round(inp_duration.default_value, 3)}s ({inp_repeat.default_value} R.)'

--- a/blender/arm/logicnode/object/LN_object.py
+++ b/blender/arm/logicnode/object/LN_object.py
@@ -11,3 +11,14 @@ class ObjectNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketObject', 'Object In')
 
         self.add_output('ArmNodeSocketObject', 'Object Out', is_var=True)
+
+    def draw_label(self) -> str:
+        inp_object = self.inputs['Object In']
+        if inp_object.is_linked:
+            return self.bl_label
+
+        obj_name = inp_object.get_default_value()
+        if obj_name == '':
+            obj_name = '_self'
+
+        return f'{self.bl_label}: {obj_name}'


### PR DESCRIPTION
Implements https://github.com/armory3d/armory/issues/2014.

Reposting the screenshots from the linked issue (for more details please refer to that):
![nodelabel_merge](https://user-images.githubusercontent.com/17685000/99579128-0cd9a200-29de-11eb-9734-641bbf8f5490.gif) ![nodelabel_loop](https://user-images.githubusercontent.com/17685000/99579130-0d723880-29de-11eb-949b-77c04fb698d0.gif)
![nodelabel_object](https://user-images.githubusercontent.com/17685000/99579136-0ea36580-29de-11eb-8f17-8eb0e9aab1e5.gif) ![nodelabel_timer](https://user-images.githubusercontent.com/17685000/99579138-0f3bfc00-29de-11eb-8e74-8a65a27a121c.gif)

- Some nodes will not display a dynamic header if the sockets are connected or only parts of the header are dynamic (for example `x...5` for a loop node where the lower value is a connected socket)
- If a user renames a node, Blender will only display that name (= no dynamic header), which gives the user more freedom.

Also, we should probably think about adding a super class for array nodes, they basically have 90% the same code.