### PR TITLE
Make sure compiled.inc is always first when parsing shaders for clusters

### DIFF
--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -208,7 +208,11 @@ class Shader:
 
     def add_include_front(self, s):
         if not self.has_include(s):
-            self.includes.insert(0, s)
+            pos = 0
+            # make sure compiled.inc is always on top
+            if len(self.includes) > 0 and self.includes[0] == 'compiled.inc':
+                pos = 1
+            self.includes.insert(pos, s)
 
     def add_in(self, s):
         if s not in self.ins:


### PR DESCRIPTION
Attempt to solve this https://github.com/armory3d/armory/pull/2102#issuecomment-778844866

The error was introduced by `add_include_front`, which allowed the `clusters.glsl` include to be written before `compiled.inc`. This produced a compiler error because `clusters.glsl` relies on macros defined in `compiled.inc`.

Tested on Linux Krom with Armory PBR material with opacity < 1.0.

![image](https://user-images.githubusercontent.com/42382648/107892372-64b37680-6f03-11eb-8750-eba9785531f6.png)
