### PR TITLE
[Blender 2.9] Object panel UI

### DIFF
--- a/blender/arm/props_lod.py
+++ b/blender/arm/props_lod.py
@@ -34,24 +34,22 @@ class ArmLodListItem(bpy.types.PropertyGroup):
 
 class ARM_UL_LodList(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
-        # We could write some code to decide which icon to use here...
-        custom_icon = 'OBJECT_DATAMODE'
+        layout.use_property_split = False
 
-        # Make sure your code supports all 3 layout types
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
             layout.prop(item, "enabled_prop")
             name = item.name
             if name == '':
                 name = 'None'
             row = layout.row()
-            row.label(text=name, icon=custom_icon)
+            row.label(text=name, icon='OBJECT_DATAMODE')
             col = row.column()
             col.alignment = 'RIGHT'
             col.label(text="{:.2f}".format(item.screen_size_prop))
 
         elif self.layout_type in {'GRID'}:
             layout.alignment = 'CENTER'
-            layout.label(text="", icon = custom_icon)
+            layout.label(text="", icon='OBJECT_DATAMODE')
 
 class ArmLodListNewItem(bpy.types.Operator):
     # Add a new item to the list

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -119,13 +119,14 @@ class ArmTraitListNewItem(bpy.types.Operator):
 
     is_object: BoolProperty(name="Object Trait", description="Whether this is an object or scene trait", default=False)
     type_prop: EnumProperty(
-        items = [('Haxe Script', 'Haxe', 'Haxe Script'),
-                 ('WebAssembly', 'Wasm', 'WebAssembly'),
-                 ('UI Canvas', 'UI', 'UI Canvas'),
-                 ('Bundled Script', 'Bundled', 'Bundled Script'),
-                 ('Logic Nodes', 'Nodes', 'Logic Nodes')
-                 ],
-        name = "Type")
+        name="Type",
+        items=[
+            ('Haxe Script', 'Haxe', 'Haxe Script'),
+            ('Logic Nodes', 'Nodes', 'Logic Nodes'),
+            ('UI Canvas', 'UI', 'UI Canvas'),
+            ('Bundled Script', 'Bundled', 'Bundled Script'),
+            ('WebAssembly', 'Wasm', 'WebAssembly')
+        ])
 
     def invoke(self, context, event):
         wm = context.window_manager

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -834,7 +834,7 @@ def draw_traits_panel(layout: bpy.types.UILayout, obj: Union[bpy.types.Object, b
             # New
             column = row.column(align=True)
             column.alignment = 'EXPAND'
-            op = column.operator("arm.new_treenode", text="New Node Tree", icon="ADD")
+            op = column.operator("arm.new_treenode", text="New Tree", icon="ADD")
             op.is_object = is_object
             # At least one check is active Logic Node Editor
             is_check_logic_node_editor = False
@@ -857,7 +857,7 @@ def draw_traits_panel(layout: bpy.types.UILayout, obj: Union[bpy.types.Object, b
                 column.enabled = False
             else:
                 column.enabled = is_check_logic_node_editor
-            op = column.operator("arm.edit_treenode", text="Edit Node Tree", icon="NODETREE")
+            op = column.operator("arm.edit_treenode", text="Edit Tree", icon="NODETREE")
             op.is_object = is_object
             # Get from Node Tree Editor
             column = row.column(align=True)
@@ -866,7 +866,7 @@ def draw_traits_panel(layout: bpy.types.UILayout, obj: Union[bpy.types.Object, b
                 column.enabled = False
             else:
                 column.enabled = is_check_logic_node_editor
-            op = column.operator("arm.get_treenode", text="From Node Editor", icon="IMPORT")
+            op = column.operator("arm.get_treenode", text="From Editor", icon="IMPORT")
             op.is_object = is_object
 
             # Row for search

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -2114,20 +2114,27 @@ class ARM_PT_ProxyPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
         layout.operator("arm.make_proxy")
+
         obj = bpy.context.object
-        if obj != None and obj.proxy != None:
-            layout.label(text="Sync")
-            layout.prop(obj, "arm_proxy_sync_loc")
-            layout.prop(obj, "arm_proxy_sync_rot")
-            layout.prop(obj, "arm_proxy_sync_scale")
-            layout.prop(obj, "arm_proxy_sync_materials")
-            layout.prop(obj, "arm_proxy_sync_modifiers")
-            layout.prop(obj, "arm_proxy_sync_traits")
-            row = layout.row()
+        if obj is not None and obj.proxy is not None:
+            col = layout.column(heading="Sync")
+            col.prop(obj, "arm_proxy_sync_loc")
+            col.prop(obj, "arm_proxy_sync_rot")
+            col.prop(obj, "arm_proxy_sync_scale")
+            col.separator()
+
+            col.prop(obj, "arm_proxy_sync_materials")
+            col.prop(obj, "arm_proxy_sync_modifiers")
+            col.separator()
+
+            col.prop(obj, "arm_proxy_sync_traits")
+            row = col.row()
             row.enabled = obj.arm_proxy_sync_traits
             row.prop(obj, "arm_proxy_sync_trait_props")
-            layout.operator("arm.proxy_toggle_all")
-            layout.operator("arm.proxy_apply_all")
+
+            row = layout.row(align=True)
+            row.operator("arm.proxy_toggle_all")
+            row.operator("arm.proxy_apply_all")
 
 class ArmMakeProxyButton(bpy.types.Operator):
     '''Create proxy from linked object'''

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1850,7 +1850,7 @@ class ARM_PT_BakePanel(bpy.types.Panel):
                         layout.label(text="Warning! Overflow not yet supported")
 
 class ArmGenLodButton(bpy.types.Operator):
-    '''Automatically generate LoD levels'''
+    """Automatically generate LoD levels."""
     bl_idname = 'arm.generate_lod'
     bl_label = 'Auto Generate'
 

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -21,8 +21,9 @@ from arm.lightmapper.utility import icon
 from arm.lightmapper.properties.denoiser import oidn, optix
 import importlib
 
-# Menu in object region
+
 class ARM_PT_ObjectPropsPanel(bpy.types.Panel):
+    """Menu in object region."""
     bl_label = "Armory Props"
     bl_space_type = "PROPERTIES"
     bl_region_type = "WINDOW"
@@ -37,12 +38,13 @@ class ARM_PT_ObjectPropsPanel(bpy.types.Panel):
         if obj == None:
             return
 
-        layout.prop(obj, 'arm_export')
+        col = layout.column()
+        col.prop(obj, 'arm_export')
         if not obj.arm_export:
             return
-        layout.prop(obj, 'arm_spawn')
-        layout.prop(obj, 'arm_mobile')
-        layout.prop(obj, 'arm_animation_enabled')
+        col.prop(obj, 'arm_spawn')
+        col.prop(obj, 'arm_mobile')
+        col.prop(obj, 'arm_animation_enabled')
 
         if obj.type == 'MESH':
             layout.prop(obj, 'arm_instanced')


### PR DESCRIPTION
UI updates to the object properties panels for Blender 2.9, most of it is just to get similar results to the old 2.8 look. Some visual changes:

**Reordered the trait types to roughly match the amount of usage:**
![trait_order](https://user-images.githubusercontent.com/17685000/103370119-479a2400-4acc-11eb-95a4-2c2f4e037b07.png)

**The proxy menu now uses a column heading instead of a label which seems to be a new Blender convention:**
![new_proxy_menu](https://user-images.githubusercontent.com/17685000/103370127-48cb5100-4acc-11eb-841e-59b506a9314a.png)

**The logic node operators under the trait menu now have shorter labels to better fit into the layout:**
![node_operators](https://user-images.githubusercontent.com/17685000/103370130-49fc7e00-4acc-11eb-9c3f-4494a6a1ff69.png)

Unfortunately (as you can see in the last image), there is a small bug in Blender's UI that places the checkbox in template lists a few pixels too much to the left. I hope this gets fixed in the future, I wasn't able to find a workaround.