### PR TITLE
Fix inverted margin for Kinematic Character

### DIFF
--- a/Sources/armory/trait/physics/bullet/KinematicCharacterController.hx
+++ b/Sources/armory/trait/physics/bullet/KinematicCharacterController.hx
@@ -72,7 +72,7 @@ class KinematicCharacterController extends Trait {
 	}
 
 	inline function withMargin(f: Float): Float {
-		return f - f * collisionMargin;
+		return f + f * collisionMargin;
 	}
 
 	public function notifyOnReady(f: Void->Void) {


### PR DESCRIPTION
Same fix as https://github.com/armory3d/armory/pull/1907