### PR TITLE
Fix Reroute nodes

### DIFF
--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -2,9 +2,10 @@ import os
 from typing import Optional, TextIO
 
 import bpy
-import arm.utils
-import arm.log
+
 from arm.exporter import ArmoryExporter
+import arm.log
+import arm.utils
 
 parsed_nodes = []
 parsed_ids = dict() # Sharing node data
@@ -102,7 +103,9 @@ def build_node_tree(node_group):
         f.write('}')
     node_group.arm_cached = True
 
-def build_node(node: bpy.types.Node, f):
+
+def build_node(node: bpy.types.Node, f: TextIO) -> Optional[str]:
+    """Builds the given node and returns its name. f is an opened file object."""
     global parsed_nodes
     global parsed_ids
 
@@ -128,7 +131,7 @@ def build_node(node: bpy.types.Node, f):
     parsed_nodes.append(name)
 
     # Create node
-    node_type = node.bl_idname[2:] # Discard 'LN'TimeNode prefix
+    node_type = node.bl_idname[2:]  # Discard 'LN' prefix
     f.write('\t\tvar ' + name + ' = new armory.logicnode.' + node_type + '(this);\n')
 
     # Handle Function Nodes

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -1,4 +1,6 @@
 import os
+from typing import Optional, TextIO
+
 import bpy
 import arm.utils
 import arm.log
@@ -167,26 +169,45 @@ def build_node(node: bpy.types.Node, f):
 
     # Create inputs
     for inp in node.inputs:
-        # Is linked - find node
+        # True if the input is connected to a unlinked reroute
+        # somewhere down the reroute line
+        unconnected = False
+
+        # Is linked -> find the connected node
         if inp.is_linked:
             n = inp.links[0].from_node
             socket = inp.links[0].from_socket
-            if (inp.bl_idname == 'ArmNodeSocketAction' and socket.bl_idname != 'ArmNodeSocketAction') or \
-                (socket.bl_idname == 'ArmNodeSocketAction' and inp.bl_idname != 'ArmNodeSocketAction'):
-                print('Armory Error: Sockets do not match in logic node tree "{0}" - node "{1}" - socket "{2}"'.format(group_name, node.name, inp.name))
-            inp_name = build_node(n, f)
-            for i in range(0, len(n.outputs)):
-                if n.outputs[i] == socket:
-                    inp_from = i
+
+            # Follow reroutes first
+            while n.type == "REROUTE":
+                if len(n.inputs) == 0 or not n.inputs[0].is_linked:
+                    unconnected = True
                     break
-        # Not linked - create node with default values
+
+                socket = n.inputs[0].links[0].from_socket
+                n = n.inputs[0].links[0].from_node
+
+            if not unconnected:
+                if (inp.bl_idname == 'ArmNodeSocketAction' and socket.bl_idname != 'ArmNodeSocketAction') or \
+                        (socket.bl_idname == 'ArmNodeSocketAction' and inp.bl_idname != 'ArmNodeSocketAction'):
+                    arm.log.warn(f'Sockets do not match in logic node tree "{group_name}": node "{node.name}", socket "{inp.name}"')
+
+                inp_name = build_node(n, f)
+                for i in range(0, len(n.outputs)):
+                    if n.outputs[i] == socket:
+                        inp_from = i
+                        break
+
+        # Not linked -> create node with default values
         else:
             inp_name = build_default_node(inp)
             inp_from = 0
+
         # The input is linked to a reroute, but the reroute is unlinked
-        if inp_name == None:
+        if unconnected:
             inp_name = build_default_node(inp)
             inp_from = 0
+
         # Add input
         f.write('\t\t' + name + '.addInput(' + inp_name + ', ' + str(inp_from) + ');\n')
 


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2090.

Reroutes were not followed correctly before, the input's `from_socket` was taken from the first node in the reroute line (that is the first reroute, and reroutes have one socket only => the index is always 0).

What looks like much in the diff is actually just a little while loop added. Tested it with a lot of example files, all worked as before.