### PR TITLE
Merge node: add execution mode and output for input index

### DIFF
--- a/Sources/armory/logicnode/MergeNode.hx
+++ b/Sources/armory/logicnode/MergeNode.hx
@@ -2,11 +2,31 @@ package armory.logicnode;
 
 class MergeNode extends LogicNode {
 
+	/** Execution mode. **/
+	public var property0: String;
+
+	var lastInputIndex = -1;
+
 	public function new(tree: LogicTree) {
 		super(tree);
+		tree.notifyOnLateUpdate(lateUpdate);
 	}
 
 	override function run(from: Int) {
+		// Check if there already were executions on the same frame
+		if (lastInputIndex != -1 && property0 == "once_per_frame") {
+			return;
+		}
+
+		lastInputIndex = from;
 		runOutput(0);
+	}
+
+	override function get(from: Int): Dynamic {
+		return lastInputIndex;
+	}
+
+	function lateUpdate() {
+		lastInputIndex = -1;
 	}
 }

--- a/blender/arm/logicnode/logic/LN_merge.py
+++ b/blender/arm/logicnode/logic/LN_merge.py
@@ -1,7 +1,23 @@
 from arm.logicnode.arm_nodes import *
 
+
 class MergeNode(ArmLogicTreeNode):
-    """Activates the output when any connected input is activated.
+    """Activates the output when at least one connected input is activated.
+    If multiple inputs are active, the behaviour is specified by the
+    `Execution Mode` option.
+
+    @output Active Input Index: [*Available if Execution Mode is set to
+        Once Per Input*] The index of the last input that activated the output,
+        -1 if there was no execution yet on the current frame.
+
+    @option Execution Mode: The node's behaviour if multiple inputs are
+        active on the same frame.
+
+        - `Once Per Input`: If multiple inputs are active on one frame, activate
+            the output for each active input individually (simple forwarding).
+
+        - `Once Per Frame`: If multiple inputs are active on one frame,
+            trigger the output only once.
 
     @option New: Add a new input socket.
     @option X Button: Remove the lowermost input socket."""
@@ -10,6 +26,21 @@ class MergeNode(ArmLogicTreeNode):
     arm_section = 'flow'
     arm_version = 1
 
+    def update_exec_mode(self, context):
+        self.outputs['Active Input Index'].hide = self.property0 == 'once_per_frame'
+
+    property0: EnumProperty(
+        name='Execution Mode',
+        description='The node\'s behaviour if multiple inputs are active on the same frame',
+        items=[('once_per_input', 'Once Per Input',
+                'If multiple inputs are active on one frame, activate the'
+                ' output for each active input individually (simple forwarding)'),
+               ('once_per_frame', 'Once Per Frame',
+                'If multiple inputs are active on one frame, trigger the output only once')],
+        default='once_per_input',
+        update=update_exec_mode,
+    )
+
     def __init__(self):
         super(MergeNode, self).__init__()
         array_nodes[str(id(self))] = self
@@ -17,10 +48,12 @@ class MergeNode(ArmLogicTreeNode):
     def init(self, context):
         super(MergeNode, self).init(context)
         self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('NodeSocketInt', 'Active Input Index')
 
     def draw_buttons(self, context, layout):
-        row = layout.row(align=True)
+        layout.prop(self, 'property0', text='')
 
+        row = layout.row(align=True)
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
         op.node_index = str(id(self))
         op.socket_type = 'ArmNodeSocketAction'

--- a/blender/arm/logicnode/replacement.py
+++ b/blender/arm/logicnode/replacement.py
@@ -254,7 +254,8 @@ def replace_all():
                     print(f"A node whose class doesn't exist was found in node tree \"{tree_name}\"", file=reportf)
                 elif error_type == 'update failed':
                     print(f"A node of type {node_class} in tree \"{tree_name}\" failed to be updated, "
-                          f"because there is no (longer?) an update routine for this version of the node.", file=reportf)
+                          f"because there is no (longer?) an update routine for this version of the node. Original exception:"
+                          "\n" + tb + "\n", file=reportf)
                 elif error_type == 'future version':
                     print(f"A node of type {node_class} in tree \"{tree_name}\" seemingly comes from a future version of armory. "
                           f"Please check whether your version of armory is up to date", file=reportf)


### PR DESCRIPTION
Closes https://github.com/armory3d/armory/issues/2189 and requires https://github.com/armory3d/armory_tools/pull/8 for the documentation.

![Node screenshot](https://user-images.githubusercontent.com/17685000/119204851-e84aa980-ba96-11eb-8d91-e11c174c64c0.png)

There is now a dropdown that lets you choose whether the node should activate its output for each active input individually or only once per frame for the first active input. If the first mode is selected, there is a new output that lets you access the index of the input that activated the node.