### PR TITLE
Add profiling of shadow map atlas logic to debug console

### DIFF
--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -113,7 +113,7 @@ class Inc {
 		#end
 		// add new lights to the atlases
 		#if arm_debug
-		beginProfile();
+		beginShadowsLogicProfile();
 		// reset data on rejected lights
 		for (atlas in ShadowMapAtlas.shadowMapAtlases) {
 			atlas.rejectedLights = [];
@@ -175,6 +175,9 @@ class Inc {
 				var face = 0;
 				var faces = ShadowMapTile.tilesLightType(tile.light.data.raw.type);
 
+				#if arm_debug
+				beginShadowsRenderProfile();
+				#end
 				tile.forEachTileLinked(function (lTile) {
 					if (faces > 1) {
 						#if arm_csm
@@ -191,6 +194,9 @@ class Inc {
 
 					path.drawMeshesStream("shadowmap");
 				});
+				#if arm_debug
+				endShadowsRenderProfile();
+				#end
 
 				path.currentFace = -1;
 			}
@@ -214,7 +220,7 @@ class Inc {
 			}
 		}
 		#if arm_debug
-		endProfile();
+		endShadowsLogicProfile();
 		#end
 		#end // rp_shadowmap
 	}
@@ -533,8 +539,10 @@ class Inc {
 	}
 
 	#if arm_debug
-	public static var shadowMapAtlasTime = 0.0;
-	static var startTime = 0.0;
+	public static var shadowsLogicTime = 0.0;
+	public static var shadowsRenderTime = 0.0;
+	static var startShadowsLogicTime = 0.0;
+	static var startShadowsRenderTime = 0.0;
 	static var callBackSetup = false;
 	static function setupEndFrameCallback() {
 		if (!callBackSetup) {
@@ -542,9 +550,11 @@ class Inc {
 			iron.App.endFrameCallbacks.push(endFrame);
 		}
 	}
-	static function beginProfile() { setupEndFrameCallback(); startTime = kha.Scheduler.realTime(); }
-	static function endProfile() { shadowMapAtlasTime += kha.Scheduler.realTime() - startTime; }
-	public static function endFrame() { shadowMapAtlasTime = 0; }
+	static function beginShadowsLogicProfile() { setupEndFrameCallback(); startShadowsLogicTime = kha.Scheduler.realTime(); }
+	static function beginShadowsRenderProfile() { startShadowsRenderTime = kha.Scheduler.realTime(); }
+	static function endShadowsLogicProfile() { shadowsLogicTime += kha.Scheduler.realTime() - startShadowsLogicTime - shadowsRenderTime; }
+	static function endShadowsRenderProfile() { shadowsRenderTime += kha.Scheduler.realTime() - startShadowsRenderTime; }
+	public static function endFrame() { shadowsLogicTime = 0;  shadowsRenderTime = 0; }
 	#end
 }
 

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -113,6 +113,7 @@ class Inc {
 		#end
 		// add new lights to the atlases
 		#if arm_debug
+		beginProfile();
 		// reset data on rejected lights
 		for (atlas in ShadowMapAtlas.shadowMapAtlases) {
 			atlas.rejectedLights = [];
@@ -212,6 +213,9 @@ class Inc {
 				tile.freeTile();
 			}
 		}
+		#if arm_debug
+		endProfile();
+		#end
 		#end // rp_shadowmap
 	}
 	#else
@@ -527,6 +531,21 @@ class Inc {
 		return null;
 		#end
 	}
+
+	#if arm_debug
+	public static var shadowMapAtlasTime = 0.0;
+	static var startTime = 0.0;
+	static var callBackSetup = false;
+	static function setupEndFrameCallback() {
+		if (!callBackSetup) {
+			callBackSetup = true;
+			iron.App.endFrameCallbacks.push(endFrame);
+		}
+	}
+	static function beginProfile() { setupEndFrameCallback(); startTime = kha.Scheduler.realTime(); }
+	static function endProfile() { shadowMapAtlasTime += kha.Scheduler.realTime() - startTime; }
+	public static function endFrame() { shadowMapAtlasTime = 0; }
+	#end
 }
 
 #if arm_shadowmap_atlas

--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -68,6 +68,8 @@ class DebugConsole extends Trait {
 	#if arm_shadowmap_atlas
 	var lightColorMap: Map<String, Int> = new Map();
 	var lightColorMapCount = 0;
+	var smaTime = 0.0;
+	var smaTimeAvg = 0.0;
 	#end
 
 	public function new(scaleFactor = 1.0, scaleDebugConsole = 1.0, positionDebugConsole = 2, visibleDebugConsole = 1,
@@ -483,6 +485,12 @@ class DebugConsole extends Trait {
 					ui.text("Physics");
 					ui.text(Math.round(physTimeAvg * 10000) / 10 + " ms", Align.Right);
 
+					#if arm_shadowmap_atlas
+					ui.row(lrow);
+					ui.text("Shadow Map Atlas (Script)");
+					ui.text(Math.round(smaTimeAvg * 10000) / 10 + " ms", Align.Right);
+					#end
+
 					ui.unindent();
 				}
 
@@ -868,6 +876,11 @@ class DebugConsole extends Trait {
 			animTimeAvg = animTime / frames;
 			physTimeAvg = physTime / frames;
 
+			#if arm_shadowmap_atlas
+			smaTimeAvg = smaTime / frames;
+			smaTime = 0;
+			#end
+
 			totalTime = 0;
 			renderPathTime = 0;
 			updateTime = 0;
@@ -891,6 +904,9 @@ class DebugConsole extends Trait {
 		animTime += iron.object.Animation.animationTime;
 	#if arm_physics
 		physTime += armory.trait.physics.PhysicsWorld.physTime;
+	#end
+	#if arm_shadowmap_atlas
+		smaTime += armory.renderpath.Inc.shadowMapAtlasTime;
 	#end
 	}
 

--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -68,8 +68,10 @@ class DebugConsole extends Trait {
 	#if arm_shadowmap_atlas
 	var lightColorMap: Map<String, Int> = new Map();
 	var lightColorMapCount = 0;
-	var smaTime = 0.0;
-	var smaTimeAvg = 0.0;
+	var smaLogicTime = 0.0;
+	var smaLogicTimeAvg = 0.0;
+	var smaRenderTime = 0.0;
+	var smaRenderTimeAvg = 0.0;
 	#end
 
 	public function new(scaleFactor = 1.0, scaleDebugConsole = 1.0, positionDebugConsole = 2, visibleDebugConsole = 1,
@@ -487,8 +489,12 @@ class DebugConsole extends Trait {
 
 					#if arm_shadowmap_atlas
 					ui.row(lrow);
-					ui.text("Shadow Map Atlas (Script)");
-					ui.text(Math.round(smaTimeAvg * 10000) / 10 + " ms", Align.Right);
+					ui.text("Shadow Map Atlas (Logic)");
+					ui.text(Math.round(smaLogicTimeAvg * 10000) / 10 + " ms", Align.Right);
+
+					ui.row(lrow);
+					ui.text("Shadow Map Atlas (Render)");
+					ui.text(Math.round(smaRenderTimeAvg * 10000) / 10 + " ms", Align.Right);
 					#end
 
 					ui.unindent();
@@ -877,8 +883,11 @@ class DebugConsole extends Trait {
 			physTimeAvg = physTime / frames;
 
 			#if arm_shadowmap_atlas
-			smaTimeAvg = smaTime / frames;
-			smaTime = 0;
+			smaLogicTimeAvg = smaLogicTime / frames;
+			smaLogicTime = 0;
+
+			smaRenderTimeAvg = smaRenderTime / frames;
+			smaRenderTime = 0;
 			#end
 
 			totalTime = 0;
@@ -906,7 +915,8 @@ class DebugConsole extends Trait {
 		physTime += armory.trait.physics.PhysicsWorld.physTime;
 	#end
 	#if arm_shadowmap_atlas
-		smaTime += armory.renderpath.Inc.shadowMapAtlasTime;
+		smaLogicTime += armory.renderpath.Inc.shadowsLogicTime;
+		smaRenderTime += armory.renderpath.Inc.shadowsRenderTime;
 	#end
 	}
 


### PR DESCRIPTION
This is to help debug atlas rendering and logic performance:
![image](https://user-images.githubusercontent.com/42382648/115976701-003a1680-a547-11eb-9a7f-5d58f8500b5a.png)


Depends on https://github.com/armory3d/iron/pull/123