### PR TITLE
Fix GetSystemName node

### DIFF
--- a/Sources/armory/logicnode/GetSystemName.hx
+++ b/Sources/armory/logicnode/GetSystemName.hx
@@ -3,22 +3,24 @@ package armory.logicnode;
 class GetSystemName extends LogicNode {
 
 	public function new(tree: LogicTree) {
-		super(tree);		
+		super(tree);
 	}
 
-	public static function equalsCI(a : String, b : String) return a.toLowerCase() == b.toLowerCase();
-
 	override function get(from: Int): Dynamic {
+		var systemName: String = kha.System.systemId;
 
 		return switch (from) {
 			case 0: systemName;
-			case 1: equalsCI(kha.System.systemId, 'Windows');
-			case 2: equalsCI(kha.System.systemId, 'Linux');
-			case 3: equalsCI(kha.System.systemId, 'Mac');
-			case 4: equalsCI(kha.System.systemId, 'HTML5');
-			case 5: equalsCI(kha.System.systemId, 'Android');
+			case 1: equalsCI(systemName, 'Windows');
+			case 2: equalsCI(systemName, 'Linux');
+			case 3: equalsCI(systemName, 'Mac');
+			case 4: equalsCI(systemName, 'HTML5');
+			case 5: equalsCI(systemName, 'Android');
 			default: null;
 		}
+	}
 
+	static inline function equalsCI(a: String, b: String): Bool {
+		return a.toLowerCase() == b.toLowerCase();
 	}
 }


### PR DESCRIPTION
Fixed `Unknown identifier : systemName` error as observed by @onelsonic in https://github.com/armory3d/armory/pull/2153.