### PR TITLE
Write debug param by default

### DIFF
--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -253,6 +253,9 @@ project.addSources('Sources');
         if wrd.arm_debug_console:
             assets.add_khafile_def('arm_debug')
             khafile.write(add_shaders(sdk_path + "/armory/Shaders/debug_draw/**", rel_path=do_relpath_sdk))
+    
+        if not is_publish and state.target == 'html5':
+            khafile.write("project.addParameter('--debug');\n")
 
         if wrd.arm_verbose_output:
             khafile.write("project.addParameter('--times');\n")


### PR DESCRIPTION
I might be mistaken, but shouldn't the  `--debug` param not get automatically added for html5, in non-publish mode, to have source-map support ?
