### PR TITLE
Fix light visual artifact when close to the camera

### DIFF
--- a/Shaders/std/clusters.glsl
+++ b/Shaders/std/clusters.glsl
@@ -8,6 +8,10 @@ int getClusterI(vec2 tc, float viewz, vec2 cameraPlane) {
 		float z = log(viewz - cnear + 1.0) / log(cameraPlane.y - cnear + 1.0);
 		sliceZ = int(z * (clusterSlices.z - 1)) + 1;
 	}
+	// address gap between near plane and cluster near offset
+	else if (viewz >= cameraPlane.x) {
+		sliceZ = 1;
+	}
 	return int(tc.x * clusterSlices.x) +
 		   int(int(tc.y * clusterSlices.y) * clusterSlices.x) +
 		   int(sliceZ * clusterSlices.x * clusterSlices.y);

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -253,7 +253,7 @@ project.addSources('Sources');
         if wrd.arm_debug_console:
             assets.add_khafile_def('arm_debug')
             khafile.write(add_shaders(sdk_path + "/armory/Shaders/debug_draw/**", rel_path=do_relpath_sdk))
-    
+
         if not is_publish and state.target == 'html5':
             khafile.write("project.addParameter('--debug');\n")
 
@@ -711,7 +711,7 @@ const float voxelgiAperture = """ + str(round(rpdat.arm_voxelgi_aperture * 100) 
             f.write(
 """const int maxLights = """ + max_lights + """;
 const int maxLightsCluster = """ + max_lights_clusters + """;
-const float clusterNear = 4.0;
+const float clusterNear = 3.0;
 """)
 
         f.write(add_compiledglsl + '\n') # External defined constants


### PR DESCRIPTION
This fixes a current problem with lights that occurs when getting too close to the camera. The issue is related to the clustering algorithm and the "cluster near solution".

> #### "Cluster near solution" explanation for context:
> Because of the logarithmic nature of how the Z slice is calculated, clusters slices get "burned" too quickly at the start of the frustum, which is not ideal. So to solve this an offset is applied to the start of the cluster frustum, which is clusterNear.

Cluster near solves one problem but creates another one: There is a gap between the near plane and the cluster near offset that gets completely ignored when calculating the Z slice. And this results in the visual artifact of a visual space not being affected by light whatsoever.

![image](https://user-images.githubusercontent.com/42382648/111036895-6851f480-8400-11eb-9536-0e3e0ffe99ff.png)

The proposed solution is to "stretch" the first slice of Z clusters to contain the gap.

### Before:

![image](https://user-images.githubusercontent.com/42382648/111036912-7acc2e00-8400-11eb-9de5-21f0142071c2.png)

### After:

![image](https://user-images.githubusercontent.com/42382648/111036917-7f90e200-8400-11eb-9271-0f9decf7d901.png)
