### PR TITLE
Improve bone IK. Add new nodes for better animation control

### DIFF
--- a/Sources/armory/logicnode/BoneFKNode.hx
+++ b/Sources/armory/logicnode/BoneFKNode.hx
@@ -1,5 +1,7 @@
 package armory.logicnode;
 
+import iron.math.Quat;
+import iron.math.Vec4;
 import iron.object.Object;
 import iron.object.BoneAnimation;
 import iron.math.Mat4;
@@ -26,21 +28,27 @@ class BoneFKNode extends LogicNode {
 		var anim = object.animation != null ? cast(object.animation, BoneAnimation) : null;
 		if (anim == null) anim = object.getParentArmature(object.name);
 
-		// Manipulating bone in world space
+		// Get bone in armature
 		var bone = anim.getBone(boneName);
-		/* m = anim.getBoneMat(bone);
-		w = anim.getAbsMat(bone); */
 
 		function moveBone() {
-			/* m.setFrom(w);
-			m.multmat(transform);
-			iw.getInverse(w);
-			m.multmat(iw); */
-			//trace("Perform FK");
-			anim.setBoneMatFromWorldMat(transform.clone(), bone);
+			
+			var t2 = Mat4.identity();
+			var loc= new Vec4();
+			var rot = new Quat();
+			var scl = new Vec4();
 
+			//Set scale to Armature scale. Bone scaling not yet implemented
+			t2.setFrom(transform);
+			t2.decompose(loc, rot, scl);
+			scl = object.transform.world.getScale();
+			t2.compose(loc, rot, scl);
+
+			//Set the bone local transform from world transform
+			anim.setBoneMatFromWorldMat(t2, bone);
+
+			//Remove this method from animation loop after FK
 			anim.removeUpdate(moveBone);
-			//trace("FK removed");
 			notified = false;
 		}
 

--- a/Sources/armory/logicnode/BoneFKNode.hx
+++ b/Sources/armory/logicnode/BoneFKNode.hx
@@ -28,17 +28,20 @@ class BoneFKNode extends LogicNode {
 
 		// Manipulating bone in world space
 		var bone = anim.getBone(boneName);
-		m = anim.getBoneMat(bone);
-		w = anim.getAbsMat(bone);
+		/* m = anim.getBoneMat(bone);
+		w = anim.getAbsMat(bone); */
 
 		function moveBone() {
-			m.setFrom(w);
+			/* m.setFrom(w);
 			m.multmat(transform);
 			iw.getInverse(w);
-			m.multmat(iw);
+			m.multmat(iw); */
+			//trace("Perform FK");
+			anim.setBoneMatFromWorldMat(transform.clone(), bone);
 
-			// anim.removeUpdate(moveBone);
-			// notified = false;
+			anim.removeUpdate(moveBone);
+			//trace("FK removed");
+			notified = false;
 		}
 
 		if (!notified) {

--- a/Sources/armory/logicnode/BoneIKNode.hx
+++ b/Sources/armory/logicnode/BoneIKNode.hx
@@ -7,6 +7,13 @@ import iron.math.Vec4;
 class BoneIKNode extends LogicNode {
 
 	var goal: Vec4;
+	var pole: Vec4;
+	var poleEnabled: Bool;
+	var chainLength: Int;
+	var maxIterartions: Int;
+	var precision: Float;
+	var rollAngle: Float;
+
 	var notified = false;
 
 	public function new(tree: LogicTree) {
@@ -19,6 +26,12 @@ class BoneIKNode extends LogicNode {
 		var object: Object = inputs[1].get();
 		var boneName: String = inputs[2].get();
 		goal = inputs[3].get();
+		poleEnabled = inputs[4].get();
+		pole = inputs[5].get();
+		chainLength = inputs[6].get();
+		maxIterartions = inputs[7].get();
+		precision = inputs[8].get();
+		rollAngle = inputs[9].get();
 
 		if (object == null || goal == null) return;
 		var anim = object.animation != null ? cast(object.animation, BoneAnimation) : null;
@@ -26,11 +39,13 @@ class BoneIKNode extends LogicNode {
 
 		var bone = anim.getBone(boneName);
 
-		function solveBone() {
-			anim.solveIK(bone, goal);
+		if(! poleEnabled) pole = null;
 
-			// anim.removeUpdate(solveBone);
-			// notified = false;
+		function solveBone() {
+			anim.solveIK(bone, goal, precision, maxIterartions, chainLength, pole, rollAngle);
+
+			anim.removeUpdate(solveBone);
+			notified = false;
 		}
 
 		if (!notified) {

--- a/Sources/armory/logicnode/BoneIKNode.hx
+++ b/Sources/armory/logicnode/BoneIKNode.hx
@@ -42,8 +42,10 @@ class BoneIKNode extends LogicNode {
 		if(! poleEnabled) pole = null;
 
 		function solveBone() {
+			//Solve IK
 			anim.solveIK(bone, goal, precision, maxIterartions, chainLength, pole, rollAngle);
 
+			//Remove this method from animation loop after IK
 			anim.removeUpdate(solveBone);
 			notified = false;
 		}

--- a/Sources/armory/logicnode/GetBoneFkIkOnlyNode.hx
+++ b/Sources/armory/logicnode/GetBoneFkIkOnlyNode.hx
@@ -1,0 +1,31 @@
+package armory.logicnode;
+
+import iron.object.Object;
+import iron.object.BoneAnimation;
+
+class GetBoneFkIkOnlyNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Bool {
+		#if arm_skin
+
+		var object: Object = inputs[0].get();
+		var boneName: String = inputs[1].get();
+
+		if (object == null) return null;
+		var anim = object.animation != null ? cast(object.animation, BoneAnimation) : null;
+		if (anim == null) anim = object.getParentArmature(object.name);
+
+		// Get bone in armature
+		var bone = anim.getBone(boneName);
+
+        //Get bone transform in world coordinates
+        return bone.is_IK_FK_only;
+
+
+		#end
+	}
+}

--- a/Sources/armory/logicnode/GetBoneTransformNode.hx
+++ b/Sources/armory/logicnode/GetBoneTransformNode.hx
@@ -1,0 +1,30 @@
+package armory.logicnode;
+
+import iron.object.Object;
+import iron.object.BoneAnimation;
+import iron.math.Mat4;
+
+class GetBoneTransformNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Mat4 {
+		#if arm_skin
+
+		var object: Object = inputs[0].get();
+		var boneName: String = inputs[1].get();
+
+		if (object == null) return null;
+		var anim = object.animation != null ? cast(object.animation, BoneAnimation) : null;
+		if (anim == null) anim = object.getParentArmature(object.name);
+
+		// Get bone in armature
+		var bone = anim.getBone(boneName);
+
+		return anim.getAbsWorldMat(bone);
+
+		#end
+	}
+}

--- a/Sources/armory/logicnode/SetBoneFkIkOnlyNode.hx
+++ b/Sources/armory/logicnode/SetBoneFkIkOnlyNode.hx
@@ -1,0 +1,35 @@
+package armory.logicnode;
+
+import iron.math.Quat;
+import iron.math.Vec4;
+import iron.object.Object;
+import iron.object.BoneAnimation;
+
+class SetBoneFkIkOnlyNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		#if arm_skin
+
+		var object: Object = inputs[1].get();
+		var boneName: String = inputs[2].get();
+		var fk_ik_only: Bool = inputs[3].get();
+
+		if (object == null) return;
+		var anim = object.animation != null ? cast(object.animation, BoneAnimation) : null;
+		if (anim == null) anim = object.getParentArmature(object.name);
+
+		// Get bone in armature
+		var bone = anim.getBone(boneName);
+
+        //Set bone animated by FK or IK only
+        bone.is_IK_FK_only = fk_ik_only;
+
+		runOutput(0);
+
+		#end
+	}
+}

--- a/blender/arm/logicnode/animation/LN_bone_ik.py
+++ b/blender/arm/logicnode/animation/LN_bone_ik.py
@@ -1,10 +1,29 @@
 from arm.logicnode.arm_nodes import *
 
 class BoneIKNode(ArmLogicTreeNode):
-    """Applies inverse kinematics in the given object bone."""
+    """Performs inverse kinematics on the selected armature with specified bone.
+    
+    @input Object: Armature on which IK should be performed.
+
+    @input Bone: Effector or tip bone for the inverse kinematics
+
+    @input Goal Position: Position in world coordinates the effector bone will track to
+
+    @input Enable Pole: Bend IK solution towards pole location
+
+    @input Pole Position: Location of the pole in world coordinates
+
+    @input Chain Length: Number of bones to include in the IK solver including the effector. If set to 0, all bones from effector to the root bone of the armature will be considered.
+    
+    @input Max Iterations: Maximum allowed FABRIK iterations to solve for IK. For longer chains, more iterations are needed.
+
+    @input Precision: Presition of IK to stop at. It is described as a tolerence in length. Typically 0.01 is a good value.
+
+    @input Roll Angle: Roll the bones along their local axis with specified radians. set 0 for no extra roll.
+    """
     bl_idname = 'LNBoneIKNode'
     bl_label = 'Bone IK'
-    arm_version = 1
+    arm_version = 2
     arm_section = 'armature'
 
     def init(self, context):
@@ -12,6 +31,22 @@ class BoneIKNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('NodeSocketString', 'Bone')
-        self.add_input('NodeSocketVector', 'Goal')
+        self.add_input('NodeSocketVector', 'Goal Position')
+        self.add_input('NodeSocketBool', 'Enable Pole')
+        self.add_input('NodeSocketVector', 'Pole Position')
+        self.add_input('NodeSocketInt', 'Chain Length')
+        self.add_input('NodeSocketInt', 'Max Iterations', 10)
+        self.add_input('NodeSocketFloat', 'Precision', 0.01)
+        self.add_input('NodeSocketFloat', 'Roll Angle')
+
 
         self.add_output('ArmNodeSocketAction', 'Out')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+        
+        return NodeReplacement(
+            'LNBoneIKNode', self.arm_version, 'LNBoneIKNode', 2,
+            in_socket_mapping={0:0, 1:1, 2:2, 3:3}, out_socket_mapping={0:0}
+        )

--- a/blender/arm/logicnode/animation/LN_get_bone_fk_ik_only.py
+++ b/blender/arm/logicnode/animation/LN_get_bone_fk_ik_only.py
@@ -1,0 +1,14 @@
+from arm.logicnode.arm_nodes import *
+
+class GetBoneFkIkOnlyNode(ArmLogicTreeNode):
+    """Get if a particular bone is animated by Forward kinematics or Inverse kinematics only."""
+    bl_idname = 'LNGetBoneFkIkOnlyNode'
+    bl_label = 'Get Bone FK IK Only'
+    arm_version = 1
+    arm_section = 'armature'
+
+    def init(self, context):
+        super(GetBoneFkIkOnlyNode, self).init(context)
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('NodeSocketString', 'Bone')
+        self.add_output('NodeSocketBool', 'FK or IK only')

--- a/blender/arm/logicnode/animation/LN_get_bone_transform.py
+++ b/blender/arm/logicnode/animation/LN_get_bone_transform.py
@@ -1,0 +1,14 @@
+from arm.logicnode.arm_nodes import *
+
+class GetBoneTransformNode(ArmLogicTreeNode):
+    """Returns bone transform in world space."""
+    bl_idname = 'LNGetBoneTransformNode'
+    bl_label = 'Get Bone Transform'
+    arm_version = 1
+    arm_section = 'armature'
+
+    def init(self, context):
+        super(GetBoneTransformNode, self).init(context)
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('NodeSocketString', 'Bone')
+        self.add_output('NodeSocketShader', 'Transform')

--- a/blender/arm/logicnode/animation/LN_set_bone_fk_ik_only.py
+++ b/blender/arm/logicnode/animation/LN_set_bone_fk_ik_only.py
@@ -1,0 +1,17 @@
+from arm.logicnode.arm_nodes import *
+
+class SetBoneFkIkOnlyNode(ArmLogicTreeNode):
+    """Set particular bone to be animated by Forward kinematics or Inverse kinematics only. All other animations will be ignored"""
+    bl_idname = 'LNSetBoneFkIkOnlyNode'
+    bl_label = 'Set Bone FK IK Only'
+    arm_version = 1
+    arm_section = 'armature'
+
+    def init(self, context):
+        super(SetBoneFkIkOnlyNode, self).init(context)
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('NodeSocketString', 'Bone')
+        self.add_input('NodeSocketBool', 'FK or IK only')
+
+        self.add_output('ArmNodeSocketAction', 'Out')


### PR DESCRIPTION
Requires https://github.com/armory3d/iron/pull/126

This PR introduces 

1. An upgraded Inverse Kinematics node, that includes pole location, bone roll, chain length and more. For better control IK and FK is now solved only when called. Before, once called FK and IK were solved every frame and could not be stopped.
![image](https://user-images.githubusercontent.com/55564981/119017022-dc79bd00-b99a-11eb-9606-4b0280a5ca50.png)

2. Nodes to set and get if a bone is controlled only by forward/inverse kinematics and should ignore other animations
![image](https://user-images.githubusercontent.com/55564981/119017273-21055880-b99b-11eb-8f31-526921a8014d.png)

3. Node to get a bone's transform in world space.
![image](https://user-images.githubusercontent.com/55564981/119017378-3c706380-b99b-11eb-8434-3cff60973ab8.png)

4. This PR also improves usability of the FK and IK nodes so they can now be used in a sequence to get better results.
![image](https://user-images.githubusercontent.com/55564981/119018962-fb794e80-b99c-11eb-930e-85a683f5f2a1.png)

