### PR TITLE
Fix forward+single atlas failing to compile with just 1 light

### DIFF
--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -4,7 +4,7 @@ def write(vert, frag):
     wrd = bpy.data.worlds['Arm']
     is_shadows = '_ShadowMap' in wrd.world_defs
     is_shadows_atlas = '_ShadowMapAtlas' in wrd.world_defs
-    is_single_atlas = is_shadows_atlas and '_SingleAtlas' in wrd.world_defs
+    is_single_atlas = '_SingleAtlas' in wrd.world_defs
 
     frag.add_include_front('std/clusters.glsl')
     frag.add_uniform('vec2 cameraProj', link='_cameraPlaneProj')
@@ -17,6 +17,8 @@ def write(vert, frag):
         if is_shadows_atlas:
             if not is_single_atlas:
                 frag.add_uniform('sampler2DShadow shadowMapAtlasPoint', included=True)
+            else:
+                frag.add_uniform('sampler2DShadow shadowMapAtlas', top=True)
             frag.add_uniform('vec4 pointLightDataArray[maxLightsCluster]', link='_pointLightsAtlasArray', included=True)
         else:
             frag.add_uniform('samplerCubeShadow shadowMapPoint[4]', included=True)
@@ -36,9 +38,12 @@ def write(vert, frag):
         frag.write('int numSpots = int(texelFetch(clustersData, ivec2(clusterI, 1 + maxLightsCluster), 0).r * 255);')
         frag.write('int numPoints = numLights - numSpots;')
         if is_shadows:
-            if is_shadows_atlas and not is_single_atlas:
-                frag.add_uniform(f'sampler2DShadow shadowMapAtlasSpot', included=True)
-            elif not is_shadows_atlas:
+            if is_shadows_atlas:
+                if not is_single_atlas:
+                    frag.add_uniform('sampler2DShadow shadowMapAtlasSpot', included=True)
+                else:
+                    frag.add_uniform('sampler2DShadow shadowMapAtlas', top=True)
+            else:
                 frag.add_uniform('sampler2DShadow shadowMapSpot[4]', included=True)
             # FIXME: type is actually mat4, but otherwise it will not be set as floats when writing the shaders' json files
             frag.add_uniform('vec4 LWVPSpotArray[maxLightsCluster]', link='_biasLightWorldViewProjectionMatrixSpotArray', included=True)

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -358,9 +358,9 @@ def make_forward_mobile(con_mesh):
 
     is_shadows = '_ShadowMap' in wrd.world_defs
     is_shadows_atlas = '_ShadowMapAtlas' in wrd.world_defs
-    is_single_atlas = is_shadows_atlas and '_SingleAtlas' in wrd.world_defs
     shadowmap_sun = 'shadowMap'
     if is_shadows_atlas:
+        is_single_atlas = '_SingleAtlas' in wrd.world_defs
         shadowmap_sun = 'shadowMapAtlasSun' if not is_single_atlas else 'shadowMapAtlas'
         frag.add_uniform('vec2 smSizeUniform', '_shadowMapSize', included=True)
     frag.write('vec3 direct = vec3(0.0);')
@@ -575,7 +575,7 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
 
     arm_discard = mat_state.material.arm_discard
     make_base(con_mesh, parse_opacity=(parse_opacity or arm_discard))
-    
+
     blend = mat_state.material.arm_blending
 
     vert = con_mesh.vert

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -223,6 +223,9 @@ class Shader:
             self.outs.append(s)
 
     def add_uniform(self, s, link=None, included=False, top=False):
+        # prevent duplicates
+        if s in self.uniforms or s in self.uniforms_top:
+            return
         ar = s.split(' ')
         # layout(RGBA8) image3D voxels
         utype = ar[-2]


### PR DESCRIPTION
This should fix an issue where the uniform for shadowMapAtlas used with the single atlas option was not added when having just 1 light.

Originally reported here https://forums.armory3d.org/t/krom-windows/4496/8