### PR TITLE
Modified UI for collision filter props_collision_filter_mask

### DIFF
--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -280,6 +280,12 @@ def init_properties():
     bpy.types.Object.arm_rb_trigger = BoolProperty(name="Trigger", description="Disable contact response", default=False)
     bpy.types.Object.arm_rb_deactivation_time = FloatProperty(name="Deactivation Time", description="Delay putting rigid body into sleep", default=0.0)
     bpy.types.Object.arm_rb_ccd = BoolProperty(name="Continuous Collision Detection", description="Improve collision for fast moving objects", default=False)
+    bpy.types.Object.arm_rb_collision_filter_mask = bpy.props.BoolVectorProperty(
+            name="Collision Collections Filter Mask",
+            description="Collision collections rigid body interacts with",
+            default=(True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False),
+            size=20,
+            subtype='LAYER')
     bpy.types.Object.arm_animation_enabled = BoolProperty(name="Animation", description="Enable skinning & timeline animation", default=True)
     bpy.types.Object.arm_tilesheet = StringProperty(name="Tilesheet", description="Set tilesheet animation", default='')
     bpy.types.Object.arm_tilesheet_action = StringProperty(name="Tilesheet Action", description="Set startup action", default='')

--- a/blender/arm/props_collision_filter_mask.py
+++ b/blender/arm/props_collision_filter_mask.py
@@ -3,29 +3,28 @@ from bpy.props import *
 from bpy.types import Panel
 
 class ARM_PT_RbCollisionFilterMaskPanel(bpy.types.Panel):
-    bl_label = "Armory Collision Filter Mask"
+    bl_label = "Collections Filter Mask"
     bl_space_type = "PROPERTIES"
     bl_region_type = "WINDOW"
     bl_context = "physics"
-    
+    bl_parent_id = "ARM_PT_PhysicsPropsPanel"
+
+    @classmethod
+    def poll(self, context):
+        obj = context.object
+        if obj is None:
+            return False
+        return obj.rigid_body is not None
 
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
-        obj = bpy.context.object
-        if obj == None:
-            return
-        if obj.rigid_body != None:
-            layout.prop(obj, 'arm_rb_collision_filter_mask')
+        obj = context.object
+        layout.prop(obj, 'arm_rb_collision_filter_mask', text="", expand=True)
 
 def register():
     bpy.utils.register_class(ARM_PT_RbCollisionFilterMaskPanel)
-    bpy.types.Object.arm_rb_collision_filter_mask = bpy.props.BoolVectorProperty(
-        name="Collision Filter Mask",
-        default=(True, False, False,False,False,False, False, False,False,False,False, False, False,False,False,False, False, False,False,False),
-        size=20,
-        subtype='LAYER')
 
 def unregister():
     bpy.utils.unregister_class(ARM_PT_RbCollisionFilterMaskPanel)


### PR DESCRIPTION
* Moved the collision filter mask panel under armory props to keep UI
more tidy.

![image](https://user-images.githubusercontent.com/42382648/111551952-15f63800-8760-11eb-830a-d034c65efb80.png)

* Moved the `arm_rb_collision_filter_mask` property out of the
props_collision_filter_mask to be with the rest of the properties.

* Changed name and description of collision filter mask to be more
consistent with the existing rigid body UI.