### PR TITLE
Solve artifact with clustering of lights

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -403,7 +403,7 @@ void main() {
 				, li, lightsArray[li * 2].w, true // bias
 			#endif
 			#ifdef _Spot
-			, li > numPoints - 1
+			, lightsArray[li * 2 + 1].w != 0.0
 			, lightsArray[li * 2 + 1].w // cutoff
 			, lightsArraySpot[li].w // cutoff - exponent
 			, lightsArraySpot[li].xyz // spotDir

--- a/Shaders/deferred_light_mobile/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_mobile/deferred_light.frag.glsl
@@ -221,7 +221,7 @@ void main() {
 				, li, lightsArray[li * 2].w, true // bias
 			#endif
 			#ifdef _Spot
-			, li > numPoints - 1
+			, lightsArray[li * 2 + 1].w != 0.0
 			, lightsArray[li * 2 + 1].w // cutoff
 			, lightsArraySpot[li].w // cutoff - exponent
 			, lightsArraySpot[li].xyz // spotDir


### PR DESCRIPTION
Changed how a spot light is detected when sampling light, which caused false positives and produced
that visual artifact described in this issue https://github.com/armory3d/armory/issues/1289#issuecomment-743190855 when a cluster/pixel was detected incorrectly as being lit with a spot light when there were no spot lights in the scene.

### before: 

![image](https://user-images.githubusercontent.com/42382648/103178141-ecafc500-485e-11eb-8fef-8d0319b03c61.png)

### after:

![image](https://user-images.githubusercontent.com/42382648/103178144-fc2f0e00-485e-11eb-9dda-9510937717ee.png)
