### PR TITLE
Fix shadow artifacts for HTML5 with shadow map atlas

### DIFF
--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -185,17 +185,13 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 				#ifdef _Clusters
 					vec4 lPos = LWVPSpotArray[index] * vec4(p + n * bias * 10, 1.0);
 					#ifdef _ShadowMapAtlas
-						vec3 uv = lPos.xyz / lPos.w;
-						#ifdef _InvY
-						uv.y = 1.0 - uv.y; // invert Y coordinates for direct3d coordinate system
-						#endif
 						direct *= shadowTest(
 							#ifndef _SingleAtlas
 							shadowMapAtlasSpot
 							#else
 							shadowMapAtlas
 							#endif
-							, uv, bias
+							, lPos.xyz / lPos.w, bias
 						);
 					#else
 							 if (index == 0) direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);

--- a/Shaders/std/light_mobile.glsl
+++ b/Shaders/std/light_mobile.glsl
@@ -80,17 +80,13 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 				#ifdef _Clusters
 					vec4 lPos = LWVPSpotArray[index] * vec4(p + n * bias * 10, 1.0);
 					#ifdef _ShadowMapAtlas
-						vec3 uv = lPos.xyz / lPos.w;
-						#ifdef _InvY
-						uv.y = 1.0 - uv.y; // invert Y coordinates for direct3d coordinate system
-						#endif
 						direct *= shadowTest(
 							#ifndef _SingleAtlas
 							shadowMapAtlasSpot
 							#else
 							shadowMapAtlas
 							#endif
-							, uv, bias
+							, lPos.xyz / lPos.w, bias
 						);
 					#else
 							 if (index == 0) direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);

--- a/Shaders/std/shadows.glsl
+++ b/Shaders/std/shadows.glsl
@@ -44,9 +44,13 @@ vec2 sampleCube(vec3 dir, out int faceIndex) {
 	// downscale uv a little to hide seams
 	// transform coordinates from clip space to texture space
 	#ifndef _FlipY
-	return uv * 0.9976 * ma + 0.5;
+		return uv * 0.9976 * ma + 0.5;
 	#else
-	return vec2(uv.x * ma, uv.y * -ma) * 0.9976 + 0.5;
+		#ifdef HLSL
+			return uv * 0.9976 * ma + 0.5;
+		#else
+			return vec2(uv.x * ma, uv.y * -ma) * 0.9976 + 0.5;
+		#endif
 	#endif
 }
 #endif

--- a/Shaders/std/shadows.glsl
+++ b/Shaders/std/shadows.glsl
@@ -42,7 +42,12 @@ vec2 sampleCube(vec3 dir, out int faceIndex) {
 		uv = vec2(dir.x < 0.0 ? dir.z : -dir.z, -dir.y);
 	}
 	// downscale uv a little to hide seams
+	// transform coordinates from clip space to texture space
+	#ifndef _FlipY
 	return uv * 0.9976 * ma + 0.5;
+	#else
+	return vec2(uv.x * ma, uv.y * -ma) * 0.9976 + 0.5;
+	#endif
 }
 #endif
 
@@ -189,7 +194,7 @@ float PCFFakeCube(sampler2DShadow shadowMap, const vec3 lp, vec3 ml, const float
 
 	vec4 pointLightTile = pointLightDataArray[lightIndex + faceIndex]; // x: tile X offset, y: tile Y offset, z: tile size relative to atlas
 	vec2 uvtiled = pointLightTile.z * uv + pointLightTile.xy;
-	#ifdef _InvY
+	#ifdef _FlipY
 	uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
 	#endif
 
@@ -199,7 +204,7 @@ float PCFFakeCube(sampler2DShadow shadowMap, const vec3 lp, vec3 ml, const float
 	uvtiled = transformOffsetedUV(faceIndex, newFaceIndex, vec2(uv + (vec2(-1.0, 0.0) / smSize)));
 	pointLightTile = pointLightDataArray[lightIndex + newFaceIndex];
 	uvtiled = pointLightTile.z * uvtiled + pointLightTile.xy;
-	#ifdef _InvY
+	#ifdef _FlipY
 	uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
 	#endif
 	result += texture(shadowMap, vec3(pointLightTile.z * uvtiled + pointLightTile.xy, compare));
@@ -207,7 +212,7 @@ float PCFFakeCube(sampler2DShadow shadowMap, const vec3 lp, vec3 ml, const float
 	uvtiled = transformOffsetedUV(faceIndex, newFaceIndex, vec2(uv + (vec2(-1.0, 1.0) / smSize)));
 	pointLightTile = pointLightDataArray[lightIndex + newFaceIndex];
 	uvtiled = pointLightTile.z * uvtiled + pointLightTile.xy;
-	#ifdef _InvY
+	#ifdef _FlipY
 	uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
 	#endif
 	result += texture(shadowMap, vec3(uvtiled, compare));
@@ -215,7 +220,7 @@ float PCFFakeCube(sampler2DShadow shadowMap, const vec3 lp, vec3 ml, const float
 	uvtiled = transformOffsetedUV(faceIndex, newFaceIndex, vec2(uv + (vec2(0.0, -1.0) / smSize)));
 	pointLightTile = pointLightDataArray[lightIndex + newFaceIndex];
 	uvtiled = pointLightTile.z * uvtiled + pointLightTile.xy;
-	#ifdef _InvY
+	#ifdef _FlipY
 	uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
 	#endif
 	result += texture(shadowMap, vec3(uvtiled, compare));
@@ -223,7 +228,7 @@ float PCFFakeCube(sampler2DShadow shadowMap, const vec3 lp, vec3 ml, const float
 	uvtiled = transformOffsetedUV(faceIndex, newFaceIndex, vec2(uv + (vec2(-1.0, -1.0) / smSize)));
 	pointLightTile = pointLightDataArray[lightIndex + newFaceIndex];
 	uvtiled = pointLightTile.z * uvtiled + pointLightTile.xy;
-	#ifdef _InvY
+	#ifdef _FlipY
 	uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
 	#endif
 	result += texture(shadowMap, vec3(uvtiled, compare));
@@ -231,7 +236,7 @@ float PCFFakeCube(sampler2DShadow shadowMap, const vec3 lp, vec3 ml, const float
 	uvtiled = transformOffsetedUV(faceIndex, newFaceIndex, vec2(uv + (vec2(0.0, 1.0) / smSize)));
 	pointLightTile = pointLightDataArray[lightIndex + newFaceIndex];
 	uvtiled = pointLightTile.z * uvtiled + pointLightTile.xy;
-	#ifdef _InvY
+	#ifdef _FlipY
 	uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
 	#endif
 	result += texture(shadowMap, vec3(uvtiled, compare));
@@ -239,7 +244,7 @@ float PCFFakeCube(sampler2DShadow shadowMap, const vec3 lp, vec3 ml, const float
 	uvtiled = transformOffsetedUV(faceIndex, newFaceIndex, vec2(uv + (vec2(1.0, -1.0) / smSize)));
 	pointLightTile = pointLightDataArray[lightIndex + newFaceIndex];
 	uvtiled = pointLightTile.z * uvtiled + pointLightTile.xy;
-	#ifdef _InvY
+	#ifdef _FlipY
 	uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
 	#endif
 	result += texture(shadowMap, vec3(uvtiled, compare));
@@ -247,7 +252,7 @@ float PCFFakeCube(sampler2DShadow shadowMap, const vec3 lp, vec3 ml, const float
 	uvtiled = transformOffsetedUV(faceIndex, newFaceIndex, vec2(uv + (vec2(1.0, 0.0) / smSize)));
 	pointLightTile = pointLightDataArray[lightIndex + newFaceIndex];
 	uvtiled = pointLightTile.z * uvtiled + pointLightTile.xy;
-	#ifdef _InvY
+	#ifdef _FlipY
 	uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
 	#endif
 	result += texture(shadowMap, vec3(uvtiled, compare));
@@ -255,7 +260,7 @@ float PCFFakeCube(sampler2DShadow shadowMap, const vec3 lp, vec3 ml, const float
 	uvtiled = transformOffsetedUV(faceIndex, newFaceIndex, vec2(uv + (vec2(1.0, 1.0) / smSize)));
 	pointLightTile = pointLightDataArray[lightIndex + newFaceIndex];
 	uvtiled = pointLightTile.z * uvtiled + pointLightTile.xy;
-	#ifdef _InvY
+	#ifdef _FlipY
 	uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
 	#endif
 	result += texture(shadowMap, vec3(uvtiled, compare));

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -211,7 +211,7 @@ def export_data(fp, sdk_path):
     resx, resy = arm.utils.get_render_resolution(arm.utils.get_active_scene())
     if wrd.arm_write_config:
         write_data.write_config(resx, resy)
-    
+
     # Change project version (Build, Publish)
     if (not state.is_play) and (wrd.arm_project_version_autoinc):
         wrd.arm_project_version = arm.utils.arm.utils.change_version_project(wrd.arm_project_version)
@@ -654,12 +654,12 @@ def build_success():
                         state.proc_publish_build = run_proc(cmd, done_gradlew_build)
                 else:
                     print('\nBuilding APK Warning: ANDROID_SDK_ROOT is not specified in environment variables and "Android SDK Path" setting is not specified in preferences: \n- If you specify an environment variable ANDROID_SDK_ROOT, then you need to restart Blender;\n- If you specify the setting "Android SDK Path" in the preferences, then repeat operation "Publish"')
-        
+
         # HTML5 After Publish
         if target_name.startswith('html5'):
             if len(arm.utils.get_html5_copy_path()) > 0 and (wrd.arm_project_html5_copy):
                 project_name = arm.utils.safesrc(wrd.arm_project_name +'-'+ wrd.arm_project_version)
-                dst = os.path.join(arm.utils.get_html5_copy_path(), project_name) 
+                dst = os.path.join(arm.utils.get_html5_copy_path(), project_name)
                 if os.path.exists(dst):
                     shutil.rmtree(dst)
                 try:
@@ -673,10 +673,10 @@ def build_success():
                     link_html5_app = arm.utils.get_link_web_server() +'/'+ project_name
                     print("Running a browser with a link " + link_html5_app)
                     webbrowser.open(link_html5_app)
-        
+
         # Windows After Publish
         if target_name.startswith('windows'):
-            list_vs = [] 
+            list_vs = []
             err = ''
             # Print message
             project_name = arm.utils.safesrc(wrd.arm_project_name +'-'+ wrd.arm_project_version)
@@ -707,18 +707,18 @@ def build_success():
                     for vs in list_vs:
                         print('- ' + vs[1] + ' (version ' + vs[3] +')')
                     return
-                # Current VS 
+                # Current VS
                 vs_path = ''
                 for vs in list_vs:
                     if vs[0] == wrd.arm_project_win_list_vs:
                         vs_path = vs[2]
                         break
-                # Open in Visual Studio                
+                # Open in Visual Studio
                 if int(wrd.arm_project_win_build) == 1:
                     cmd = os.path.join('start "' + vs_path, 'Common7', 'IDE', 'devenv.exe" "' + os.path.join(project_path, project_name + '.sln"'))
                     subprocess.Popen(cmd, shell=True)
                 # Compile
-                if int(wrd.arm_project_win_build) > 1:                    
+                if int(wrd.arm_project_win_build) > 1:
                     bits = '64' if wrd.arm_project_win_build_arch == 'x64' else '32'
                     # vcvars
                     cmd = os.path.join(vs_path, 'VC', 'Auxiliary', 'Build', 'vcvars' + bits + '.bat')
@@ -792,7 +792,7 @@ def done_vs_vars():
         # MSBuild
         wrd = bpy.data.worlds['Arm']
         list_vs, err = arm.utils.get_list_installed_vs(True, True, True)
-        # Current VS 
+        # Current VS
         vs_path = ''
         vs_name = ''
         for vs in list_vs:
@@ -851,7 +851,7 @@ def done_vs_build():
             os.chdir(res_path) # set work folder
             subprocess.Popen(cmd, shell=True)
         # Open Build Directory
-        if wrd.arm_project_win_build_open:               
+        if wrd.arm_project_win_build_open:
             arm.utils.open_folder(path)
         state.redraw_ui = True
     else:

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -537,6 +537,9 @@ def write_compiledglsl(defs, make_variants):
 #endif
 """)
 
+        if state.target == 'html5':
+            f.write("#define _FlipY\n")
+
         f.write("""const float PI = 3.1415926535;
 const float PI2 = PI * 2.0;
 const vec2 shadowmapSize = vec2(""" + str(shadowmap_size) + """, """ + str(shadowmap_size) + """);

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -537,7 +537,7 @@ def write_compiledglsl(defs, make_variants):
 #endif
 """)
 
-        if state.target == 'html5':
+        if state.target == 'html5' or arm.utils.get_gapi() == 'direct3d11':
             f.write("#define _FlipY\n")
 
         f.write("""const float PI = 3.1415926535;


### PR DESCRIPTION
This solves https://github.com/armory3d/armory/issues/2110 by applying a workaround discussed in the issue found by @Naxela: 

WebGL supposedly has the same texture coordinate system as openGL, but for whatever reason coordinates require a special treatment in order to make texture reading (and consequently shadows) work on Firefox and Chrome (Windows and Linux), so this should solve it for spot lights, sun and point lights.

Explanation:
Basically what's done is coordinates are flipped after applying the projection (in LightObject and Uniform for spot lights and sun respectively, and sampleCube() in the shaders for point lights). Then after computing the uv for the atlas, the coordinates are flipped again and that makes it work.

The result are coordinates which are "offseted"
![image](https://user-images.githubusercontent.com/42382648/109564410-c9ec9780-7abf-11eb-955c-1e6fa72a27be.png)


Also a minimal optimization was applied by moving part of the uv computing for spot lights and sun to LightObject/Uniform instead of doing it every time in the shader.

Requires https://github.com/armory3d/iron/pull/114