### PR TITLE
[Blender 2.9] Slightly improve debug console panel UI

### DIFF
--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -934,23 +934,20 @@ class ARM_PT_ProjectFlagsDebugConsolePanel(bpy.types.Panel):
     bl_options = {'DEFAULT_CLOSED'}
     bl_parent_id = "ARM_PT_ProjectFlagsPanel"
 
+    def draw_header(self, context):
+        wrd = bpy.data.worlds['Arm']
+        self.layout.prop(wrd, 'arm_debug_console', text='')
+
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
         wrd = bpy.data.worlds['Arm']
-        row = layout.row()
-        row.enabled = wrd.arm_ui != 'Disabled'
-        row.prop(wrd, 'arm_debug_console')
-        row = layout.row()
-        row.enabled = wrd.arm_debug_console
-        row.prop(wrd, 'arm_debug_console_position')
-        row = layout.row()
-        row.enabled = wrd.arm_debug_console
-        row.prop(wrd, 'arm_debug_console_scale')
-        row = layout.row()
-        row.enabled = wrd.arm_debug_console
-        row.prop(wrd, 'arm_debug_console_visible')
+        col = layout.column()
+        col.enabled = wrd.arm_debug_console
+        col.prop(wrd, 'arm_debug_console_position')
+        col.prop(wrd, 'arm_debug_console_scale')
+        col.prop(wrd, 'arm_debug_console_visible')
 
 class ARM_PT_ProjectWindowPanel(bpy.types.Panel):
     bl_label = "Window"


### PR DESCRIPTION
Part of https://github.com/armory3d/armory/pull/2082.

One click less to enable/disable the debug console if the panel is closed.

Previously:
![debuc_console_ui_prev](https://user-images.githubusercontent.com/17685000/117355038-59446b80-aeb2-11eb-8a2b-be1285d62a46.png)

Now:
![debug_console_ui_now](https://user-images.githubusercontent.com/17685000/117355055-5d708900-aeb2-11eb-9e39-eed78d3a6f82.png)