### PR TITLE
Fix double-export of linked objects (#2175)

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1594,9 +1594,11 @@ Make sure the mesh only has tris/quads.""")
 
                 asset_name = arm.utils.asset_name(bobject)
 
+                # Collection is in the same file
                 if collection.library is None:
-                    # collection is in the same file, but (likely) on another scene
-                    if asset_name not in scene_objects:
+                    # Only export linked objects (from other scenes for example),
+                    # all other objects (in scene_objects) are already exported.
+                    if bobject.name not in scene_objects:
                         self.process_bobject(bobject)
                         self.export_object(bobject, self.scene)
                 else:


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2175.

This issue occurred because of a comparison of scene object names with the asset name of a linked object instead of its actual name (asset names aren't comparable with scene object names).

I also tested this PR with the blend file in https://github.com/armory3d/armory/pull/1597, which first introduced the now fixed code. It should work for both cases now.