### PR TITLE
Blending fix + ignore irradiance per material

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -21,6 +21,7 @@
 uniform sampler2D gbufferD;
 uniform sampler2D gbuffer0;
 uniform sampler2D gbuffer1;
+uniform sampler2D gbuffer2;
 
 #ifdef _VoxelAOvar
 uniform sampler3D voxels;
@@ -205,6 +206,8 @@ void main() {
 	vec3 v = normalize(eye - p);
 	float dotNV = max(dot(n, v), 0.0);
 
+	vec4 g2 = textureLod(gbuffer2, texCoord, 0.0);
+
 #ifdef _MicroShadowing
 	occspec.x = mix(1.0, occspec.x, dotNV); // AO Fresnel
 #endif
@@ -215,7 +218,15 @@ void main() {
 
 	// Envmap
 #ifdef _Irr
+
 	vec3 envl = shIrradiance(n, shirr);
+
+	if (g2.b < 0.5) {
+		envl = envl;
+	} else {
+		envl = vec3(1.0);
+	}
+
 	#ifdef _EnvTex
 	envl /= PI;
 	#endif

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -549,6 +549,13 @@ class RenderPathDeferred {
 		path.bindTarget("_main", "gbufferD");
 		path.bindTarget("gbuffer0", "gbuffer0");
 		path.bindTarget("gbuffer1", "gbuffer1");
+
+		#if rp_gbuffer2
+		{
+			path.bindTarget("gbuffer2", "gbuffer2");
+		}
+		#end
+
 		#if (rp_ssgi != "Off")
 		{
 			if (armory.data.Config.raw.rp_ssgi != false) {

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -665,6 +665,7 @@ class RenderPathDeferred {
 
 		#if rp_blending
 		{
+			path.setTarget("tex");
 			path.drawMeshes("blend");
 		}
 		#end

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -367,7 +367,18 @@ def build():
         assets.add_khafile_def('rp_chromatic_aberration')
         assets.add_shader_pass('chromatic_aberration_pass')
 
-    gbuffer2 = '_Veloc' in wrd.world_defs
+    ignoreIrr = False
+
+    for obj in bpy.data.objects:
+        if obj.type == "MESH":
+            for slot in obj.material_slots:
+                mat = slot.material
+                if mat.arm_ignore_irradiance:
+                    ignoreIrr = True
+
+    if ignoreIrr:
+        wrd.world_defs += '_IgnoreIrr'
+    gbuffer2 = '_Veloc' in wrd.world_defs or '_IgnoreIrr' in wrd.world_defs
     if gbuffer2:
         assets.add_khafile_def('rp_gbuffer2')
         wrd.world_defs += '_gbuffer2'

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -572,13 +572,15 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
 
     arm_discard = mat_state.material.arm_discard
     make_base(con_mesh, parse_opacity=(parse_opacity or arm_discard))
+    
+    blend = mat_state.material.arm_blending
 
     vert = con_mesh.vert
     frag = con_mesh.frag
     tese = con_mesh.tese
 
     if parse_opacity or arm_discard:
-        if arm_discard:
+        if arm_discard or blend:
             opac = mat_state.material.arm_discard_opacity
             frag.write('if (opacity < {0}) discard;'.format(opac))
         elif transluc_pass:
@@ -587,7 +589,6 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
             opac = '0.9999' # 1.0 - eps
             frag.write('if (opacity < {0}) discard;'.format(opac))
 
-    blend = mat_state.material.arm_blending
     if blend:
         frag.add_out('vec4 fragColor[1]')
         if parse_opacity:

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -268,6 +268,9 @@ def make_deferred(con_mesh, rpasses):
             frag.write('vec2 posb = (prevwvpposition.xy / prevwvpposition.w) * 0.5 + 0.5;')
             frag.write('fragColor[2].rg = vec2(posa - posb);')
 
+        if mat_state.material.arm_ignore_irradiance:
+            frag.write('fragColor[2].b = 1.0;')
+
     return con_mesh
 
 def make_raytracer(con_mesh):

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -331,6 +331,7 @@ def init_properties():
     bpy.types.Material.arm_overlay = BoolProperty(name="Overlay", default=False)
     bpy.types.Material.arm_decal = BoolProperty(name="Decal", default=False)
     bpy.types.Material.arm_two_sided = BoolProperty(name="Two-Sided", description="Flip normal when drawing back-face", default=False)
+    bpy.types.Material.arm_ignore_irradiance = BoolProperty(name="Ignore Irradiance", description="Ignore irradiance for material", default=False)
     bpy.types.Material.arm_cull_mode = EnumProperty(
         items=[('none', 'Both', 'None'),
                ('clockwise', 'Front', 'Clockwise'),

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -446,6 +446,7 @@ class ARM_PT_MaterialPropsPanel(bpy.types.Panel):
         wrd = bpy.data.worlds['Arm']
         columnb.enabled = len(wrd.arm_rplist) > 0 and arm.utils.get_rp().rp_renderer == 'Forward'
         columnb.prop(mat, 'arm_receive_shadow')
+        layout.prop(mat, 'arm_ignore_irradiance')
         layout.prop(mat, 'arm_two_sided')
         columnb = layout.column()
         columnb.enabled = not mat.arm_two_sided


### PR DESCRIPTION
I thought I had made a pull request about this earlier, but turns out I had forgotten to.

In any case, it's a fix for https://github.com/armory3d/armory/issues/1615 which involves issues with blending. On deferred blending causes a setPipeline error, whilst forward displays nothing.

Before on forward:

![Forward](https://user-images.githubusercontent.com/5429817/108596103-2692d880-7383-11eb-9400-3fe2343fa954.png)

After:

![Fixed](https://user-images.githubusercontent.com/5429817/108596105-298dc900-7383-11eb-9231-3ac16e5af5ff.png)

