### PR TITLE
Fix Layer Weight node and multiple cycles shaders in one material

### DIFF
--- a/Shaders/std/sky.glsl
+++ b/Shaders/std/sky.glsl
@@ -60,7 +60,7 @@ float random(vec2 coords) {
 
 vec3 nishita_lookupLUT(const float height, const float sunTheta) {
 	vec2 coords = vec2(
-	sqrt(height * (1 / nishita_atmo_radius)),
+		sqrt(height * (1 / nishita_atmo_radius)),
 		0.5 + 0.5 * sign(sunTheta - HALF_PI) * sqrt(abs(sunTheta * (1 / HALF_PI) - 1))
 	);
 	return textureLod(nishitaLUT, coords, 0.0).rgb;
@@ -125,7 +125,7 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 		// Idea behind this: "Rotate" everything by iPos (-> iPos is the new zenith) and then all calculations for the
 		// inner integral only depend on the sample height (iHeight) and sunTheta (angle between sun and new zenith).
 		float sunTheta = acos(dot(normalize(iPos), normalize(pSun)));
-		vec3 jODepth = nishita_lookupLUT(iHeight, sunTheta);// * vec3(14000000 / 255, 14000000 / 255, 2000000 / 255);
+		vec3 jODepth = nishita_lookupLUT(iHeight, sunTheta);
 
 		// Apply dithering to reduce visible banding
 		jODepth += mix(-1000, 1000, random(r.xy));

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -204,6 +204,8 @@ def parse_shader(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> Tuple[st
         'BSDF_VELVET': nodes_shader.parse_bsdfvelvet,
     }
 
+    state.reset_outs()
+
     if node.type in node_parser_funcs:
         node_parser_funcs[node.type](node, socket, state)
 

--- a/blender/arm/material/make_attrib.py
+++ b/blender/arm/material/make_attrib.py
@@ -34,13 +34,11 @@ def write_vertpos(vert):
 
 
 def write_norpos(con_mesh: shader.ShaderContext, vert: shader.Shader, declare=False, write_nor=True):
-    prep = ''
-    if declare:
-        prep = 'vec3 '
     is_bone = con_mesh.is_elem('bone')
     if is_bone:
         make_skin.skin_pos(vert)
     if write_nor:
+        prep = 'vec3 ' if declare else ''
         if is_bone:
             make_skin.skin_nor(vert, prep)
         else:

--- a/blender/arm/material/make_depth.py
+++ b/blender/arm/material/make_depth.py
@@ -33,8 +33,6 @@ def make(context_id, rpasses, shadowmap=False):
     parse_custom_particle = (cycles.node_by_name(mat_state.nodes, 'ArmCustomParticleNode') is not None)
 
     if parse_opacity:
-        frag.write('vec3 n;') # Discard at compile time
-        frag.write('float dotNV;')
         frag.write('float opacity;')
 
     if con_depth.is_elem('bone'):

--- a/blender/arm/material/make_finalize.py
+++ b/blender/arm/material/make_finalize.py
@@ -1,7 +1,10 @@
 import bpy
-import arm.material.make_tess as make_tess
 
-def make(con_mesh):
+import arm.material.make_tess as make_tess
+from arm.material.shader import ShaderContext
+
+
+def make(con_mesh: ShaderContext):
     vert = con_mesh.vert
     frag = con_mesh.frag
     geom = con_mesh.geom
@@ -32,7 +35,7 @@ def make(con_mesh):
 
     write_wpos = False
     if frag.contains('vVec') and not frag.contains('vec3 vVec'):
-        if tese != None:
+        if tese is not None:
             tese.add_out('vec3 eyeDir')
             tese.add_uniform('vec3 eye', '_cameraPosition')
             tese.write('eyeDir = eye - wposition;')
@@ -48,7 +51,7 @@ def make(con_mesh):
     export_wpos = False
     if frag.contains('wposition') and not frag.contains('vec3 wposition'):
         export_wpos = True
-    if tese != None:
+    if tese is not None:
         export_wpos = True
     if vert.contains('wposition'):
         write_wpos = True
@@ -67,7 +70,7 @@ def make(con_mesh):
         vert.add_uniform('float posUnpack', link='_posUnpack')
         vert.write_attrib('mposition = spos.xyz * posUnpack;')
 
-    if tese != None:
+    if tese is not None:
         if frag_mpos:
             make_tess.interpolate(tese, 'mposition', 3, declare_out=True)
         elif tese.contains('mposition') and not tese.contains('vec3 mposition'):
@@ -89,7 +92,7 @@ def make(con_mesh):
         vert.write_attrib('if (dim.y == 0) bposition.y = 0;')
         vert.write_attrib('if (dim.x == 0) bposition.x = 0;')
 
-    if tese != None:
+    if tese is not None:
         if frag_bpos:
             make_tess.interpolate(tese, 'bposition', 3, declare_out=True)
         elif tese.contains('bposition') and not tese.contains('vec3 bposition'):
@@ -110,7 +113,7 @@ def make(con_mesh):
         vert.write('wtangent = normalize(N * tang.xyz);')
         vert.write_pre = False
 
-    if tese != None:
+    if tese is not None:
         if frag_wtan:
             make_tess.interpolate(tese, 'wtangent', 3, declare_out=True)
         elif tese.contains('wtangent') and not tese.contains('vec3 wtangent'):

--- a/blender/arm/material/make_finalize.py
+++ b/blender/arm/material/make_finalize.py
@@ -13,6 +13,23 @@ def make(con_mesh):
     if frag.contains('dotNV') and not frag.contains('float dotNV'):
         frag.write_init('float dotNV = max(dot(n, vVec), 0.0);')
 
+        # n is not always defined yet (in some shadowmap shaders e.g.)
+        if not frag.contains('vec3 n'):
+            vert.add_out('vec3 wnormal')
+            vert.add_uniform('mat3 N', '_normalMatrix')
+            vert.write_attrib('wnormal = normalize(N * vec3(nor.xy, pos.w));')
+            frag.write_attrib('vec3 n = normalize(wnormal);')
+
+            # If not yet added, add nor vertex data
+            vertex_elems = con_mesh.data['vertex_elements']
+            has_normals = False
+            for elem in vertex_elems:
+                if elem['name'] == 'nor':
+                    has_normals = True
+                    break
+            if not has_normals:
+                vertex_elems.append({'name': 'nor', 'data': 'short2norm'})
+
     write_wpos = False
     if frag.contains('vVec') and not frag.contains('vec3 vVec'):
         if tese != None:

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -64,6 +64,16 @@ class ParserState:
         self.out_opacity: floatstr = '1.0'
         self.out_emission: floatstr = '0.0'
 
+    def reset_outs(self):
+        """Reset the shader output values to their default values."""
+        self.out_basecol = 'vec3(0.8)'
+        self.out_roughness = '0.0'
+        self.out_metallic = '0.0'
+        self.out_occlusion = '1.0'
+        self.out_specular = '1.0'
+        self.out_opacity = '1.0'
+        self.out_emission = '0.0'
+
     def get_outs(self) -> Tuple[vec3str, floatstr, floatstr, floatstr, floatstr, floatstr, floatstr]:
         """Return the shader output values as a tuple."""
         return (self.out_basecol, self.out_roughness, self.out_metallic, self.out_occlusion, self.out_specular,


### PR DESCRIPTION
This fixes https://github.com/armory3d/armory/issues/2186.

The issue was caused by the Layer Weight node which needs to access normals that were not available in the generated shadowmap shaders. Because the Layer Weight node might change the opacity of objects depending on normals and thus also should affect shadowmap rendering, the normals are now added to the shader if this is not yet the case (e.g. this is already done when displacement is enabled).

@luboslenco do you remember what the following comment (on now removed code) meant?

https://github.com/armory3d/armory/blob/138386f02a031e958daec1d0dca1ab2af1cf7f45/blender/arm/material/make_depth.py#L35-L37

How is something discarded at compile time (particularly by adding `vec3 n`)? Or is this just related to the discarding of fragments below a certain opacity threshold? If there is some fancy compile time optimization, I might need to revise my solution.

There also is [another comment](https://github.com/armory3d/armory/blob/138386f02a031e958daec1d0dca1ab2af1cf7f45/blender/arm/material/make_finalize.py#L11-L12) in `make_finalize` that I'm not sure how it is meant. I had an idea (that I yet have to test) that might make the shader export simpler and remove some code duplicates, which sounds a bit like the comment. The idea is to add a set of variables/values that a material can "require" while parsing it. Requirements can add other requirements transitively and at the end, code for all of those is added to the shader, for example a shader requires `dotNV` which also needs `n` which needs `wnormal` to exist. What do you think of this? Is this what was meant by the comment?

During fixing of the above, I found another issue that could happen if multiple cycles shaders were combined in one material. It's just a few lines of code, so I included it in this PR as well as some minor code cleanups.