### PR TITLE
Show warnings for invalid instancing configurations + cleanup

### DIFF
--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -1,6 +1,7 @@
 import bpy
 import arm.utils
 import arm.node_utils
+from typing import Dict
 import arm.material.make_shader as make_shader
 import arm.material.mat_batch as mat_batch
 import arm.material.mat_state as mat_state
@@ -21,7 +22,8 @@ def glsl_value(val):
     else:
         return val
 
-def parse(material, mat_data, mat_users, mat_armusers):
+
+def parse(material: bpy.types.Material, mat_data, mat_users: Dict[bpy.types.Material, bpy.types.Object], mat_armusers):
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
 
@@ -54,6 +56,7 @@ def parse(material, mat_data, mat_users, mat_armusers):
         bind_constants['mesh'] = []
         bind_textures = {}
         bind_textures['mesh'] = []
+        make_shader.make_instancing_and_skinning(material, mat_users)
     elif not wrd.arm_batch_materials or material.name.startswith('armdefault'):
         rpasses, shader_data, shader_data_name, bind_constants, bind_textures = make_shader.build(material, mat_users, mat_armusers)
         sd = shader_data.sd

--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -1,17 +1,15 @@
+from typing import Dict, List
+
 import bpy
-import arm.utils
-import arm.node_utils
-from typing import Dict
+from bpy.types import Material
+from bpy.types import Object
+
+import arm.material.cycles as cycles
 import arm.material.make_shader as make_shader
 import arm.material.mat_batch as mat_batch
-import arm.material.mat_state as mat_state
-import arm.material.cycles as cycles
+import arm.node_utils
+import arm.utils
 
-def glsl_type(t): # Merge with cycles
-    if t == 'RGB' or t == 'RGBA' or t == 'VECTOR':
-        return 'vec3'
-    else:
-        return 'float'
 
 def glsl_value(val):
     if str(type(val)) == "<class 'bpy_prop_array'>":
@@ -23,39 +21,25 @@ def glsl_value(val):
         return val
 
 
-def parse(material: bpy.types.Material, mat_data, mat_users: Dict[bpy.types.Material, bpy.types.Object], mat_armusers):
+def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]], mat_armusers):
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
 
     # No batch - shader data per material
     if material.arm_custom_material != '':
         rpasses = ['mesh']
-        sd = {}
-        sd['contexts'] = []
-        con = {}
-        con['vertex_elements'] = []
-        elem = {}
-        elem['name'] = 'pos'
-        elem['data'] = 'short4norm'
-        con['vertex_elements'].append(elem)
-        elem = {}
-        elem['name'] = 'nor'
-        elem['data'] = 'short2norm'
-        con['vertex_elements'].append(elem)
-        elem = {}
-        elem['name'] = 'tex'
-        elem['data'] = 'short2norm'
-        con['vertex_elements'].append(elem)
-        elem = {}
-        elem['name'] = 'tex1'
-        elem['data'] = 'short2norm'
-        con['vertex_elements'].append(elem)
-        sd['contexts'].append(con)
+
+        con = {'vertex_elements': []}
+        con['vertex_elements'].append({'name': 'pos', 'data': 'short4norm'})
+        con['vertex_elements'].append({'name': 'nor', 'data': 'short2norm'})
+        con['vertex_elements'].append({'name': 'tex', 'data': 'short2norm'})
+        con['vertex_elements'].append({'name': 'tex1', 'data': 'short2norm'})
+
+        sd = {'contexts': [con]}
         shader_data_name = material.arm_custom_material
-        bind_constants = {}
-        bind_constants['mesh'] = []
-        bind_textures = {}
-        bind_textures['mesh'] = []
+        bind_constants = {'mesh': []}
+        bind_textures = {'mesh': []}
+
         make_shader.make_instancing_and_skinning(material, mat_users)
     elif not wrd.arm_batch_materials or material.name.startswith('armdefault'):
         rpasses, shader_data, shader_data_name, bind_constants, bind_textures = make_shader.build(material, mat_users, mat_armusers)
@@ -66,39 +50,35 @@ def parse(material: bpy.types.Material, mat_data, mat_users: Dict[bpy.types.Mate
 
     # Material
     for rp in rpasses:
-
-        c = {}
-        c['name'] = rp
-        c['bind_constants'] = [] + bind_constants[rp]
-        c['bind_textures'] = [] + bind_textures[rp]
+        c = {
+            'name': rp,
+            'bind_constants': [] + bind_constants[rp],
+            'bind_textures': [] + bind_textures[rp],
+        }
         mat_data['contexts'].append(c)
 
         if rp == 'mesh':
-            const = {}
-            const['name'] = 'receiveShadow'
-            const['bool'] = material.arm_receive_shadow
-            c['bind_constants'].append(const)
+            c['bind_constants'].append({'name': 'receiveShadow', 'bool': material.arm_receive_shadow})
 
             if material.arm_material_id != 0:
-                const = {}
-                const['name'] = 'materialID'
-                const['int'] = material.arm_material_id
-                c['bind_constants'].append(const)
+                c['bind_constants'].append({'name': 'materialID', 'int': material.arm_material_id})
+
                 if material.arm_material_id == 2:
                     wrd.world_defs += '_Hair'
+
             elif rpdat.rp_sss_state == 'On':
                 sss = False
                 sss_node = arm.node_utils.get_node_by_type(material.node_tree, 'SUBSURFACE_SCATTERING')
-                if sss_node != None and sss_node.outputs[0].is_linked: # Check linked node
+                if sss_node is not None and sss_node.outputs[0].is_linked: # Check linked node
                     sss = True
                 sss_node = arm.node_utils.get_node_by_type(material.node_tree, 'BSDF_PRINCIPLED')
-                if sss_node != None and sss_node.outputs[0].is_linked and (sss_node.inputs[1].is_linked or sss_node.inputs[1].default_value != 0.0):
+                if sss_node is not None and sss_node.outputs[0].is_linked and (sss_node.inputs[1].is_linked or sss_node.inputs[1].default_value != 0.0):
                     sss = True
                 sss_node = arm.node_utils.get_node_armorypbr(material.node_tree)
-                if sss_node != None and sss_node.outputs[0].is_linked and (sss_node.inputs[8].is_linked or sss_node.inputs[8].default_value != 0.0):
+                if sss_node is not None and sss_node.outputs[0].is_linked and (sss_node.inputs[8].is_linked or sss_node.inputs[8].default_value != 0.0):
                     sss = True
-                const = {}
-                const['name'] = 'materialID'
+
+                const = {'name': 'materialID'}
                 if sss:
                     const['int'] = 2
                 else:
@@ -114,27 +94,20 @@ def parse(material: bpy.types.Material, mat_data, mat_users: Dict[bpy.types.Mate
                         if node.type == 'TEX_IMAGE':
                             tex_name = arm.utils.safesrc(node.name)
                             tex = cycles.make_texture(node, tex_name)
-                            if tex == None: # Empty texture
-                                tex = {}
-                                tex['name'] = tex_name
-                                tex['file'] = ''
+                            # Empty texture
+                            if tex is None:
+                                tex = {'name': tex_name, 'file': ''}
                             c['bind_textures'].append(tex)
 
                 # Set marked inputs as uniforms
                 for node in material.node_tree.nodes:
                     for inp in node.inputs:
                         if inp.is_uniform:
-                            uname = arm.utils.safesrc(inp.node.name) + arm.utils.safesrc(inp.name)  # Merge with cycles
-                            const = {}
-                            const['name'] = uname
-                            const[glsl_type(inp.type)] = glsl_value(inp.default_value)
-                            c['bind_constants'].append(const)
+                            uname = arm.utils.safesrc(inp.node.name) + arm.utils.safesrc(inp.name)  # Merge with cycles module
+                            c['bind_constants'].append({'name': uname, cycles.glsl_type(inp.type): glsl_value(inp.default_value)})
 
         elif rp == 'translucent':
-            const = {}
-            const['name'] = 'receiveShadow'
-            const['bool'] = material.arm_receive_shadow
-            c['bind_constants'].append(const)
+            c['bind_constants'].append({'name': 'receiveShadow', 'bool': material.arm_receive_shadow})
 
     if wrd.arm_single_data_file:
         mat_data['shader'] = shader_data_name


### PR DESCRIPTION
Closes https://github.com/armory3d/armory/issues/2072 (please refer to this for more details).

When multiple objects share one material but only some of them are instanced there can be visible flickering in the game because instance attributes like `ipos` are set with garbage values. In those cases there is now a warning printed. Is there a reason why instancing is set per-object and not per-material?

I moved the instancing part in its own method so that we can display the warning for custom shaders too while having to iterate only once over all material users when _not_ using custom shaders. The reason there is only a warning and no workaround behaviour is that users can then decide what to do (for example split materials or enable instancing for all objects with that material).

I also did some cleanup with import reorganization, more type hints and there were some lines where you could simplify the syntax a bit.
