### PR TITLE
Fix rendering multiple movie textures 

### DIFF
--- a/Sources/armory/trait/internal/MovieTexture.hx
+++ b/Sources/armory/trait/internal/MovieTexture.hx
@@ -2,9 +2,16 @@ package armory.trait.internal;
 
 import kha.Image;
 import kha.Video;
+
 import iron.Trait;
 import iron.object.MeshObject;
 
+/**
+	Replaces the diffuse texture of the first material of the trait's object
+	with a video texture.
+
+	@see https://github.com/armory3d/armory_examples/tree/master/material_movie
+**/
 class MovieTexture extends Trait {
 
 	/**

--- a/Sources/armory/trait/internal/MovieTexture.hx
+++ b/Sources/armory/trait/internal/MovieTexture.hx
@@ -8,8 +8,7 @@ import iron.object.MeshObject;
 class MovieTexture extends Trait {
 
 	var video: Video;
-	public static var image: Image;
-	public static var created = false;
+	var image: Image;
 
 	var videoName: String;
 
@@ -33,10 +32,7 @@ class MovieTexture extends Trait {
 
 		this.videoName = videoName;
 
-		if (!created) {
-			created = true;
-			notifyOnInit(init);
-		}
+		notifyOnInit(init);
 	}
 
 	function init() {
@@ -46,7 +42,7 @@ class MovieTexture extends Trait {
 
 			image = Image.createRenderTarget(getPower2(video.width()), getPower2(video.height()));
 
-			var o = cast(object, iron.object.MeshObject);
+			var o = cast(object, MeshObject);
 			o.materials[0].contexts[0].textures[0] = image; // Override diffuse texture
 			notifyOnRender2D(render);
 		});


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1562.

Previously, the rendertarget used for rendering movies was static. This PR makes the rendertarget non-static and instead adds a cache that makes it possible to reuse rendertargets with the same size to lower memory consumption compared to not using a cache.