### PR TITLE
Fix threading and publishing in background mode

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -220,6 +220,9 @@ def register():
 
 
 def unregister():
+    bpy.app.timers.unregister(poll_threads)
+    bpy.app.timers.unregister(always)
+
     bpy.app.handlers.load_post.remove(on_load_post)
     bpy.app.handlers.depsgraph_update_post.remove(on_depsgraph_update_post)
     # bpy.app.handlers.undo_post.remove(on_undo_post)

--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -90,16 +90,17 @@ def send_operator(op):
         else: # Rebuild
             make.patch()
 
-def always():
+
+def always() -> float:
     # Force ui redraw
-    if state.redraw_ui and context_screen != None:
+    if state.redraw_ui and context_screen is not None:
         for area in context_screen.areas:
             if area.type == 'VIEW_3D' or area.type == 'PROPERTIES':
                 area.tag_redraw()
         state.redraw_ui = False
     # TODO: depsgraph.updates only triggers material trees
     space = arm.utils.logic_editor_space(context_screen)
-    if space != None:
+    if space is not None:
         space.node_tree.arm_cached = False
     return 0.5
 

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -1,17 +1,16 @@
+import errno
 import glob
 import json
 import os
+from queue import Queue
+import shlex
 import shutil
-import time
 import stat
 import subprocess
 import threading
-import webbrowser
-import shlex
-import errno
-import math
+import time
 from typing import Callable
-from queue import Queue
+import webbrowser
 
 import bpy
 

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -10,6 +10,8 @@ import webbrowser
 import shlex
 import errno
 import math
+from typing import Callable
+from queue import Queue
 
 import bpy
 
@@ -28,14 +30,41 @@ import arm.write_data as write_data
 scripts_mtime = 0 # Monitor source changes
 profile_time = 0
 
-def run_proc(cmd, done):
-    def fn(p, done):
-        p.wait()
-        if done != None:
+# Queue of threads and their done callbacks. Item format: [thread, done]
+thread_callback_queue = Queue(maxsize=0)
+
+
+def run_proc(cmd, done: Callable) -> subprocess.Popen:
+    """Creates a subprocess with the given command and returns it.
+
+    If Blender is not running in background mode, a thread is spawned
+    that waits until the subprocess has finished executing to not freeze
+    the UI, otherwise (in background mode) execution is blocked until
+    the subprocess has finished.
+
+    If `done` is not `None`, it is called afterwards in the main thread.
+    """
+    use_thread = not bpy.app.background
+
+    def wait_for_proc(proc: subprocess.Popen):
+        proc.wait()
+
+        if use_thread:
+            # Put the done callback into the callback queue so that it
+            # can be received by a polling function in the main thread
+            thread_callback_queue.put([threading.current_thread(), done], block=True)
+        else:
             done()
+
     p = subprocess.Popen(cmd)
-    threading.Thread(target=fn, args=(p, done)).start()
+
+    if use_thread:
+        threading.Thread(target=wait_for_proc, args=(p,)).start()
+    else:
+        wait_for_proc(p)
+
     return p
+
 
 def compile_shader_pass(res, raw_shaders_path, shader_name, defs, make_variants):
     os.chdir(raw_shaders_path + '/' + shader_name)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -626,7 +626,6 @@ class ARM_PT_ArmoryExporterPanel(bpy.types.Panel):
         row = layout.row(align=True)
         row.alignment = 'EXPAND'
         row.scale_y = 1.3
-        row.enabled = wrd.arm_exporterlist_index >= 0 and len(wrd.arm_exporterlist) > 0
         row.operator("arm.build_project", icon="MOD_BUILD")
         # row.operator("arm.patch_project")
         row.operator("arm.publish_project", icon="EXPORT")
@@ -1053,9 +1052,14 @@ class ArmoryStopButton(bpy.types.Operator):
         return{'FINISHED'}
 
 class ArmoryBuildProjectButton(bpy.types.Operator):
-    '''Build and compile project'''
+    """Build and compile project"""
     bl_idname = 'arm.build_project'
     bl_label = 'Build'
+
+    @classmethod
+    def poll(cls, context):
+        wrd = bpy.data.worlds['Arm']
+        return wrd.arm_exporterlist_index >= 0 and len(wrd.arm_exporterlist) > 0
 
     def execute(self, context):
         # Compare version Blender and Armory (major, minor)
@@ -1093,9 +1097,14 @@ class ArmoryBuildProjectButton(bpy.types.Operator):
         return{'FINISHED'}
 
 class ArmoryPublishProjectButton(bpy.types.Operator):
-    '''Build project ready for publishing'''
+    """Build project ready for publishing."""
     bl_idname = 'arm.publish_project'
     bl_label = 'Publish'
+
+    @classmethod
+    def poll(cls, context):
+        wrd = bpy.data.worlds['Arm']
+        return wrd.arm_exporterlist_index >= 0 and len(wrd.arm_exporterlist) > 0
 
     def execute(self, context):
         # Compare version Blender and Armory (major, minor)


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2237. Please refer to that issue for a detailed explanation of this PR.

**Short summary of the changes:**
- If Blender is run in the background, there is no longer threading to wait for subprocesses, instead the main thread waits and blocks execution. There is no UI that can freeze and threading leads to problems because Blender finishes with the executing script before the thread ends, resulting in crashes and error messages.
- If Blender is run with UI, the `done` callback that is executed after a subprocess has finished is no longer called in the thread that waits for the subprocess but instead is called in the main thread to have access to Blender data without crashing. This is solved via a queue between the threads that sends the callback to the main thread. For this the main thread has to use a poll function which does not work in background mode (timers don't seem to work then).

While testing the linked issue I found another small issue that allowed the build operators to be called without having an exporter configuration which this PR also fixes.