### PR TITLE
[Blender 2.9] Nishita sky model & (ir)radiance support for all world shaders

### DIFF
--- a/Shaders/std/sky.glsl
+++ b/Shaders/std/sky.glsl
@@ -3,6 +3,7 @@
  * Nishita model is based on https://github.com/wwwtyro/glsl-atmosphere (Unlicense License)
  * Changes to the original implementation:
  *  - r and pSun parameters of nishita_atmosphere() are already normalized
+ *  - Some original parameters of nishita_atmosphere() are replaced with pre-defined values
  */
 
 #ifndef _SKY_GLSL_
@@ -12,6 +13,18 @@
 
 #define nishita_iSteps 16
 #define nishita_jSteps 8
+
+// The values here are taken from Cycles code if they
+// exist there, otherwise they are taken from the example
+// in the glsl-atmosphere repo
+#define nishita_sun_intensity 22.0
+#define nishita_atmo_radius 6420e3
+#define nishita_rayleigh_scale 8e3
+#define nishita_rayleigh_coeff vec3(5.5e-6, 13.0e-6, 22.4e-6)
+#define nishita_mie_scale 1.2e3
+#define nishita_mie_coeff 2e-5
+#define nishita_mie_dir 0.76 // Aerosols anisotropy ("direction")
+#define nishita_mie_dir_sq 0.5776 // Squared aerosols anisotropy
 
 /* ray-sphere intersection that assumes
  * the sphere is centered at the origin.
@@ -29,11 +42,15 @@ vec2 nishita_rsi(const vec3 r0, const vec3 rd, const float sr) {
 	);
 }
 
-vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const float iSun, const float rPlanet, const float rAtmos, const vec3 kRlh, const float kMie, const float shRlh, const float shMie, const float g) {
-	// r and pSun must be already normalized!
-
+/*
+ * r: normalized ray direction
+ * r0: ray origin
+ * pSun: normalized sun direction
+ * rPlanet: planet radius
+ */
+vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const float rPlanet) {
 	// Calculate the step size of the primary ray.
-	vec2 p = nishita_rsi(r0, r, rAtmos);
+	vec2 p = nishita_rsi(r0, r, nishita_atmo_radius);
 	if (p.x > p.y) return vec3(0,0,0);
 	p.y = min(p.y, nishita_rsi(r0, r, rPlanet).x);
 	float iStepSize = (p.y - p.x) / float(nishita_iSteps);
@@ -52,9 +69,8 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 	// Calculate the Rayleigh and Mie phases.
 	float mu = dot(r, pSun);
 	float mumu = mu * mu;
-	float gg = g * g;
 	float pRlh = 3.0 / (16.0 * PI) * (1.0 + mumu);
-	float pMie = 3.0 / (8.0 * PI) * ((1.0 - gg) * (mumu + 1.0)) / (pow(1.0 + gg - 2.0 * mu * g, 1.5) * (2.0 + gg));
+	float pMie = 3.0 / (8.0 * PI) * ((1.0 - nishita_mie_dir_sq) * (mumu + 1.0)) / (pow(1.0 + nishita_mie_dir_sq - 2.0 * mu * nishita_mie_dir, 1.5) * (2.0 + nishita_mie_dir_sq));
 
 	// Sample the primary ray.
 	for (int i = 0; i < nishita_iSteps; i++) {
@@ -66,15 +82,15 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 		float iHeight = length(iPos) - rPlanet;
 
 		// Calculate the optical depth of the Rayleigh and Mie scattering for this step.
-		float odStepRlh = exp(-iHeight / shRlh) * iStepSize;
-		float odStepMie = exp(-iHeight / shMie) * iStepSize;
+		float odStepRlh = exp(-iHeight / nishita_rayleigh_scale) * iStepSize;
+		float odStepMie = exp(-iHeight / nishita_mie_scale) * iStepSize;
 
 		// Accumulate optical depth.
 		iOdRlh += odStepRlh;
 		iOdMie += odStepMie;
 
 		// Calculate the step size of the secondary ray.
-		float jStepSize = nishita_rsi(iPos, pSun, rAtmos).y / float(nishita_jSteps);
+		float jStepSize = nishita_rsi(iPos, pSun, nishita_atmo_radius).y / float(nishita_jSteps);
 
 		// Initialize the secondary ray time.
 		float jTime = 0.0;
@@ -93,15 +109,15 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 			float jHeight = length(jPos) - rPlanet;
 
 			// Accumulate the optical depth.
-			jOdRlh += exp(-jHeight / shRlh) * jStepSize;
-			jOdMie += exp(-jHeight / shMie) * jStepSize;
+			jOdRlh += exp(-jHeight / nishita_rayleigh_scale) * jStepSize;
+			jOdMie += exp(-jHeight / nishita_mie_scale) * jStepSize;
 
 			// Increment the secondary ray time.
 			jTime += jStepSize;
 		}
 
 		// Calculate attenuation.
-		vec3 attn = exp(-(kMie * (iOdMie + jOdMie) + kRlh * (iOdRlh + jOdRlh)));
+		vec3 attn = exp(-(nishita_mie_coeff * (iOdMie + jOdMie) + nishita_rayleigh_coeff * (iOdRlh + jOdRlh)));
 
 		// Accumulate scattering.
 		totalRlh += odStepRlh * attn;
@@ -112,7 +128,7 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 	}
 
 	// Calculate and return the final color.
-	return iSun * (pRlh * kRlh * totalRlh + pMie * kMie * totalMie);
+	return nishita_sun_intensity * (pRlh * nishita_rayleigh_coeff * totalRlh + pMie * nishita_mie_coeff * totalMie);
 }
 
 #endif

--- a/Shaders/std/sky.glsl
+++ b/Shaders/std/sky.glsl
@@ -1,0 +1,118 @@
+/* Various sky functions
+ *
+ * Nishita model is based on https://github.com/wwwtyro/glsl-atmosphere (Unlicense License)
+ * Changes to the original implementation:
+ *  - r and pSun parameters of nishita_atmosphere() are already normalized
+ */
+
+#ifndef _SKY_GLSL_
+#define _SKY_GLSL_
+
+#define PI 3.141592
+
+#define nishita_iSteps 16
+#define nishita_jSteps 8
+
+/* ray-sphere intersection that assumes
+ * the sphere is centered at the origin.
+ * No intersection when result.x > result.y */
+vec2 nishita_rsi(const vec3 r0, const vec3 rd, const float sr) {
+	float a = dot(rd, rd);
+	float b = 2.0 * dot(rd, r0);
+	float c = dot(r0, r0) - (sr * sr);
+	float d = (b*b) - 4.0*a*c;
+
+	if (d < 0.0) return vec2(1e5,-1e5);
+	return vec2(
+		(-b - sqrt(d))/(2.0*a),
+		(-b + sqrt(d))/(2.0*a)
+	);
+}
+
+vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const float iSun, const float rPlanet, const float rAtmos, const vec3 kRlh, const float kMie, const float shRlh, const float shMie, const float g) {
+	// r and pSun must be already normalized!
+
+	// Calculate the step size of the primary ray.
+	vec2 p = nishita_rsi(r0, r, rAtmos);
+	if (p.x > p.y) return vec3(0,0,0);
+	p.y = min(p.y, nishita_rsi(r0, r, rPlanet).x);
+	float iStepSize = (p.y - p.x) / float(nishita_iSteps);
+
+	// Initialize the primary ray time.
+	float iTime = 0.0;
+
+	// Initialize accumulators for Rayleigh and Mie scattering.
+	vec3 totalRlh = vec3(0,0,0);
+	vec3 totalMie = vec3(0,0,0);
+
+	// Initialize optical depth accumulators for the primary ray.
+	float iOdRlh = 0.0;
+	float iOdMie = 0.0;
+
+	// Calculate the Rayleigh and Mie phases.
+	float mu = dot(r, pSun);
+	float mumu = mu * mu;
+	float gg = g * g;
+	float pRlh = 3.0 / (16.0 * PI) * (1.0 + mumu);
+	float pMie = 3.0 / (8.0 * PI) * ((1.0 - gg) * (mumu + 1.0)) / (pow(1.0 + gg - 2.0 * mu * g, 1.5) * (2.0 + gg));
+
+	// Sample the primary ray.
+	for (int i = 0; i < nishita_iSteps; i++) {
+
+		// Calculate the primary ray sample position.
+		vec3 iPos = r0 + r * (iTime + iStepSize * 0.5);
+
+		// Calculate the height of the sample.
+		float iHeight = length(iPos) - rPlanet;
+
+		// Calculate the optical depth of the Rayleigh and Mie scattering for this step.
+		float odStepRlh = exp(-iHeight / shRlh) * iStepSize;
+		float odStepMie = exp(-iHeight / shMie) * iStepSize;
+
+		// Accumulate optical depth.
+		iOdRlh += odStepRlh;
+		iOdMie += odStepMie;
+
+		// Calculate the step size of the secondary ray.
+		float jStepSize = nishita_rsi(iPos, pSun, rAtmos).y / float(nishita_jSteps);
+
+		// Initialize the secondary ray time.
+		float jTime = 0.0;
+
+		// Initialize optical depth accumulators for the secondary ray.
+		float jOdRlh = 0.0;
+		float jOdMie = 0.0;
+
+		// Sample the secondary ray.
+		for (int j = 0; j < nishita_jSteps; j++) {
+
+			// Calculate the secondary ray sample position.
+			vec3 jPos = iPos + pSun * (jTime + jStepSize * 0.5);
+
+			// Calculate the height of the sample.
+			float jHeight = length(jPos) - rPlanet;
+
+			// Accumulate the optical depth.
+			jOdRlh += exp(-jHeight / shRlh) * jStepSize;
+			jOdMie += exp(-jHeight / shMie) * jStepSize;
+
+			// Increment the secondary ray time.
+			jTime += jStepSize;
+		}
+
+		// Calculate attenuation.
+		vec3 attn = exp(-(kMie * (iOdMie + jOdMie) + kRlh * (iOdRlh + jOdRlh)));
+
+		// Accumulate scattering.
+		totalRlh += odStepRlh * attn;
+		totalMie += odStepMie * attn;
+
+		// Increment the primary ray time.
+		iTime += iStepSize;
+	}
+
+	// Calculate and return the final color.
+	return iSun * (pRlh * kRlh * totalRlh + pMie * kMie * totalMie);
+}
+
+#endif

--- a/Shaders/std/sky.glsl
+++ b/Shaders/std/sky.glsl
@@ -66,25 +66,15 @@ vec3 nishita_lookupLUT(const float height, const float sunTheta) {
 	return textureLod(nishitaLUT, coords, 0.0).rgb;
 }
 
-/* Approximates the density of ozone for a given sample height. Values taken from Cycles code. */
-float nishita_density_ozone(const float height) {
-	return (height < 10000.0 || height >= 40000.0) ? 0.0 : (height < 25000.0 ? (height - 10000.0) / 15000.0 : -((height - 40000.0) / 15000.0));
-}
-
-/* ray-sphere intersection that assumes
- * the sphere is centered at the origin.
- * No intersection when result.x > result.y */
+/* See raySphereIntersection() in armory/Sources/renderpath/Nishita.hx */
 vec2 nishita_rsi(const vec3 r0, const vec3 rd, const float sr) {
 	float a = dot(rd, rd);
 	float b = 2.0 * dot(rd, r0);
 	float c = dot(r0, r0) - (sr * sr);
 	float d = (b*b) - 4.0*a*c;
 
-	if (d < 0.0) return vec2(1e5,-1e5);
-	return vec2(
-		(-b - sqrt(d))/(2.0*a),
-		(-b + sqrt(d))/(2.0*a)
-	);
+	// If d < 0.0 the ray does not intersect the sphere
+	return (d < 0.0) ? vec2(1e5,-1e5) : vec2((-b - sqrt(d))/(2.0*a), (-b + sqrt(d))/(2.0*a));
 }
 
 /*
@@ -94,43 +84,41 @@ vec2 nishita_rsi(const vec3 r0, const vec3 rd, const float sr) {
  * rPlanet: planet radius
  */
 vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const float rPlanet) {
-	// Calculate the step size of the primary ray.
+	// Calculate the step size of the primary ray
 	vec2 p = nishita_rsi(r0, r, nishita_atmo_radius);
-	if (p.x > p.y) return vec3(0,0,0);
+	if (p.x > p.y) return vec3(0.0);
 	p.y = min(p.y, nishita_rsi(r0, r, rPlanet).x);
 	float iStepSize = (p.y - p.x) / float(nishita_iSteps);
 
-	// Initialize the primary ray time.
+	// Primary ray time
 	float iTime = 0.0;
 
-	// Initialize accumulators for Rayleigh and Mie scattering.
+	// Accumulators for Rayleigh and Mie scattering.
 	vec3 totalRlh = vec3(0,0,0);
 	vec3 totalMie = vec3(0,0,0);
 
-	// Initialize optical depth accumulators for the primary ray.
+	// Optical depth accumulators for the primary ray
 	float iOdRlh = 0.0;
 	float iOdMie = 0.0;
 
-	// Calculate the Rayleigh and Mie phases.
+	// Calculate the Rayleigh and Mie phases
 	float mu = dot(r, pSun);
 	float mumu = mu * mu;
 	float pRlh = 3.0 / (16.0 * PI) * (1.0 + mumu);
 	float pMie = 3.0 / (8.0 * PI) * ((1.0 - nishita_mie_dir_sq) * (mumu + 1.0)) / (pow(1.0 + nishita_mie_dir_sq - 2.0 * mu * nishita_mie_dir, 1.5) * (2.0 + nishita_mie_dir_sq));
 
-	// Sample the primary ray.
+	// Sample the primary ray
 	for (int i = 0; i < nishita_iSteps; i++) {
 
-		// Calculate the primary ray sample position.
+		// Calculate the primary ray sample position and height
 		vec3 iPos = r0 + r * (iTime + iStepSize * 0.5);
-
-		// Calculate the height of the sample.
 		float iHeight = length(iPos) - rPlanet;
 
 		// Calculate the optical depth of the Rayleigh and Mie scattering for this step
 		float odStepRlh = exp(-iHeight / nishita_rayleigh_scale) * nishitaDensity.x * iStepSize;
 		float odStepMie = exp(-iHeight / nishita_mie_scale) * nishitaDensity.y * iStepSize;
 
-		// Accumulate optical depth.
+		// Accumulate optical depth
 		iOdRlh += odStepRlh;
 		iOdMie += odStepMie;
 
@@ -142,22 +130,20 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 		// Apply dithering to reduce visible banding
 		jODepth += mix(-1000, 1000, random(r.xy));
 
-		// Calculate attenuation.
+		// Calculate attenuation
 		vec3 attn = exp(-(
 			nishita_mie_coeff * (iOdMie + jODepth.y)
 			+ (nishita_rayleigh_coeff) * (iOdRlh + jODepth.x)
 			+ nishita_ozone_coeff * jODepth.z
 		));
 
-		// Accumulate scattering.
+		// Accumulate scattering
 		totalRlh += odStepRlh * attn;
 		totalMie += odStepMie * attn;
 
-		// Increment the primary ray time.
 		iTime += iStepSize;
 	}
 
-	// Calculate and return the final color.
 	return nishita_sun_intensity * (pRlh * nishita_rayleigh_coeff * totalRlh + pMie * nishita_mie_coeff * totalMie);
 }
 
@@ -166,7 +152,7 @@ vec3 sun_disk(const vec3 n, const vec3 light_dir, const float disk_size, const f
 	float dist = distance(n, light_dir) / disk_size;
 
 	// Darken the edges of the sun
-	// [Hill: 28, 60] (code from [Nec96])
+	// [Hill: 28, 60] (according to [Nec96])
 	float invDist = 1.0 - dist;
 	float mu = sqrt(invDist * invDist);
 	vec3 limb_darkening = 1.0 - (1.0 - pow(vec3(mu), sun_limb_darkening_col));

--- a/Shaders/std/sky.glsl
+++ b/Shaders/std/sky.glsl
@@ -21,6 +21,7 @@
 #define _SKY_GLSL_
 
 uniform sampler2D nishitaLUT;
+uniform vec2 nishitaDensity;
 
 #ifndef PI
 	#define PI 3.141592
@@ -91,9 +92,8 @@ vec2 nishita_rsi(const vec3 r0, const vec3 rd, const float sr) {
  * r0: ray origin
  * pSun: normalized sun direction
  * rPlanet: planet radius
- * density: (air density, dust density, ozone density)
  */
-vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const float rPlanet, const vec3 density) {
+vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const float rPlanet) {
 	// Calculate the step size of the primary ray.
 	vec2 p = nishita_rsi(r0, r, nishita_atmo_radius);
 	if (p.x > p.y) return vec3(0,0,0);
@@ -127,8 +127,8 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 		float iHeight = length(iPos) - rPlanet;
 
 		// Calculate the optical depth of the Rayleigh and Mie scattering for this step
-		float odStepRlh = exp(-iHeight / nishita_rayleigh_scale) * density.x * iStepSize;
-		float odStepMie = exp(-iHeight / nishita_mie_scale) * density.y * iStepSize;
+		float odStepRlh = exp(-iHeight / nishita_rayleigh_scale) * nishitaDensity.x * iStepSize;
+		float odStepMie = exp(-iHeight / nishita_mie_scale) * nishitaDensity.y * iStepSize;
 
 		// Accumulate optical depth.
 		iOdRlh += odStepRlh;

--- a/Sources/armory/math/Helper.hx
+++ b/Sources/armory/math/Helper.hx
@@ -72,4 +72,13 @@ class Helper {
 		if (value <= leftMin) return rightMin;
 		return map(value, leftMin, leftMax, rightMin, rightMax);
 	}
+
+	/**
+		Return the sign of the given value represented as `1.0` (positive value)
+		or `-1.0` (negative value). The sign of `0` is `0`.
+	**/
+	public static inline function sign(value: Float): Float {
+		if (value == 0) return 0;
+		return (value < 0) ? -1.0 : 1.0;
+	}
 }

--- a/Sources/armory/object/Uniforms.hx
+++ b/Sources/armory/object/Uniforms.hx
@@ -177,9 +177,9 @@ class Uniforms {
 		var v: Vec4 = null;
 		switch (link) {
 			case "_nishitaDensity": {
-				v = iron.object.Uniforms.helpVec;
 				var w = Scene.active.world;
 				if (w != null) {
+					v = iron.object.Uniforms.helpVec;
 					// We only need Rayleigh and Mie density in the sky shader -> Vec2
 					v.x = w.raw.nishita_density[0];
 					v.y = w.raw.nishita_density[1];

--- a/Sources/armory/object/Uniforms.hx
+++ b/Sources/armory/object/Uniforms.hx
@@ -11,14 +11,14 @@ class Uniforms {
 
 	public static function register() {
 		iron.object.Uniforms.externalTextureLinks = [textureLink];
-		iron.object.Uniforms.externalVec2Links = [];
+		iron.object.Uniforms.externalVec2Links = [vec2Link];
 		iron.object.Uniforms.externalVec3Links = [vec3Link];
 		iron.object.Uniforms.externalVec4Links = [];
 		iron.object.Uniforms.externalFloatLinks = [floatLink];
 		iron.object.Uniforms.externalIntLinks = [];
 	}
 
-	public static function textureLink(object: Object, mat: MaterialData, link: String): kha.Image {
+	public static function textureLink(object: Object, mat: MaterialData, link: String): Null<kha.Image> {
 		switch (link) {
 			case "_nishitaLUT": {
 				if (armory.renderpath.Nishita.data == null) armory.renderpath.Nishita.recompute(Scene.active.world);
@@ -40,7 +40,7 @@ class Uniforms {
 		return target != null ? target.image : null;
 	}
 
-	public static function vec3Link(object: Object, mat: MaterialData, link: String): iron.math.Vec4 {
+	public static function vec3Link(object: Object, mat: MaterialData, link: String): Null<iron.math.Vec4> {
 		var v: Vec4 = null;
 		switch (link) {
 			#if arm_hosek
@@ -168,6 +168,23 @@ class Uniforms {
 				v.set(Math.floor(v.x / f) * f, Math.floor(v.y / f) * f, Math.floor(v.z / f) * f);
 			}
 			#end
+		}
+
+		return v;
+	}
+
+	public static function vec2Link(object: Object, mat: MaterialData, link: String): Null<iron.math.Vec4> {
+		var v: Vec4 = null;
+		switch (link) {
+			case "_nishitaDensity": {
+				v = iron.object.Uniforms.helpVec;
+				var w = Scene.active.world;
+				if (w != null) {
+					// We only need Rayleigh and Mie density in the sky shader -> Vec2
+					v.x = w.raw.nishita_density[0];
+					v.y = w.raw.nishita_density[1];
+				}
+			}
 		}
 
 		return v;

--- a/Sources/armory/object/Uniforms.hx
+++ b/Sources/armory/object/Uniforms.hx
@@ -19,8 +19,12 @@ class Uniforms {
 	}
 
 	public static function textureLink(object: Object, mat: MaterialData, link: String): kha.Image {
+		if (link == "_nishitaLUT") {
+			if (armory.renderpath.Nishita.data == null) armory.renderpath.Nishita.recompute(Scene.active.world);
+			return armory.renderpath.Nishita.data.optDepthLUT;
+		}
 		#if arm_ltc
-		if (link == "_ltcMat") {
+		else if (link == "_ltcMat") {
 			if (armory.data.ConstData.ltcMatTex == null) armory.data.ConstData.initLTC();
 			return armory.data.ConstData.ltcMatTex;
 		}

--- a/Sources/armory/object/Uniforms.hx
+++ b/Sources/armory/object/Uniforms.hx
@@ -19,172 +19,179 @@ class Uniforms {
 	}
 
 	public static function textureLink(object: Object, mat: MaterialData, link: String): kha.Image {
-		if (link == "_nishitaLUT") {
-			if (armory.renderpath.Nishita.data == null) armory.renderpath.Nishita.recompute(Scene.active.world);
-			return armory.renderpath.Nishita.data.lut;
+		switch (link) {
+			case "_nishitaLUT": {
+				if (armory.renderpath.Nishita.data == null) armory.renderpath.Nishita.recompute(Scene.active.world);
+				return armory.renderpath.Nishita.data.lut;
+			}
+			#if arm_ltc
+			case "_ltcMat": {
+				if (armory.data.ConstData.ltcMatTex == null) armory.data.ConstData.initLTC();
+				return armory.data.ConstData.ltcMatTex;
+			}
+			case "_ltcMag": {
+				if (armory.data.ConstData.ltcMagTex == null) armory.data.ConstData.initLTC();
+				return armory.data.ConstData.ltcMagTex;
+			}
+			#end
 		}
-		#if arm_ltc
-		else if (link == "_ltcMat") {
-			if (armory.data.ConstData.ltcMatTex == null) armory.data.ConstData.initLTC();
-			return armory.data.ConstData.ltcMatTex;
-		}
-		else if (link == "_ltcMag") {
-			if (armory.data.ConstData.ltcMagTex == null) armory.data.ConstData.initLTC();
-			return armory.data.ConstData.ltcMagTex;
-		}
-		#end
+
 		var target = iron.RenderPath.active.renderTargets.get(link.endsWith("_depth") ? link.substr(0, link.length - 6) : link);
 		return target != null ? target.image : null;
 	}
 
 	public static function vec3Link(object: Object, mat: MaterialData, link: String): iron.math.Vec4 {
 		var v: Vec4 = null;
-		#if arm_hosek
-		if (link == "_hosekA") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+		switch (link) {
+			#if arm_hosek
+			case "_hosekA": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.A.x;
+					v.y = armory.renderpath.HosekWilkie.data.A.y;
+					v.z = armory.renderpath.HosekWilkie.data.A.z;
+				}
 			}
-			if (armory.renderpath.HosekWilkie.data != null) {
+			case "_hosekB": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.B.x;
+					v.y = armory.renderpath.HosekWilkie.data.B.y;
+					v.z = armory.renderpath.HosekWilkie.data.B.z;
+				}
+			}
+			case "_hosekC": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.C.x;
+					v.y = armory.renderpath.HosekWilkie.data.C.y;
+					v.z = armory.renderpath.HosekWilkie.data.C.z;
+				}
+			}
+			case "_hosekD": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.D.x;
+					v.y = armory.renderpath.HosekWilkie.data.D.y;
+					v.z = armory.renderpath.HosekWilkie.data.D.z;
+				}
+			}
+			case "_hosekE": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.E.x;
+					v.y = armory.renderpath.HosekWilkie.data.E.y;
+					v.z = armory.renderpath.HosekWilkie.data.E.z;
+				}
+			}
+			case "_hosekF": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.F.x;
+					v.y = armory.renderpath.HosekWilkie.data.F.y;
+					v.z = armory.renderpath.HosekWilkie.data.F.z;
+				}
+			}
+			case "_hosekG": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.G.x;
+					v.y = armory.renderpath.HosekWilkie.data.G.y;
+					v.z = armory.renderpath.HosekWilkie.data.G.z;
+				}
+			}
+			case "_hosekH": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.H.x;
+					v.y = armory.renderpath.HosekWilkie.data.H.y;
+					v.z = armory.renderpath.HosekWilkie.data.H.z;
+				}
+			}
+			case "_hosekI": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.I.x;
+					v.y = armory.renderpath.HosekWilkie.data.I.y;
+					v.z = armory.renderpath.HosekWilkie.data.I.z;
+				}
+			}
+			case "_hosekZ": {
+				if (armory.renderpath.HosekWilkie.data == null) {
+					armory.renderpath.HosekWilkie.recompute(Scene.active.world);
+				}
+				if (armory.renderpath.HosekWilkie.data != null) {
+					v = iron.object.Uniforms.helpVec;
+					v.x = armory.renderpath.HosekWilkie.data.Z.x;
+					v.y = armory.renderpath.HosekWilkie.data.Z.y;
+					v.z = armory.renderpath.HosekWilkie.data.Z.z;
+				}
+			}
+			#end
+			#if rp_voxelao
+			case "_cameraPositionSnap": {
 				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.A.x;
-				v.y = armory.renderpath.HosekWilkie.data.A.y;
-				v.z = armory.renderpath.HosekWilkie.data.A.z;
+				var camera = iron.Scene.active.camera;
+				v.set(camera.transform.worldx(), camera.transform.worldy(), camera.transform.worldz());
+				var l = camera.lookWorld();
+				var e = Main.voxelgiHalfExtents;
+				v.x += l.x * e * 0.9;
+				v.y += l.y * e * 0.9;
+				var f = Main.voxelgiVoxelSize * 8; // Snaps to 3 mip-maps range
+				v.set(Math.floor(v.x / f) * f, Math.floor(v.y / f) * f, Math.floor(v.z / f) * f);
 			}
+			#end
 		}
-		else if (link == "_hosekB") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
-			}
-			if (armory.renderpath.HosekWilkie.data != null) {
-				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.B.x;
-				v.y = armory.renderpath.HosekWilkie.data.B.y;
-				v.z = armory.renderpath.HosekWilkie.data.B.z;
-			}
-		}
-		else if (link == "_hosekC") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
-			}
-			if (armory.renderpath.HosekWilkie.data != null) {
-				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.C.x;
-				v.y = armory.renderpath.HosekWilkie.data.C.y;
-				v.z = armory.renderpath.HosekWilkie.data.C.z;
-			}
-		}
-		else if (link == "_hosekD") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
-			}
-			if (armory.renderpath.HosekWilkie.data != null) {
-				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.D.x;
-				v.y = armory.renderpath.HosekWilkie.data.D.y;
-				v.z = armory.renderpath.HosekWilkie.data.D.z;
-			}
-		}
-		else if (link == "_hosekE") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
-			}
-			if (armory.renderpath.HosekWilkie.data != null) {
-				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.E.x;
-				v.y = armory.renderpath.HosekWilkie.data.E.y;
-				v.z = armory.renderpath.HosekWilkie.data.E.z;
-			}
-		}
-		else if (link == "_hosekF") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
-			}
-			if (armory.renderpath.HosekWilkie.data != null) {
-				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.F.x;
-				v.y = armory.renderpath.HosekWilkie.data.F.y;
-				v.z = armory.renderpath.HosekWilkie.data.F.z;
-			}
-		}
-		else if (link == "_hosekG") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
-			}
-			if (armory.renderpath.HosekWilkie.data != null) {
-				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.G.x;
-				v.y = armory.renderpath.HosekWilkie.data.G.y;
-				v.z = armory.renderpath.HosekWilkie.data.G.z;
-			}
-		}
-		else if (link == "_hosekH") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
-			}
-			if (armory.renderpath.HosekWilkie.data != null) {
-				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.H.x;
-				v.y = armory.renderpath.HosekWilkie.data.H.y;
-				v.z = armory.renderpath.HosekWilkie.data.H.z;
-			}
-		}
-		else if (link == "_hosekI") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
-			}
-			if (armory.renderpath.HosekWilkie.data != null) {
-				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.I.x;
-				v.y = armory.renderpath.HosekWilkie.data.I.y;
-				v.z = armory.renderpath.HosekWilkie.data.I.z;
-			}
-		}
-		else if (link == "_hosekZ") {
-			if (armory.renderpath.HosekWilkie.data == null) {
-				armory.renderpath.HosekWilkie.recompute(Scene.active.world);
-			}
-			if (armory.renderpath.HosekWilkie.data != null) {
-				v = iron.object.Uniforms.helpVec;
-				v.x = armory.renderpath.HosekWilkie.data.Z.x;
-				v.y = armory.renderpath.HosekWilkie.data.Z.y;
-				v.z = armory.renderpath.HosekWilkie.data.Z.z;
-			}
-		}
-		#end
-		#if rp_voxelao
-		if (link == "_cameraPositionSnap") {
-			v = iron.object.Uniforms.helpVec;
-			var camera = iron.Scene.active.camera;
-			v.set(camera.transform.worldx(), camera.transform.worldy(), camera.transform.worldz());
-			var l = camera.lookWorld();
-			var e = Main.voxelgiHalfExtents;
-			v.x += l.x * e * 0.9;
-			v.y += l.y * e * 0.9;
-			var f = Main.voxelgiVoxelSize * 8; // Snaps to 3 mip-maps range
-			v.set(Math.floor(v.x / f) * f, Math.floor(v.y / f) * f, Math.floor(v.z / f) * f);
-		}
-		#end
 
 		return v;
 	}
 
 	public static function floatLink(object: Object, mat: MaterialData, link: String): Null<kha.FastFloat> {
-		#if rp_dynres
-		if (link == "_dynamicScale") {
-			return armory.renderpath.DynamicResolutionScale.dynamicScale;
+		switch (link) {
+			#if rp_dynres
+			case "_dynamicScale": {
+				return armory.renderpath.DynamicResolutionScale.dynamicScale;
+			}
+			#end
+			#if arm_debug
+			case "_debugFloat": {
+				return armory.trait.internal.DebugConsole.debugFloat;
+			}
+			#end
+			#if rp_voxelao
+			case "_voxelBlend": { // Blend current and last voxels
+				var freq = armory.renderpath.RenderPathCreator.voxelFreq;
+				return (armory.renderpath.RenderPathCreator.voxelFrame % freq) / freq;
+			}
+			#end
 		}
-		#end
-		#if arm_debug
-		if (link == "_debugFloat") {
-			return armory.trait.internal.DebugConsole.debugFloat;
-		}
-		#end
-		#if rp_voxelao
-		if (link == "_voxelBlend") { // Blend current and last voxels
-			var freq = armory.renderpath.RenderPathCreator.voxelFreq;
-			return (armory.renderpath.RenderPathCreator.voxelFrame % freq) / freq;
-		}
-		#end
 		return null;
 	}
 }

--- a/Sources/armory/object/Uniforms.hx
+++ b/Sources/armory/object/Uniforms.hx
@@ -21,7 +21,7 @@ class Uniforms {
 	public static function textureLink(object: Object, mat: MaterialData, link: String): kha.Image {
 		if (link == "_nishitaLUT") {
 			if (armory.renderpath.Nishita.data == null) armory.renderpath.Nishita.recompute(Scene.active.world);
-			return armory.renderpath.Nishita.data.optDepthLUT;
+			return armory.renderpath.Nishita.data.lut;
 		}
 		#if arm_ltc
 		else if (link == "_ltcMat") {

--- a/Sources/armory/renderpath/Nishita.hx
+++ b/Sources/armory/renderpath/Nishita.hx
@@ -1,0 +1,80 @@
+package armory.renderpath;
+
+import kha.FastFloat;
+import kha.graphics4.TextureFormat;
+import kha.graphics4.Usage;
+
+import iron.data.WorldData;
+
+import armory.math.Helper;
+
+class Nishita {
+
+	public static var data: NishitaData = null;
+
+	public static function recompute(world: WorldData) {
+		if (world == null || world.raw.sun_direction == null) return;
+		if (data == null) data = new NishitaData();
+
+		// TODO
+		data.recompute(1.0, 1.0, 1.0);
+	}
+}
+
+class NishitaData {
+	static inline var LUT_WIDTH = 16;
+
+	/** Maximum ray height as defined by Cycles **/
+	static inline var MAX_HEIGHT = 60000;
+
+	static inline var RAYLEIGH_SCALE = 8e3;
+	static inline var MIE_SCALE = 1.2e3;
+
+	public var optDepthLUT: kha.Image;
+
+	public function new() {}
+
+	function getOzoneDensity(height: FastFloat): FastFloat {
+		if (height < 10000.0 || height >= 40000.0) {
+			return 0.0;
+		}
+		if (height < 25000.0) {
+			return (height - 10000.0) / 15000.0;
+		}
+		return -((height - 40000.0) / 15000.0);
+	}
+
+	/**
+		The RGBA texture layout looks as follows:
+			R = Rayleigh optical depth at height \in [0, 60000]
+			G = Mie optical depth at height \in [0, 60000]
+			B = Ozone optical depth at height \in [0, 60000]
+			A = Unused
+	**/
+	public function recompute(densityFacAir: FastFloat, densityFacDust: FastFloat, densityFacOzone: FastFloat) {
+		optDepthLUT = kha.Image.create(LUT_WIDTH, 1, TextureFormat.RGBA32, Usage.StaticUsage);
+
+		var textureData = optDepthLUT.lock();
+		for (i in 0...LUT_WIDTH) {
+			// Get the height for each LUT pixel i (in [-1, 1] range)
+			var height = (i / LUT_WIDTH) * 2 - 1;
+
+			// Use quadratic height for better horizon precision
+			// See https://sebh.github.io/publications/egsr2020.pdf (5.3)
+			height = 0.5 + 0.5 * Helper.sign(height) * Math.sqrt(Math.abs(height));
+			height *= MAX_HEIGHT; // Denormalize
+
+			// Make sure we use 32 bit floats
+			var optDepthRayleigh: FastFloat = Math.exp(-height / RAYLEIGH_SCALE) * densityFacAir;
+			var optDepthMie: FastFloat = Math.exp(-height / MIE_SCALE) * densityFacDust;
+			var optDepthOzone: FastFloat = getOzoneDensity(height) * densityFacOzone;
+
+			// 10 is the maximum density, so we divide by it to be able to use normalized values
+			textureData.set(i * 4 + 0, Std.int(optDepthRayleigh * 255 / 10));
+			textureData.set(i * 4 + 1, Std.int(optDepthMie * 255 / 10));
+			textureData.set(i * 4 + 2, Std.int(optDepthOzone * 255 / 10));
+			textureData.set(i * 4 + 3, 255); // Unused
+		}
+		optDepthLUT.unlock();
+	}
+}

--- a/Sources/armory/renderpath/Nishita.hx
+++ b/Sources/armory/renderpath/Nishita.hx
@@ -1,6 +1,7 @@
 package armory.renderpath;
 
 import kha.FastFloat;
+import kha.arrays.Float32Array;
 import kha.graphics4.TextureFormat;
 import kha.graphics4.Usage;
 
@@ -18,15 +19,28 @@ class Nishita {
 	public static var data: NishitaData = null;
 
 	/**
-		Recompute the nishita lookup table. Call this function after updating
-		the sky density settings.
+		Recomputes the nishita lookup table after the density settings changed.
+		Do not call this method on every frame (it's slow)!
 	**/
 	public static function recompute(world: WorldData) {
-		if (world == null || world.raw.sun_direction == null) return;
+		if (world == null || world.raw.nishita_density == null) return;
 		if (data == null) data = new NishitaData();
 
-		// TODO
-		data.computeLUT(new Vec3(1.0, 1.0, 1.0));
+		var density = world.raw.nishita_density;
+		data.computeLUT(new Vec3(density[0], density[1], density[2]));
+	}
+
+	/** Sets the sky's density parameters and calls `recompute()` afterwards. **/
+	public static function setDensity(world: WorldData, densityAir: FastFloat, densityDust: FastFloat, densityOzone: FastFloat) {
+		if (world == null) return;
+
+		if (world.raw.nishita_density == null) world.raw.nishita_density = new Float32Array(3);
+		var density = world.raw.nishita_density;
+		density[0] = Helper.clamp(densityAir, 0, 10);
+		density[1] = Helper.clamp(densityDust, 0, 10);
+		density[2] = Helper.clamp(densityOzone, 0, 10);
+
+		recompute(world);
 	}
 }
 

--- a/Sources/armory/renderpath/Nishita.hx
+++ b/Sources/armory/renderpath/Nishita.hx
@@ -5,36 +5,77 @@ import kha.graphics4.TextureFormat;
 import kha.graphics4.Usage;
 
 import iron.data.WorldData;
+import iron.math.Vec2;
+import iron.math.Vec3;
 
 import armory.math.Helper;
 
+/**
+	Utility class to control the Nishita sky model.
+**/
 class Nishita {
 
 	public static var data: NishitaData = null;
 
+	/**
+		Recompute the nishita lookup table. Call this function after updating
+		the sky density settings.
+	**/
 	public static function recompute(world: WorldData) {
 		if (world == null || world.raw.sun_direction == null) return;
 		if (data == null) data = new NishitaData();
 
 		// TODO
-		data.recompute(1.0, 1.0, 1.0);
+		data.computeLUT(new Vec3(1.0, 1.0, 1.0));
 	}
 }
 
+/**
+	This class holds the precalculated result of the inner scattering integral
+	of the Nishita sky model. The outer integral is calculated in
+	[`armory/Shaders/std/sky.glsl`](https://github.com/armory3d/armory/blob/master/Shaders/std/sky.glsl).
+
+	@see `armory.renderpath.Nishita`
+**/
 class NishitaData {
-	static inline var LUT_WIDTH = 16;
 
-	/** Maximum ray height as defined by Cycles **/
-	static inline var MAX_HEIGHT = 60000;
+	public var lut: kha.Image;
 
-	static inline var RAYLEIGH_SCALE = 8e3;
-	static inline var MIE_SCALE = 1.2e3;
+	/**
+		The amount of individual sample heights stored in the LUT (and the width
+		of the LUT image).
+	**/
+	public static var lutHeightSteps = 128;
+	/**
+		The amount of individual sun angle steps stored in the LUT (and the
+		height of the LUT image).
+	**/
+	public static var lutAngleSteps = 128;
 
-	public var optDepthLUT: kha.Image;
+	/**
+		Amount of steps for calculating the inner scattering integral. Heigher
+		values are more precise but take longer to compute.
+	**/
+	public static var jSteps = 8;
+
+	/** Radius of the atmosphere in meters. **/
+	public static var radiusAtmo = 6420000;
+	/**
+		Radius of the planet in meters. The default value is the earth radius as
+		defined in Cycles.
+	**/
+	public static var radiusPlanet = 6360000;
+
+	/** Rayleigh scattering scale parameter. **/
+	public static var rayleighScale = 8e3;
+	/** Mie scattering scale parameter. **/
+	public static var mieScale = 1.2e3;
 
 	public function new() {}
 
+	/** Approximates the density of ozone for a given sample height. **/
 	function getOzoneDensity(height: FastFloat): FastFloat {
+		// Values are taken from Cycles code
 		if (height < 10000.0 || height >= 40000.0) {
 			return 0.0;
 		}
@@ -45,36 +86,91 @@ class NishitaData {
 	}
 
 	/**
-		The RGBA texture layout looks as follows:
-			R = Rayleigh optical depth at height \in [0, 60000]
-			G = Mie optical depth at height \in [0, 60000]
-			B = Ozone optical depth at height \in [0, 60000]
-			A = Unused
+		Ray-sphere intersection test that assumes the sphere is centered at the
+		origin. There is no intersection when result.x > result.y. Otherwise
+		this function returns the distances to the two intersection points,
+		which might be equal.
 	**/
-	public function recompute(densityFacAir: FastFloat, densityFacDust: FastFloat, densityFacOzone: FastFloat) {
-		optDepthLUT = kha.Image.create(LUT_WIDTH, 1, TextureFormat.RGBA32, Usage.StaticUsage);
+	function raySphereIntersection(rayOrigin: Vec3, rayDirection: Vec3, sphereRadius: Int): Vec2 {
+		// Algorithm is described here: https://en.wikipedia.org/wiki/Line%E2%80%93sphere_intersection
+		var a = rayDirection.dot(rayDirection);
+		var b = 2.0 * rayDirection.dot(rayOrigin);
+		var c = rayOrigin.dot(rayOrigin) - (sphereRadius * sphereRadius);
+		var d = (b * b) - 4.0 * a * c;
 
-		var textureData = optDepthLUT.lock();
-		for (i in 0...LUT_WIDTH) {
-			// Get the height for each LUT pixel i (in [-1, 1] range)
-			var height = (i / LUT_WIDTH) * 2 - 1;
+		// Ray does not intersect the sphere
+		if (d < 0.0) return new Vec2(1e5, -1e5);
+
+		return new Vec2(
+			(-b - Math.sqrt(d)) / (2.0 * a),
+			(-b + Math.sqrt(d)) / (2.0 * a)
+		);
+	}
+
+	/**
+		Computes the LUT texture for the given density values.
+		@param density 3D vector of air density, dust density, ozone density
+	**/
+	public function computeLUT(density: Vec3) {
+		var imageData = new haxe.io.Float32Array(lutHeightSteps * lutAngleSteps * 4);
+
+		for (x in 0...lutHeightSteps) {
+			var height = (x / (lutHeightSteps - 1));
 
 			// Use quadratic height for better horizon precision
-			// See https://sebh.github.io/publications/egsr2020.pdf (5.3)
-			height = 0.5 + 0.5 * Helper.sign(height) * Math.sqrt(Math.abs(height));
-			height *= MAX_HEIGHT; // Denormalize
+			height *= height;
+			height *= radiusAtmo; // Denormalize
 
-			// Make sure we use 32 bit floats
-			var optDepthRayleigh: FastFloat = Math.exp(-height / RAYLEIGH_SCALE) * densityFacAir;
-			var optDepthMie: FastFloat = Math.exp(-height / MIE_SCALE) * densityFacDust;
-			var optDepthOzone: FastFloat = getOzoneDensity(height) * densityFacOzone;
+			for (y in 0...lutAngleSteps) {
+				var sunTheta = y / (lutAngleSteps - 1) * 2 - 1;
 
-			// 10 is the maximum density, so we divide by it to be able to use normalized values
-			textureData.set(i * 4 + 0, Std.int(optDepthRayleigh * 255 / 10));
-			textureData.set(i * 4 + 1, Std.int(optDepthMie * 255 / 10));
-			textureData.set(i * 4 + 2, Std.int(optDepthOzone * 255 / 10));
-			textureData.set(i * 4 + 3, 255); // Unused
+				// Improve horizon precision
+				// See https://sebh.github.io/publications/egsr2020.pdf (5.3)
+				sunTheta = Helper.sign(sunTheta) * sunTheta * sunTheta;
+				sunTheta = sunTheta * Math.PI / 2 + Math.PI / 2; // Denormalize
+
+				var jODepth = sampleSecondaryRay(height, sunTheta, density);
+
+				var pixelIndex = (x + y * lutHeightSteps) * 4;
+				imageData[pixelIndex + 0] = jODepth.x;
+				imageData[pixelIndex + 1] = jODepth.y;
+				imageData[pixelIndex + 2] = jODepth.z;
+				imageData[pixelIndex + 3] = 1.0; // Unused
+			}
 		}
-		optDepthLUT.unlock();
+
+		lut = kha.Image.fromBytes(imageData.view.buffer, lutHeightSteps, lutAngleSteps, TextureFormat.RGBA128, Usage.StaticUsage);
+	}
+
+	/**
+		Calculates the integral for the secondary ray.
+	**/
+	public function sampleSecondaryRay(height: FastFloat, sunTheta: FastFloat, density: Vec3): Vec3 {
+		// Reconstruct values from the shader
+		var iPos = new Vec3(0, 0, height + radiusPlanet);
+		var pSun = new Vec3(0.0, Math.sin(sunTheta), Math.cos(sunTheta)).normalize();
+
+		var jTime: FastFloat = 0.0;
+		var jStepSize: FastFloat = raySphereIntersection(iPos, pSun, radiusAtmo).y / jSteps;
+
+		// Optical depth accumulators for the secondary ray (Rayleigh, Mie, ozone)
+		var jODepth = new Vec3();
+
+		for (i in 0...jSteps) {
+
+			// Calculate the secondary ray sample position and height
+			var jPos = iPos.clone().add(pSun.clone().mult(jTime + jStepSize * 0.5));
+			var jHeight = jPos.length() - radiusPlanet;
+
+			// Accumulate optical depth
+			var optDepthRayleigh = Math.exp(-jHeight / rayleighScale) * density.x;
+			var optDepthMie = Math.exp(-jHeight / mieScale) * density.y;
+			var optDepthOzone = getOzoneDensity(jHeight) * density.z;
+			jODepth.addf(optDepthRayleigh, optDepthMie, optDepthOzone);
+
+			jTime += jStepSize;
+		}
+
+		return jODepth.mult(jStepSize);
 	}
 }

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2858,16 +2858,9 @@ class ArmoryExporter:
         rpdat = arm.utils.get_rp()
         solid_mat = rpdat.arm_material_model == 'Solid'
         arm_irradiance = rpdat.arm_irradiance and not solid_mat
-        arm_radiance = False
-        radtex = world.arm_envtex_name.rsplit('.', 1)[0]
+        arm_radiance = rpdat.arm_radiance
+        radtex = world.arm_envtex_name.rsplit('.', 1)[0]  # Remove file extension
         irrsharmonics = world.arm_envtex_irr_name
-
-        # Radiance
-        if '_EnvTex' in world.world_defs:
-            arm_radiance = rpdat.arm_radiance
-        elif '_EnvSky' in world.world_defs:
-            arm_radiance = rpdat.arm_radiance
-            radtex = 'hosek'
         num_mips = world.arm_envtex_num_mips
         strength = world.arm_envtex_strength
 

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2843,6 +2843,7 @@ class ArmoryExporter:
             out_world['sun_direction'] = list(world.arm_envtex_sun_direction)
             out_world['turbidity'] = world.arm_envtex_turbidity
             out_world['ground_albedo'] = world.arm_envtex_ground_albedo
+            out_world['nishita_density'] = list(world.arm_nishita_density)
 
         disable_hdr = world.arm_envtex_name.endswith('.jpg')
 

--- a/blender/arm/make_world.py
+++ b/blender/arm/make_world.py
@@ -279,7 +279,12 @@ def frag_write_clouds(world: bpy.types.World, frag: Shader):
 
     func_cloud_radiance = 'float cloudRadiance(vec3 p, vec3 dir) {\n'
     if '_EnvSky' in world.world_defs:
-        func_cloud_radiance += '\tvec3 sun_dir = hosekSunDirection;\n'
+        # Nishita sky
+        if 'vec3 sunDir' in frag.uniforms:
+            func_cloud_radiance += '\tvec3 sun_dir = sunDir;\n'
+        # Hosek
+        else:
+            func_cloud_radiance += '\tvec3 sun_dir = hosekSunDirection;\n'
     else:
         func_cloud_radiance += '\tvec3 sun_dir = vec3(0, 0, -1);\n'
     func_cloud_radiance += '''\tconst int steps = 8;
@@ -313,6 +318,7 @@ def frag_write_clouds(world: bpy.types.World, frag: Shader):
 \t\tuv += (dir.xy / dir.z) * step_size * cloudsUpper;
 \t}
 '''
+
     if world.arm_darken_clouds:
         func_trace_clouds += '\t// Darken clouds when the sun is low\n'
 

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -640,8 +640,12 @@ def to_vec1(v):
     return str(v)
 
 
+def to_vec2(v):
+    return f'vec2({v[0]}, {v[1]})'
+
+
 def to_vec3(v):
-    return 'vec3({0}, {1}, {2})'.format(v[0], v[1], v[2])
+    return f'vec3({v[0]}, {v[1]}, {v[2]})'
 
 
 def rgb_to_bw(res_var: vec3str) -> floatstr:

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -377,11 +377,7 @@ def parse_sky_nishita(node: bpy.types.ShaderNodeTexSky, state: ParserState) -> v
     planet_radius = 6360e3  # Earth radius used in Blender
     ray_origin_z = planet_radius + node.altitude
 
-    d_air = node.air_density
-    d_dust = node.dust_density
-    # Todo: Implement ozone density (ignored for now)
-    # d_ozone = node.ozone_density
-    density = c.to_vec2((d_air, d_dust))
+    density = c.to_vec3((node.air_density, node.dust_density, node.ozone_density))
 
     sun = ''
     if node.sun_disc:

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -373,6 +373,8 @@ def parse_sky_nishita(node: bpy.types.ShaderNodeTexSky, state: ParserState) -> v
     curshader = state.curshader
     curshader.add_include('std/sky.glsl')
     curshader.add_uniform('vec3 sunDir', link='_sunDirection')
+    curshader.add_uniform('sampler2D nishitaLUT', link='_nishitaLUT', included=True,
+                          tex_addr_u='clamp', tex_addr_v='clamp')
 
     planet_radius = 6360e3  # Earth radius used in Blender
     ray_origin_z = planet_radius + node.altitude

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -375,11 +375,12 @@ def parse_sky_nishita(node: bpy.types.ShaderNodeTexSky, state: ParserState) -> v
     curshader.add_uniform('vec3 sunDir', link='_sunDirection')
     curshader.add_uniform('sampler2D nishitaLUT', link='_nishitaLUT', included=True,
                           tex_addr_u='clamp', tex_addr_v='clamp')
+    curshader.add_uniform('vec2 nishitaDensity', link='_nishitaDensity', included=True)
 
     planet_radius = 6360e3  # Earth radius used in Blender
     ray_origin_z = planet_radius + node.altitude
 
-    density = c.to_vec3((node.air_density, node.dust_density, node.ozone_density))
+    state.world.arm_nishita_density = [node.air_density, node.dust_density, node.ozone_density]
 
     sun = ''
     if node.sun_disc:
@@ -399,7 +400,7 @@ def parse_sky_nishita(node: bpy.types.ShaderNodeTexSky, state: ParserState) -> v
         size = math.cos(theta)
         sun = f'* sun_disk(n, sunDir, {size}, {node.sun_intensity})'
 
-    return f'nishita_atmosphere(n, vec3(0, 0, {ray_origin_z}), sunDir, {planet_radius}, {density}){sun}'
+    return f'nishita_atmosphere(n, vec3(0, 0, {ray_origin_z}), sunDir, {planet_radius}){sun}'
 
 
 def parse_tex_environment(node: bpy.types.ShaderNodeTexEnvironment, out_socket: bpy.types.NodeSocket, state: ParserState) -> vec3str:

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -296,7 +296,7 @@ def parse_tex_sky(node: bpy.types.ShaderNodeTexSky, out_socket: bpy.types.NodeSo
 
     if node.sky_type == 'PREETHAM' or node.sky_type == 'HOSEK_WILKIE':
         if node.sky_type == 'PREETHAM':
-            log.warn('Preetham sky model is not supported, using Hosek Wilkie sky model instead')
+            log.info('Info: Preetham sky model is not supported, using Hosek Wilkie sky model instead')
 
         return parse_sky_hosekwilkie(node, state)
 

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -376,7 +376,13 @@ def parse_sky_nishita(node: bpy.types.ShaderNodeTexSky, state: ParserState) -> v
     planet_radius = 6360e3  # Earth radius used in Blender
     ray_origin_z = planet_radius + node.altitude * 1000
 
-    return f'nishita_atmosphere(n, vec3(0, 0, {ray_origin_z}), sunDir, {planet_radius})'
+    d_air = node.air_density
+    d_dust = node.dust_density
+    # Todo: Implement ozone density (ignored for now)
+    # d_ozone = node.ozone_density
+    density = c.to_vec2((d_air, d_dust))
+
+    return f'nishita_atmosphere(n, vec3(0, 0, {ray_origin_z}), sunDir, {planet_radius}, {density})'
 
 
 def parse_tex_environment(node: bpy.types.ShaderNodeTexEnvironment, out_socket: bpy.types.NodeSocket, state: ParserState) -> vec3str:

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -373,7 +373,10 @@ def parse_sky_nishita(node: bpy.types.ShaderNodeTexSky, state: ParserState) -> v
     curshader.add_include('std/sky.glsl')
     curshader.add_uniform('vec3 sunDir', link='_sunDirection')
 
-    return 'nishita_atmosphere(n, vec3(0,0,6372e3), sunDir, 22.0, 6371e3, 6471e3, vec3(5.5e-6,13.0e-6,22.4e-6), 21e-6, 8e3, 1.2e3, 0.758)'
+    planet_radius = 6360e3  # Earth radius used in Blender
+    ray_origin_z = planet_radius + node.altitude * 1000
+
+    return f'nishita_atmosphere(n, vec3(0, 0, {ray_origin_z}), sunDir, {planet_radius})'
 
 
 def parse_tex_environment(node: bpy.types.ShaderNodeTexEnvironment, out_socket: bpy.types.NodeSocket, state: ParserState) -> vec3str:

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -294,6 +294,8 @@ def parse_tex_sky(node: bpy.types.ShaderNodeTexSky, out_socket: bpy.types.NodeSo
         # Pass through
         return c.to_vec3([0.0, 0.0, 0.0])
 
+    state.world.world_defs += '_EnvSky'
+
     if node.sky_type == 'PREETHAM' or node.sky_type == 'HOSEK_WILKIE':
         if node.sky_type == 'PREETHAM':
             log.info('Info: Preetham sky model is not supported, using Hosek Wilkie sky model instead')
@@ -315,7 +317,6 @@ def parse_sky_hosekwilkie(node: bpy.types.ShaderNodeTexSky, state: ParserState) 
     # Match to cycles
     world.arm_envtex_strength *= 0.1
 
-    world.world_defs += '_EnvSky'
     assets.add_khafile_def('arm_hosek')
     curshader.add_uniform('vec3 A', link="_hosekA")
     curshader.add_uniform('vec3 B', link="_hosekB")

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -375,7 +375,7 @@ def parse_sky_nishita(node: bpy.types.ShaderNodeTexSky, state: ParserState) -> v
     curshader.add_uniform('vec3 sunDir', link='_sunDirection')
 
     planet_radius = 6360e3  # Earth radius used in Blender
-    ray_origin_z = planet_radius + node.altitude * 1000
+    ray_origin_z = planet_radius + node.altitude
 
     d_air = node.air_density
     d_dust = node.dust_density

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -119,16 +119,29 @@ class ShaderContext:
             c['link'] = link
         self.constants.append(c)
 
-    def add_texture_unit(self, ctype, name, link=None, is_image=None):
+    def add_texture_unit(self, name, link=None, is_image=None,
+                         addr_u=None, addr_v=None,
+                         filter_min=None, filter_mag=None, mipmap_filter=None):
         for c in self.tunits:
             if c['name'] == name:
                 return
 
-        c = { 'name': name }
-        if link != None:
+        c = {'name': name}
+        if link is not None:
             c['link'] = link
-        if is_image != None:
+        if is_image is not None:
             c['is_image'] = is_image
+        if addr_u is not None:
+            c['addressing_u'] = addr_u
+        if addr_v is not None:
+            c['addressing_v'] = addr_v
+        if filter_min is not None:
+            c['filter_min'] = filter_min
+        if filter_mag is not None:
+            c['filter_mag'] = filter_mag
+        if mipmap_filter is not None:
+            c['mipmap_filter'] = mipmap_filter
+
         self.tunits.append(c)
 
     def make_vert(self, custom_name: str = None):
@@ -213,7 +226,10 @@ class Shader:
         if s not in self.outs:
             self.outs.append(s)
 
-    def add_uniform(self, s, link=None, included=False):
+    def add_uniform(self, s, link=None, included=False,
+                    tex_addr_u=None, tex_addr_v=None,
+                    tex_filter_min=None, tex_filter_mag=None,
+                    tex_mipmap_filter=None):
         ar = s.split(' ')
         # layout(RGBA8) image3D voxels
         utype = ar[-2]
@@ -224,9 +240,15 @@ class Shader:
                 # Add individual units - mySamplers[0], mySamplers[1]
                 for i in range(int(uname[-2])):
                     uname_array = uname[:-2] + str(i) + ']'
-                    self.context.add_texture_unit(utype, uname_array, link=link, is_image=is_image)
+                    self.context.add_texture_unit(
+                        uname_array, link, is_image,
+                        tex_addr_u, tex_addr_v,
+                        tex_filter_min, tex_filter_mag, tex_mipmap_filter)
             else:
-                self.context.add_texture_unit(utype, uname, link=link, is_image=is_image)
+                self.context.add_texture_unit(
+                    uname, link, is_image,
+                    tex_addr_u, tex_addr_v,
+                    tex_filter_min, tex_filter_mag, tex_mipmap_filter)
         else:
             # Prefer vec4[] for d3d to avoid padding
             if ar[0] == 'float' and '[' in ar[1]:

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -435,6 +435,10 @@ def init_properties():
     bpy.types.World.compo_defs = StringProperty(name="Compositor Shader Defs", default='')
 
     bpy.types.World.arm_use_clouds = BoolProperty(name="Clouds", default=False, update=assets.invalidate_shader_cache)
+    bpy.types.World.arm_darken_clouds = BoolProperty(
+        name="Darken Clouds at Night",
+        description="Darkens the clouds when the sun is low. This setting is for artistic purposes and is not physically correct",
+        default=False, update=assets.invalidate_shader_cache)
     bpy.types.World.arm_clouds_lower = FloatProperty(name="Lower", default=1.0, min=0.1, max=10.0, update=assets.invalidate_shader_cache)
     bpy.types.World.arm_clouds_upper = FloatProperty(name="Upper", default=1.0, min=0.1, max=10.0, update=assets.invalidate_shader_cache)
     bpy.types.World.arm_clouds_wind = FloatVectorProperty(name="Wind", default=[1.0, 0.0], size=2, update=assets.invalidate_shader_cache)

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -326,6 +326,7 @@ def init_properties():
     bpy.types.World.arm_envtex_sun_direction = FloatVectorProperty(name="Sun Direction", size=3, default=[0,0,0])
     bpy.types.World.arm_envtex_turbidity = FloatProperty(name="Turbidity", default=1.0)
     bpy.types.World.arm_envtex_ground_albedo = FloatProperty(name="Ground Albedo", default=0.0)
+    bpy.types.World.arm_nishita_density = FloatVectorProperty(name="Nishita Density", size=3, default=[1, 1, 1])
     bpy.types.Material.arm_cast_shadow = BoolProperty(name="Cast Shadow", default=True)
     bpy.types.Material.arm_receive_shadow = BoolProperty(name="Receive Shadow", description="Requires forward render path", default=True)
     bpy.types.Material.arm_overlay = BoolProperty(name="Overlay", default=False)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -244,6 +244,7 @@ class ARM_PT_WorldPropsPanel(bpy.types.Panel):
         layout.prop(world, 'arm_use_clouds')
         col = layout.column(align=True)
         col.enabled = world.arm_use_clouds
+        col.prop(world, 'arm_darken_clouds')
         col.prop(world, 'arm_clouds_lower')
         col.prop(world, 'arm_clouds_upper')
         col.prop(world, 'arm_clouds_precipitation')

--- a/blender/arm/write_probes.py
+++ b/blender/arm/write_probes.py
@@ -317,6 +317,8 @@ def sh_to_json(sh_file):
     parse_band_floats(irradiance_floats, band0_line)
     parse_band_floats(irradiance_floats, band1_line)
     parse_band_floats(irradiance_floats, band2_line)
+    for i in range(0, len(irradiance_floats)):
+        irradiance_floats[i] /= 2
 
     sh_json = {'irradiance': irradiance_floats}
     ext = '.arm' if bpy.data.worlds['Arm'].arm_minimize else ''


### PR DESCRIPTION
Part of https://github.com/armory3d/armory/pull/2082.

This PR adds an implementation of the Nishita sky model which was introduced in Blender 2.9. It was ported from https://github.com/wwwtyro/glsl-atmosphere which is licensed under the [Unlicense](https://github.com/wwwtyro/glsl-atmosphere/blob/master/LICENSE).

![nishita_cycle_small](https://user-images.githubusercontent.com/17685000/113421626-bb014980-93cb-11eb-9289-b06ee5446769.gif)

- To make it work fast, I moved the computation of the inner integral to a precalculated 2D LUT texture that only needs to be recalculated if the density parameters change. In the future we could improve things further by (optionally) rendering the sky to a lower resolution texture first, but that's not part of this PR. The LUT also makes it possible to store presets for different atmospheres.

- Also, I added support for all the node settings such as air, dust and ozone density and a sun disk with limb darkening.

- For clouds, there is now an option to (artificially) darken them based on the sun direction, this should probably be replaced in the future with a more physically accurate representation (but before the clouds would just remain bright):

  ![nishita_cycle_clouds_small](https://user-images.githubusercontent.com/17685000/113421635-bd63a380-93cb-11eb-8939-8e37d4b0be81.gif)
  (The artifacts in the clouds are caused by the gif compression)

- In addition to the new sky model, worlds are now rendered in the background to (ir)radiance maps when no other node already set those maps (environment texture node for example). This takes about ~1s per world on my quite old mid-level machine from 2015, even with very complex node setups because worlds only need one sample. Actually I wanted to implement world caching in this PR, but it turns out to be more complicated than I thought so I will postpone it to a future PR.

- There is also a new API for setting texture parameters in shaders.py based on https://github.com/armory3d/iron/pull/118.