### PR TITLE
Blender 2.9: Update operator options

### DIFF
--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -112,6 +112,7 @@ class ArmNodeAddInputButton(bpy.types.Operator):
     """Add a new input socket to the node set by node_index."""
     bl_idname = 'arm.node_add_input'
     bl_label = 'Add Input'
+    bl_options = {'UNDO', 'INTERNAL'}
 
     node_index: StringProperty(name='Node Index', default='')
     socket_type: StringProperty(name='Socket Type', default='NodeSocketShader')
@@ -135,6 +136,7 @@ class ArmNodeAddInputValueButton(bpy.types.Operator):
     """Add new input"""
     bl_idname = 'arm.node_add_input_value'
     bl_label = 'Add Input'
+    bl_options = {'UNDO', 'INTERNAL'}
     node_index: StringProperty(name='Node Index', default='')
     socket_type: StringProperty(name='Socket Type', default='NodeSocketShader')
 
@@ -148,6 +150,7 @@ class ArmNodeRemoveInputButton(bpy.types.Operator):
     """Remove last input"""
     bl_idname = 'arm.node_remove_input'
     bl_label = 'Remove Input'
+    bl_options = {'UNDO', 'INTERNAL'}
     node_index: StringProperty(name='Node Index', default='')
 
     def execute(self, context):
@@ -163,6 +166,7 @@ class ArmNodeRemoveInputValueButton(bpy.types.Operator):
     """Remove last input"""
     bl_idname = 'arm.node_remove_input_value'
     bl_label = 'Remove Input'
+    bl_options = {'UNDO', 'INTERNAL'}
     node_index: StringProperty(name='Node Index', default='')
 
     def execute(self, context):
@@ -178,6 +182,7 @@ class ArmNodeAddOutputButton(bpy.types.Operator):
     """Add a new output socket to the node set by node_index"""
     bl_idname = 'arm.node_add_output'
     bl_label = 'Add Output'
+    bl_options = {'UNDO', 'INTERNAL'}
 
     node_index: StringProperty(name='Node Index', default='')
     socket_type: StringProperty(name='Socket Type', default='NodeSocketShader')
@@ -201,6 +206,7 @@ class ArmNodeRemoveOutputButton(bpy.types.Operator):
     """Remove last output"""
     bl_idname = 'arm.node_remove_output'
     bl_label = 'Remove Output'
+    bl_options = {'UNDO', 'INTERNAL'}
     node_index: StringProperty(name='Node Index', default='')
 
     def execute(self, context):
@@ -216,6 +222,7 @@ class ArmNodeAddInputOutputButton(bpy.types.Operator):
     """Add new input and output"""
     bl_idname = 'arm.node_add_input_output'
     bl_label = 'Add Input Output'
+    bl_options = {'UNDO', 'INTERNAL'}
 
     node_index: StringProperty(name='Node Index', default='')
     in_socket_type: StringProperty(name='In Socket Type', default='NodeSocketShader')
@@ -246,6 +253,7 @@ class ArmNodeRemoveInputOutputButton(bpy.types.Operator):
     """Remove last input and output"""
     bl_idname = 'arm.node_remove_input_output'
     bl_label = 'Remove Input Output'
+    bl_options = {'UNDO', 'INTERNAL'}
     node_index: StringProperty(name='Node Index', default='')
 
     def execute(self, context):

--- a/blender/arm/logicnode/input/LN_on_swipe.py
+++ b/blender/arm/logicnode/input/LN_on_swipe.py
@@ -5,6 +5,7 @@ class NodeAddOutputButton(bpy.types.Operator):
     """Add 4 States"""
     bl_idname = 'arm.add_output_4_parameters'
     bl_label = 'Add 4 States'
+    bl_options = {'UNDO', 'INTERNAL'}
     node_index: StringProperty(name='Node Index', default='')
     socket_type: StringProperty(name='Socket Type', default='NodeSocketShader')
     name_format: StringProperty(name='Name Format', default='Output {0}')
@@ -31,6 +32,7 @@ class NodeRemoveOutputButton(bpy.types.Operator):
     """Remove 4 last states"""
     bl_idname = 'arm.remove_output_4_parameters'
     bl_label = 'Remove 4 States'
+    bl_options = {'UNDO', 'INTERNAL'}
     node_index: StringProperty(name='Node Index', default='')
 
     def execute(self, context):

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -58,13 +58,14 @@ class ARM_OT_AddNodeOverride(bpy.types.Operator):
     bl_idname = "arm.add_node_override"
     bl_label = "Add Node"
     bl_property = "type"
+    bl_options = {'INTERNAL'}
 
     type: StringProperty(name="NodeItem type")
     use_transform: BoolProperty(name="Use Transform")
 
     def invoke(self, context, event):
         bpy.ops.node.add_node('INVOKE_DEFAULT', type=self.type, use_transform=self.use_transform)
-        return {"FINISHED"}
+        return {'FINISHED'}
 
     @classmethod
     def description(cls, context, properties):
@@ -261,7 +262,7 @@ class ARM_PT_Variables(bpy.types.Panel):
             setN.ntype = ID
 
 class ARMAddVarNode(bpy.types.Operator):
-    '''Add a linked node of that Variable'''
+    """Add a linked node of that Variable"""
     bl_idname = 'arm.add_var_node'
     bl_label = 'Add Get'
     bl_options = {'GRAB_CURSOR', 'BLOCKING'}
@@ -296,7 +297,7 @@ class ARMAddVarNode(bpy.types.Operator):
         return({'FINISHED'})
 
 class ARMAddSetVarNode(bpy.types.Operator):
-    '''Add a node to set this Variable'''
+    """Add a node to set this Variable"""
     bl_idname = 'arm.add_setvar_node'
     bl_label = 'Add Set'
     bl_options = {'GRAB_CURSOR', 'BLOCKING'}

--- a/blender/arm/props_exporter.py
+++ b/blender/arm/props_exporter.py
@@ -358,7 +358,7 @@ class ArmExporterSpecialsMenu(bpy.types.Menu):
         layout.operator("arm.exporter_gpuprofile")
 
 class ArmoryExporterOpenFolderButton(bpy.types.Operator):
-    '''Open published folder'''
+    """Open published folder"""
     bl_idname = 'arm.exporter_open_folder'
     bl_label = 'Open Folder'
 

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -270,7 +270,7 @@ class ARM_PT_ScenePropsPanel(bpy.types.Panel):
         row.prop(scene, 'arm_export')
 
 class InvalidateCacheButton(bpy.types.Operator):
-    '''Delete cached mesh data'''
+    """Delete cached mesh data"""
     bl_idname = "arm.invalidate_cache"
     bl_label = "Invalidate Cache"
 
@@ -279,7 +279,7 @@ class InvalidateCacheButton(bpy.types.Operator):
         return{'FINISHED'}
 
 class InvalidateMaterialCacheButton(bpy.types.Operator):
-    '''Delete cached material data'''
+    """Delete cached material data"""
     bl_idname = "arm.invalidate_material_cache"
     bl_label = "Invalidate Cache"
 
@@ -2246,7 +2246,7 @@ class ARM_OT_ShowFileVersionInfo(bpy.types.Operator):
     bl_idname = 'arm.show_old_file_version_info'
     bl_description = ('Displays an info panel that warns about opening a file'
                        'which was created in a previous version of Armory')
-    # bl_options = {'INTERNAL'}
+    bl_options = {'INTERNAL'}
 
     wrd = None
 


### PR DESCRIPTION
Part of https://github.com/armory3d/armory/pull/2082.

The [Blender 2.9 release notes](https://wiki.blender.org/wiki/Reference/Release_Notes/2.90/Python_API) state:

> With the new operator search that only searches through menus, add-ons that expose operators only through search need to be updated. In general it is good practice to always expose operators through menus so users can find them.

But it doesn't seem to affect Armory operators as far as I could see. Nonetheless, I updated a few operators so that they no longer show up in the search menu when they are not meant to appear there.