### PR TITLE
Add button to create a new custom material

### DIFF
--- a/Shaders/custom_mat_presets/custom_mat_deferred.frag.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_deferred.frag.glsl
@@ -1,0 +1,31 @@
+#version 450
+
+// Include functions for gbuffer operations (packFloat2() etc.)
+#include "../std/gbuffer.glsl"
+
+// World-space normal from the vertex shader stage
+in vec3 wnormal;
+
+// Gbuffer output. Deferred rendering uses the following layout:
+// [0]: normal x      normal y      roughness     metallic/matID
+// [1]: base color r  base color g  base color b  occlusion/specular
+out vec4 fragColor[2];
+
+void main() {
+    // Pack normals into 2 components to fit into the gbuffer
+    vec3 n = normalize(wnormal);
+    n /= (abs(n.x) + abs(n.y) + abs(n.z));
+    n.xy = n.z >= 0.0 ? n.xy : octahedronWrap(n.xy);
+
+    // Define PBR material values
+    vec3 basecol = vec3(1.0);
+    float roughness = 0.0;
+    float metallic = 0.0;
+    float occlusion = 1.0;
+    float specular = 1.0;
+    uint materialId = 0;
+
+    // Store in gbuffer (see layout table above)
+    fragColor[0] = vec4(n.xy, roughness, packFloatInt16(metallic, materialId));
+    fragColor[1] = vec4(basecol.rgb, packFloat2(occlusion, specular));
+}

--- a/Shaders/custom_mat_presets/custom_mat_deferred.vert.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_deferred.vert.glsl
@@ -1,0 +1,20 @@
+#version 450
+
+// World to view projection matrix to correctly position the vertex on screen
+uniform mat4 WVP;
+// Matrix to transform normals from local into world space
+uniform mat3 N;
+
+// Position and normal vector in local space for the current vertex
+// Armory packs the vertex data to preserve memory, so nor.z values are
+// saved in pos.w
+in vec4 pos; // pos.xyz, nor.w
+in vec2 nor; // nor.xy
+
+// Normal vector in world space
+out vec3 wnormal;
+
+void main() {
+    wnormal = normalize(N * vec3(nor.xy, pos.w));
+    gl_Position = WVP * vec4(pos.xyz, 1.0);
+}

--- a/Shaders/custom_mat_presets/custom_mat_deferred.vert.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_deferred.vert.glsl
@@ -5,7 +5,7 @@ uniform mat4 WVP;
 // Matrix to transform normals from local into world space
 uniform mat3 N;
 
-// Position and normal vector in local space for the current vertex
+// Position and normal vectors of the current vertex in local space
 // Armory packs the vertex data to preserve memory, so nor.z values are
 // saved in pos.w
 in vec4 pos; // pos.xyz, nor.w

--- a/Shaders/custom_mat_presets/custom_mat_forward.frag.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_forward.frag.glsl
@@ -1,0 +1,12 @@
+#version 450
+
+// World-space normal from the vertex shader stage
+in vec3 wnormal;
+
+// Color of each fragment on the screen
+out vec4 fragColor;
+
+void main() {
+    // Shadeless white color
+    fragColor = vec4(1.0);
+}

--- a/Shaders/custom_mat_presets/custom_mat_forward.frag.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_forward.frag.glsl
@@ -1,8 +1,5 @@
 #version 450
 
-// World-space normal from the vertex shader stage
-in vec3 wnormal;
-
 // Color of each fragment on the screen
 out vec4 fragColor;
 

--- a/Shaders/custom_mat_presets/custom_mat_forward.vert.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_forward.vert.glsl
@@ -1,0 +1,11 @@
+#version 450
+
+// World to view projection matrix to correctly position the vertex on screen
+uniform mat4 WVP;
+
+// Position and normal vector in local space for the current vertex
+in vec3 pos;
+
+void main() {
+	gl_Position = WVP * vec4(pos, 1.0);
+}

--- a/Shaders/custom_mat_presets/custom_mat_forward.vert.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_forward.vert.glsl
@@ -3,7 +3,7 @@
 // World to view projection matrix to correctly position the vertex on screen
 uniform mat4 WVP;
 
-// Position and normal vector in local space for the current vertex
+// Position vector of the current vertex in local space
 in vec3 pos;
 
 void main() {

--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -112,7 +112,8 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
     if wrd.arm_single_data_file:
         mat_data['shader'] = shader_data_name
     else:
-        ext = '' if wrd.arm_minimize else '.json'
+        # Make sure that custom materials are not expected to be in .arm format
+        ext = '' if wrd.arm_minimize and material.arm_custom_material == "" else '.json'
         mat_data['shader'] = shader_data_name + ext + '/' + shader_data_name
 
     return sd, rpasses


### PR DESCRIPTION
This adds a button to the material UI that opens a small dialog for creating a custom material. All files and folders will be created automatically without having to setup and lookup everything by yourself. The shaders used are the slightly modified minimal glsl examples from [the wiki](https://github.com/armory3d/armory/wiki/renderpath#forward-path), I hope the path where they are currently saved is ok (I can still change that if it doesn't fit). The glsl files are extensively commented to make it easier to getting started with shader programming, json doesn't allow comments.

![custom_mat_dialog](https://user-images.githubusercontent.com/17685000/107812041-65b39f00-6d6f-11eb-92f3-031fa86af02a.png)

If the material definition file and/or the glsl files exist already, separate warnings are displayed (Blender makes a confimation dialog rather complicated):
![custom_mat_warnings](https://user-images.githubusercontent.com/17685000/107812047-664c3580-6d6f-11eb-85e9-4dbe378e456a.png)
