### PR TITLE
Fix case where sun shadows are not working if there are other type of lights present 

### DIFF
--- a/Shaders/deferred_light/deferred_light.json
+++ b/Shaders/deferred_light/deferred_light.json
@@ -99,7 +99,7 @@
 				},
 				{
 					"name": "LWVP",
-					"link": "_biasLightWorldViewProjectionMatrix",
+					"link": "_biasLightWorldViewProjectionMatrixSun",
 					"ifndef": ["_CSM"],
 					"ifdef": ["_Sun", "_ShadowMap"]
 				},

--- a/Shaders/deferred_light_mobile/deferred_light_mobile.json
+++ b/Shaders/deferred_light_mobile/deferred_light_mobile.json
@@ -88,7 +88,7 @@
 				},
 				{
 					"name": "LWVP",
-					"link": "_biasLightWorldViewProjectionMatrix",
+					"link": "_biasLightWorldViewProjectionMatrixSun",
 					"ifndef": ["_CSM"],
 					"ifdef": ["_Sun", "_ShadowMap"]
 				},

--- a/Shaders/volumetric_light/volumetric_light.json
+++ b/Shaders/volumetric_light/volumetric_light.json
@@ -63,7 +63,7 @@
 				},
 				{
 					"name": "LWVP",
-					"link": "_biasLightWorldViewProjectionMatrix",
+					"link": "_biasLightWorldViewProjectionMatrixSun",
 					"ifndef": ["_CSM"],
 					"ifdef": ["_Sun", "_ShadowMap"]
 				},

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -372,7 +372,7 @@ def make_forward_mobile(con_mesh):
         frag.write('float sdotNL = max(dot(n, sunDir), 0.0);')
         if is_shadows:
             vert.add_out('vec4 lightPosition')
-            vert.add_uniform('mat4 LWVP', '_biasLightWorldViewProjectionMatrix')
+            vert.add_uniform('mat4 LWVP', '_biasLightWorldViewProjectionMatrixSun')
             vert.write('lightPosition = LWVP * spos;')
             frag.add_uniform('bool receiveShadow')
             frag.add_uniform(f'sampler2DShadow {shadowmap_sun}')
@@ -694,7 +694,7 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
                         vert.write('lightPosition = LVP * vec4(wposition, 1.0);')
                     else:
                         vert.add_out('vec4 lightPosition')
-                        vert.add_uniform('mat4 LWVP', '_biasLightWorldViewProjectionMatrix')
+                        vert.add_uniform('mat4 LWVP', '_biasLightWorldViewProjectionMatrixSun')
                         vert.write('lightPosition = LWVP * spos;')
                 frag.write('vec3 lPos = lightPosition.xyz / lightPosition.w;')
                 frag.write('const vec2 smSize = shadowmapSize;')


### PR DESCRIPTION
user `Lytz1` over the Armory discord server found the issue on this test file: [AtlasShadowTest.zip](https://github.com/armory3d/armory/files/6224434/AtlasShadowTest.zip), which upon investigation it seems the problem is that the uniform variables that the deferred light shader relies on for computing the sun shadows (`LWVP` and `casData`) are computed with the incorrect light (the point light in the test file).

Before:

![image](https://user-images.githubusercontent.com/42382648/112899756-ee389580-90b8-11eb-856e-731e5d53808b.png "Sun shadows are completely wrong when computing so they don't show up")

After:

![image](https://user-images.githubusercontent.com/42382648/112899838-07d9dd00-90b9-11eb-859d-b8b78efcf784.png)



This occurs because when generating those uniforms, `Uniform` expects you to set up the `light` parameter of `renderpath` correctly. So it can occur a case where the wrong light ends up picked instead of the sun when computing the uniform data for the `deferred light` shader.  

Solution: So the solution was to simply remove the need for the user input and instead simply loop over lights to find the sun, like pretty much all other uniforms that use lights do. Obviously to keep the case where the user (that uses iron uniforms) actually needs to compute it after some light, the `_biasLightWorldViewProjectionMatrix` uniform was separated into two, one that keeps the original logic (before atlas) and one for sun specifically.

Tested on Krom Linux, with and without cascades, forward and deferred.

Depends on https://github.com/armory3d/iron/pull/120.
