### PR TITLE
Replace ' and " characters in asset names

### DIFF
--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -576,7 +576,7 @@ def safesrc(s):
 def safestr(s: str) -> str:
     """Outputs a string where special characters have been replaced with
     '_', which can be safely used in file and path names."""
-    for c in r'[]/\;,><&*:%=+@!#^()|?^':
+    for c in r'''[]/\;,><&*:%=+@!#^()|?^'"''':
         s = s.replace(c, '_')
     return ''.join([i if ord(i) < 128 else '_' for i in s])
 


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2143.

I also think there was a similar issue somewhere that could be fixed by this (I had the changes already stashed in my local repo but forgot about it...) but I can't find it anymore/am not sure if it existed at all. If anyone knows, please let me know.