### PR TITLE
Normalize sdk path

### DIFF
--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -156,11 +156,11 @@ def get_sdk_path():
     addon_prefs = get_arm_preferences()
     p = bundled_sdk_path()
     if use_local_sdk:
-        return get_fp() + '/armsdk/'
+        return os.path.normpath(get_fp() + '/armsdk/')
     elif os.path.exists(p) and addon_prefs.sdk_bundled:
-        return p
+        return os.path.normpath(p)
     else:
-        return addon_prefs.sdk_path
+        return os.path.normpath(addon_prefs.sdk_path)
 
 def get_last_commit():
     p = get_sdk_path() + 'armory/.git/refs/heads/master'


### PR DESCRIPTION
Removes the trailing slash of the sdk path (which gets automatically added by blender).  
Before that combined paths did have 2 slashes in between:
`…/armsdk//Krom/Krom` → `…/armsdk/Krom/Krom` 
