### PR TITLE
[Blender 2.9] Fix material translucency in Blender 2.9+

### DIFF
--- a/blender/arm/material/mat_utils.py
+++ b/blender/arm/material/mat_utils.py
@@ -73,7 +73,8 @@ def is_transluc_type(node):
        node.type == 'BSDF_TRANSPARENT' or \
        node.type == 'BSDF_TRANSLUCENT' or \
        (node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR') and (node.inputs[1].is_linked or node.inputs[1].default_value != 1.0)) or \
-       (node.type == 'BSDF_PRINCIPLED' and len(node.inputs) > 20 and (node.inputs[18].is_linked or node.inputs[18].default_value != 1.0)):
+       (node.type == 'BSDF_PRINCIPLED' and len(node.inputs) > 20 and (node.inputs[18].is_linked or node.inputs[18].default_value != 1.0)) or \
+       (node.type == 'BSDF_PRINCIPLED' and len(node.inputs) > 21 and (node.inputs[19].is_linked or node.inputs[19].default_value != 1.0)):
        return True
     return False
 


### PR DESCRIPTION
The extra input node in the principled for 2.9+ is now taken into consideration.

Before:
![image](https://user-images.githubusercontent.com/5429817/112047255-58978600-8b4d-11eb-9436-a71ed8b7eb73.png)

Now:
![image](https://user-images.githubusercontent.com/5429817/112047263-5b927680-8b4d-11eb-84a5-9e0aedae11bb.png)
