### PR TITLE
Fix shadow rendering for point and spot lights for deferred and forward mobile

### DIFF
--- a/Shaders/deferred_light_mobile/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_mobile/deferred_light.frag.glsl
@@ -29,6 +29,9 @@ uniform int envmapNumMipmaps;
 uniform vec3 backgroundCol;
 #endif
 
+#ifdef _SMSizeUniform
+//!uniform vec2 smSizeUniform;
+#endif
 uniform vec2 cameraProj;
 uniform vec3 eye;
 uniform vec3 eyeLook;

--- a/Shaders/deferred_light_mobile/deferred_light_mobile.json
+++ b/Shaders/deferred_light_mobile/deferred_light_mobile.json
@@ -108,6 +108,11 @@
 					"ifdef": ["_SSRS"]
 				},
 				{
+					"name": "smSizeUniform",
+					"link": "_shadowMapSize",
+					"ifdef": ["_SMSizeUniform"]
+				},
+				{
 					"name": "lightProj",
 					"link": "_lightPlaneProj",
 					"ifdef": ["_ShadowMap"]

--- a/Shaders/std/light_mobile.glsl
+++ b/Shaders/std/light_mobile.glsl
@@ -8,38 +8,38 @@
 #endif
 
 #ifdef _ShadowMap
-#ifdef _SinglePoint
-	#ifdef _Spot
-	uniform sampler2DShadow shadowMapSpot[1];
-	uniform mat4 LWVPSpot[1];
-	#else
-	uniform samplerCubeShadow shadowMapPoint[1];
-	uniform vec2 lightProj;
+	#ifdef _SinglePoint
+		#ifdef _Spot
+		uniform sampler2DShadow shadowMapSpot[1];
+		uniform mat4 LWVPSpot[1];
+		#else
+		uniform samplerCubeShadow shadowMapPoint[1];
+		uniform vec2 lightProj;
+		#endif
 	#endif
-#endif
-#ifdef _Clusters
-	#ifdef _SingleAtlas
-	//!uniform sampler2DShadow shadowMapAtlas;
-	#endif
-	uniform vec2 lightProj;
-	#ifdef _ShadowMapAtlas
-	#ifndef _SingleAtlas
-	uniform sampler2DShadow shadowMapAtlasPoint;
-	#endif
-	#else
-	uniform samplerCubeShadow shadowMapPoint[4];
-	#endif
-	#ifdef _Spot
+	#ifdef _Clusters
+		#ifdef _SingleAtlas
+		//!uniform sampler2DShadow shadowMapAtlas;
+		#endif
+		uniform vec2 lightProj;
 		#ifdef _ShadowMapAtlas
 		#ifndef _SingleAtlas
-		uniform sampler2DShadow shadowMapAtlasSpot;
+		uniform sampler2DShadow shadowMapAtlasPoint;
 		#endif
 		#else
-		uniform sampler2DShadow shadowMapSpot[maxLightsCluster];
+		uniform samplerCubeShadow shadowMapPoint[4];
 		#endif
-		uniform mat4 LWVPSpotArray[maxLightsCluster];
+		#ifdef _Spot
+			#ifdef _ShadowMapAtlas
+			#ifndef _SingleAtlas
+			uniform sampler2DShadow shadowMapAtlasSpot;
+			#endif
+			#else
+			uniform sampler2DShadow shadowMapSpot[maxLightsCluster];
+			#endif
+			uniform mat4 LWVPSpotArray[maxLightsCluster];
+		#endif
 	#endif
-#endif
 #endif
 
 vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, const vec3 lp, const vec3 lightCol,
@@ -102,10 +102,12 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	#endif
 
 	#ifdef _ShadowMap
-	#ifndef _Spot
+
 		if (receiveShadow) {
 			#ifdef _SinglePoint
+			#ifndef _Spot
 			direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+			#endif
 			#endif
 			#ifdef _Clusters
 				#ifdef _ShadowMapAtlas
@@ -125,7 +127,6 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 				#endif
 			#endif
 		}
-	#endif
 	#endif
 
 	return direct;


### PR DESCRIPTION
Tested with Krom Linux with point lights and spot lights with deferred and forward using the Mobile render path preset, 
Test file: [deferred_mobile.blend.zip](https://github.com/armory3d/armory/files/6138138/deferred_mobile.blend.zip)

### before:

![before](https://user-images.githubusercontent.com/42382648/111091494-ddf9b580-8511-11eb-9147-a4f87d98ddaa.png)

### after:

![after](https://user-images.githubusercontent.com/42382648/111091502-e225d300-8511-11eb-9304-23e9c1c614d8.png)
