### PR TITLE
Expose the exported rigid body type to the UI to make rb less confusing

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2308,6 +2308,10 @@ class ArmoryExporter:
 
         return instanced_type, instanced_data
 
+    @staticmethod
+    def rigid_body_static(rb):
+        return (not rb.enabled and not rb.kinematic) or (rb.type == 'PASSIVE' and not rb.kinematic)
+
     def post_export_object(self, bobject: bpy.types.Object, o, type):
         # Export traits
         self.export_traits(bobject, o)
@@ -2334,7 +2338,7 @@ class ArmoryExporter:
             elif rb.collision_shape == 'CAPSULE':
                 shape = 6
             body_mass = rb.mass
-            is_static = (not rb.enabled and not rb.kinematic) or (rb.type == 'PASSIVE' and not rb.kinematic)
+            is_static = self.rigid_body_static(rb)
             if is_static:
                 body_mass = 0
             x = {}

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -22,6 +22,8 @@ from arm.lightmapper.utility import icon
 from arm.lightmapper.properties.denoiser import oidn, optix
 import importlib
 
+from arm.exporter import ArmoryExporter
+
 # Menu in object region
 class ARM_PT_ObjectPropsPanel(bpy.types.Panel):
     bl_label = "Armory Props"
@@ -180,7 +182,19 @@ class ARM_PT_PhysicsPropsPanel(bpy.types.Panel):
         if obj == None:
             return
 
-        if obj.rigid_body != None:
+        rb = obj.rigid_body
+        if rb is not None:
+            col = layout.column()
+            row = col.row()
+            row.alignment = 'RIGHT'
+
+            rb_type = 'Dynamic'
+            if ArmoryExporter.rigid_body_static(rb):
+                rb_type = 'Static'
+            if rb.kinematic:
+                rb_type = 'Kinematic'
+            row.label(text=(f'Rigid Body Export Type: {rb_type}'), icon='AUTO')
+
             layout.prop(obj, 'arm_rb_linear_factor')
             layout.prop(obj, 'arm_rb_angular_factor')
             layout.prop(obj, 'arm_rb_trigger')


### PR DESCRIPTION
Defining the final type of rigid body is not as straight forward in the UI because of the many options that can change it, so I thought it could be exposed in the UI to make it more clear:

![ui](https://user-images.githubusercontent.com/42382648/111720522-cb96b900-883c-11eb-97cf-83906988a286.gif "look at the bottom")
