### PR TITLE
Show error in the UI for tangent calculation error instead of just crashing to blender UI

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -32,6 +32,7 @@ import arm.material.mat_batch as mat_batch
 import arm.utils
 import arm.profiler
 
+import arm.log as log
 
 @unique
 class NodeType(Enum):
@@ -1157,7 +1158,16 @@ class ArmoryExporter:
             else:
                 invscale_tex = 1 * 32767
             if has_tang:
-                exportMesh.calc_tangents(uvmap=lay0.name)
+                try:
+                    exportMesh.calc_tangents(uvmap=lay0.name)
+                except Exception as e:
+                    if hasattr(e, 'message'):
+                        log.error(e.message)
+                    else:
+                        # Assume it was caused because of encountering n-gons
+                        log.error(f"""object {bobject.name} contains n-gons in its mesh, so it's impossible to compute tanget space for normal mapping.
+Make sure the mesh only has tris/quads.""")
+
                 tangdata = np.empty(num_verts * 3, dtype='<f4')
         if has_col:
             cdata = np.empty(num_verts * 3, dtype='<f4')

--- a/blender/arm/log.py
+++ b/blender/arm/log.py
@@ -31,11 +31,13 @@ info_text = ''
 num_warnings = 0
 num_errors = 0
 
-def clear(clear_warnings=False):
-    global info_text, num_warnings
+def clear(clear_warnings=False, clear_errors=False):
+    global info_text, num_warnings, num_errors
     info_text = ''
     if clear_warnings:
         num_warnings = 0
+    if clear_errors:
+        num_errors = 0
 
 def format_text(text):
     return (text[:80] + '..') if len(text) > 80 else text # Limit str size

--- a/blender/arm/log.py
+++ b/blender/arm/log.py
@@ -29,6 +29,7 @@ else:
 
 info_text = ''
 num_warnings = 0
+num_errors = 0
 
 def clear(clear_warnings=False):
     global info_text, num_warnings
@@ -62,4 +63,6 @@ def warn(text):
     print_warn(text)
 
 def error(text):
+    global num_errors
+    num_errors += 1
     log('ERROR: ' + text, ERROR)

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -338,7 +338,7 @@ def build(target, is_play=False, is_publish=False, is_export=False):
     if arm.utils.get_save_on_build():
         bpy.ops.wm.save_mainfile()
 
-    log.clear(clear_warnings=True)
+    log.clear(clear_warnings=True, clear_errors=True)
 
     # Set camera in active scene
     active_scene = arm.utils.get_active_scene()

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -560,7 +560,19 @@ class ARM_PT_ArmoryPlayerPanel(bpy.types.Panel):
             box = layout.box()
             # Less spacing between lines
             col = box.column(align=True)
-            col.label(text=f'{log.num_warnings} warnings occurred during compilation!', icon='ERROR')
+            warnings = 'warnings' if log.num_warnings > 1 else 'warning'
+            col.label(text=f'{log.num_warnings} {warnings} occurred during compilation!', icon='ERROR')
+            # Blank icon to achieve the same indentation as the line before
+            # prevent showing "open console" twice:
+            if log.num_errors == 0:
+                col.label(text='Please open the console to get more information.', icon='BLANK1')
+
+        if log.num_errors > 0:
+            box = layout.box()
+            # Less spacing between lines
+            col = box.column(align=True)
+            errors = 'errors' if log.num_errors > 1 else 'error'
+            col.label(text=f'{log.num_errors} {errors} occurred during compilation!', icon='CANCEL')
             # Blank icon to achieve the same indentation as the line before
             col.label(text='Please open the console to get more information.', icon='BLANK1')
 


### PR DESCRIPTION
Log and show and error instead of just letting the error pop up in the blender UI, like this: 
![image](https://user-images.githubusercontent.com/42382648/111797558-0a158d80-88a8-11eb-80a2-8a2540ce3c3a.png)

Instead show this

![image](https://user-images.githubusercontent.com/42382648/111797641-18fc4000-88a8-11eb-9609-8d31ed936f9c.png)

and this:

![image](https://user-images.githubusercontent.com/42382648/111797690-25809880-88a8-11eb-9280-b16e00d15d61.png)

Ideally an error should probably stop the building, but I'm not sure if there is a system in place to do that... for now showing a better error would do 

Related: https://github.com/armory3d/armory/issues/2136, https://github.com/armory3d/armory/issues/1411
