### PR TITLE
Fix for material NoneType and fix for Blender exit error

### DIFF
--- a/blender/arm/keymap.py
+++ b/blender/arm/keymap.py
@@ -17,6 +17,8 @@ def register():
 
     km = addon_keyconfig.keymaps.new(name='Window', space_type='EMPTY', region_type="WINDOW")
     km.keymap_items.new(props_ui.ArmoryPlayButton.bl_idname, type='F5', value='PRESS')
+    km.keymap_items.new("tlm.build_lightmaps", type='F6', value='PRESS')
+    km.keymap_items.new("tlm.clean_lightmaps", type='F7', value='PRESS')
     arm_keymaps.append(km)
 
 def unregister():

--- a/blender/arm/lightmapper/keymap/__init__.py
+++ b/blender/arm/lightmapper/keymap/__init__.py
@@ -1,7 +1,0 @@
-from . import keymap
-
-def register():
-    keymap.register()
-
-def unregister():
-    keymap.unregister()

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -373,8 +373,11 @@ def build():
         if obj.type == "MESH":
             for slot in obj.material_slots:
                 mat = slot.material
-                if mat.arm_ignore_irradiance:
-                    ignoreIrr = True
+
+                if mat: #Check if not NoneType
+
+                    if mat.arm_ignore_irradiance:
+                        ignoreIrr = True
 
     if ignoreIrr:
         wrd.world_defs += '_IgnoreIrr'

--- a/blender/arm/props_bake.py
+++ b/blender/arm/props_bake.py
@@ -3,7 +3,7 @@ import arm.assets
 import bpy
 from bpy.types import Menu, Panel, UIList
 from bpy.props import *
-from arm.lightmapper import operators, properties, utility, keymap
+from arm.lightmapper import operators, properties, utility
 
 class ArmBakeListItem(bpy.types.PropertyGroup):
     obj: PointerProperty(type=bpy.types.Object, description="The object to bake")
@@ -361,7 +361,6 @@ def register():
 
     operators.register()
     properties.register()
-    keymap.register()
 
 def unregister():
     bpy.utils.unregister_class(ArmBakeListItem)
@@ -381,4 +380,3 @@ def unregister():
 
     operators.unregister()
     properties.unregister()
-    keymap.unregister()


### PR DESCRIPTION
First commit is a fix where unallocated material slots would cause an error with the arm_ignore_irradiance check, as reported by a user on Discord:

![image0](https://user-images.githubusercontent.com/5429817/110688966-7296a780-81e2-11eb-8bf9-a95f551ac51e.jpg)

![image](https://user-images.githubusercontent.com/5429817/110688996-7b877900-81e2-11eb-83eb-d3d74978ec03.png)

Second commit is a fix for the annoying winman error - It's already fixed in the upcoming lightmapper update for the 2.9 branch, but I'm not sure how far out the branch is yet, so I've fixed it for the main branch as well:

![image](https://user-images.githubusercontent.com/5429817/110689139-a40f7300-81e2-11eb-8f55-8b86147005fc.png)