### PR TITLE
Fix shadows not working when there are lights present with cast_shadow=false

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -94,7 +94,7 @@ uniform vec3 eye;
 uniform vec3 eyeLook;
 
 #ifdef _Clusters
-uniform vec4 lightsArray[maxLights * 2];
+uniform vec4 lightsArray[maxLights * 3];
 	#ifdef _Spot
 	uniform vec4 lightsArraySpot[maxLights];
 	#endif
@@ -456,18 +456,19 @@ void main() {
 			n,
 			v,
 			dotNV,
-			lightsArray[li * 2].xyz, // lp
-			lightsArray[li * 2 + 1].xyz, // lightCol
+			lightsArray[li * 3].xyz, // lp
+			lightsArray[li * 3 + 1].xyz, // lightCol
 			albedo,
 			roughness,
 			occspec.y,
 			f0
 			#ifdef _ShadowMap
-				, li, lightsArray[li * 2].w, true // bias
+				// light index, shadow bias, cast_shadows
+				, li, lightsArray[li * 3 + 2].x, lightsArray[li * 3 + 2].z != 0.0
 			#endif
 			#ifdef _Spot
-			, lightsArray[li * 2 + 1].w != 0.0
-			, lightsArray[li * 2 + 1].w // cutoff
+			, lightsArray[li * 3 + 2].y != 0.0
+			, lightsArray[li * 3 + 2].y // cutoff
 			, lightsArraySpot[li].w // cutoff - exponent
 			, lightsArraySpot[li].xyz // spotDir
 			#endif

--- a/Shaders/deferred_light_mobile/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_mobile/deferred_light.frag.glsl
@@ -34,7 +34,7 @@ uniform vec3 eye;
 uniform vec3 eyeLook;
 
 #ifdef _Clusters
-uniform vec4 lightsArray[maxLights * 2];
+uniform vec4 lightsArray[maxLights * 3];
 	#ifdef _Spot
 	uniform vec4 lightsArraySpot[maxLights];
 	#endif
@@ -255,18 +255,19 @@ void main() {
 			n,
 			v,
 			dotNV,
-			lightsArray[li * 2].xyz, // lp
-			lightsArray[li * 2 + 1].xyz, // lightCol
+			lightsArray[li * 3].xyz, // lp
+			lightsArray[li * 3 + 1].xyz, // lightCol
 			albedo,
 			roughness,
 			occspec.y,
 			f0
 			#ifdef _ShadowMap
-				, li, lightsArray[li * 2].w, true // bias
+				// light index, shadow bias, cast_shadows
+				, li, lightsArray[li * 3 + 2].x, lightsArray[li * 3 + 2].z != 0.0
 			#endif
 			#ifdef _Spot
-			, lightsArray[li * 2 + 1].w != 0.0
-			, lightsArray[li * 2 + 1].w // cutoff
+			, lightsArray[li * 3 + 2].y != 0.0
+			, lightsArray[li * 3 + 2].y // cutoff
 			, lightsArraySpot[li].w // cutoff - exponent
 			, lightsArraySpot[li].xyz // spotDir
 			#endif

--- a/Shaders/volumetric_light/volumetric_light.frag.glsl
+++ b/Shaders/volumetric_light/volumetric_light.frag.glsl
@@ -12,7 +12,7 @@ uniform sampler2D gbufferD;
 uniform sampler2D snoise;
 
 #ifdef _Clusters
-uniform vec4 lightsArray[maxLights * 2];
+uniform vec4 lightsArray[maxLights * 3];
 	#ifdef _Spot
 	uniform vec4 lightsArraySpot[maxLights];
 	#endif

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -57,7 +57,11 @@ class Inc {
 					break;
 				if (LightObject.discardLightCulled(light)) continue;
 				if (light.data.raw.type == "point") {
-					for(k in 0...light.tileOffsetX.length) {
+					if (!light.data.raw.cast_shadow) {
+						j += 4 * 6;
+						continue;
+					}
+					for(k in 0...6) {
 						LightObject.pointLightsData[j	 ] = light.tileOffsetX[k]; // posx
 						LightObject.pointLightsData[j + 1] = light.tileOffsetY[k]; // posy
 						LightObject.pointLightsData[j + 2] = light.tileScale[k]; // tile scale factor relative to atlas

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -9,7 +9,7 @@ def write(vert, frag):
     frag.add_include_front('std/clusters.glsl')
     frag.add_uniform('vec2 cameraProj', link='_cameraPlaneProj')
     frag.add_uniform('vec2 cameraPlane', link='_cameraPlane')
-    frag.add_uniform('vec4 lightsArray[maxLights * 2]', link='_lightsArray')
+    frag.add_uniform('vec4 lightsArray[maxLights * 3]', link='_lightsArray')
     frag.add_uniform('sampler2D clustersData', link='_clustersData')
     if is_shadows:
         frag.add_uniform('bool receiveShadow')
@@ -56,19 +56,19 @@ def write(vert, frag):
     frag.write('    n,')
     frag.write('    vVec,')
     frag.write('    dotNV,')
-    frag.write('    lightsArray[li * 2].xyz,') # lp
-    frag.write('    lightsArray[li * 2 + 1].xyz,') # lightCol
+    frag.write('    lightsArray[li * 3].xyz,') # lp
+    frag.write('    lightsArray[li * 3 + 1].xyz,') # lightCol
     frag.write('    albedo,')
     frag.write('    roughness,')
     frag.write('    specular,')
     frag.write('    f0')
     if is_shadows:
-        frag.write('    , li, lightsArray[li * 2].w, receiveShadow') # bias
+        frag.write('\t, li, lightsArray[li * 3 + 2].x, lightsArray[li * 3 + 2].z != 0.0') # bias
     if '_Spot' in wrd.world_defs:
-        frag.write('    , lightsArray[li * 2 + 1].w != 0.0')
-        frag.write('    , lightsArray[li * 2 + 1].w') # cutoff
-        frag.write('    , lightsArraySpot[li].w') # cutoff - exponent
-        frag.write('    , lightsArraySpot[li].xyz') # spotDir
+        frag.write('\t, lightsArray[li * 3 + 2].y != 0.0')
+        frag.write('\t, lightsArray[li * 3 + 2].y') # cutoff
+        frag.write('\t, lightsArraySpot[li].w') # cutoff - exponent
+        frag.write('\t, lightsArraySpot[li].xyz') # spotDir
     if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:
         frag.write('  , voxels, voxpos')
     frag.write(');')


### PR DESCRIPTION
With this it's possible to combine lights that cast no shadows (cast_shadow=false/"Shadow" toggled off on Blender's UI) with shadow casting lights, otherwise previously broken because of the hardcoded nature of `ReceiveShadows` when invoking `sampleLight()`.

This was done by exposing cast_shadows to the shaders through pointLightData.

Note: 
Because there was not enough space I had to increment the requirement for lights from 2 to 3 vec4 in the lightsArray, so this solution leaves 3 unused spaces per light (for now). I've tried to change lightsArray to be an array of vec3 to avoid wasting space, but after testing I've noticed it doesn't play nice on Windows with Direct3D, so I had to revert it to vec4.

Tested with Krom Linux / Krom Windows, with point lights and spot lights with deferred and forward, 
Test file: [cast_shadow_test.blend.zip](https://github.com/armory3d/armory/files/6138318/cast_shadow_test.blend.zip)

Depends on this https://github.com/armory3d/iron/pull/117

### before (points):

![before_points](https://user-images.githubusercontent.com/42382648/111094385-f241b080-8519-11eb-8622-4ac706ac6a6f.png)

### after (points) :

![after_points](https://user-images.githubusercontent.com/42382648/111094423-038abd00-851a-11eb-8f06-627d7038d494.png)

### before (spots):

![before_spots](https://user-images.githubusercontent.com/42382648/111094451-18675080-851a-11eb-8a36-59e7a924cc13.png)

### after (spots):

![after_spots](https://user-images.githubusercontent.com/42382648/111094461-1e5d3180-851a-11eb-95f4-1700e7538bef.png)

