### PR TITLE
Add option for relative physics constraint

### DIFF
--- a/Sources/armory/trait/physics/bullet/PhysicsConstraintExportHelper.hx
+++ b/Sources/armory/trait/physics/bullet/PhysicsConstraintExportHelper.hx
@@ -18,8 +18,9 @@ class PhysicsConstraintExportHelper extends iron.Trait {
 	var breakingThreshold: Float;
 	var limits: Array<Float>;
 	var constraintAdded: Bool = false;
+	var relativeConstraint: Bool = false;
 
-	public function new(body1: String, body2: String, type: Int, disableCollisions: Bool, breakingThreshold: Float, limits: Array<Float> = null) {
+	public function new(body1: String, body2: String, type: Int, disableCollisions: Bool, breakingThreshold: Float, relatieConstraint: Bool = false, limits: Array<Float> = null) {
 		super();
 
 		this.body1 = body1;
@@ -27,14 +28,26 @@ class PhysicsConstraintExportHelper extends iron.Trait {
 		this.type = type;
 		this.disableCollisions = disableCollisions;
 		this.breakingThreshold = breakingThreshold;
+		this.relativeConstraint = relatieConstraint;
 		this.limits = limits;
 		notifyOnInit(init);
 		notifyOnUpdate(update);
 	}
 
 	function init() {
-		var target1 = Scene.active.getChild(body1);
-		var target2 = Scene.active.getChild(body2);
+		var target1; 
+		var target2;
+
+		if(relativeConstraint) {
+
+			target1 = object.parent.getChild(body1);
+			target2 = object.parent.getChild(body2);
+		}
+		else {
+			
+			target1 = Scene.active.getChild(body1);
+			target2 = Scene.active.getChild(body2);
+		}
 		object.addTrait(new PhysicsConstraint(target1, target2, type, disableCollisions, breakingThreshold, limits));
 		constraintAdded = true;
 	}

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2440,7 +2440,7 @@ Make sure the mesh only has tris/quads.""")
             # Rigid body constraint
             rbc = bobject.rigid_body_constraint
             if rbc is not None and rbc.enabled:
-                self.add_rigidbody_constraint(o, rbc)
+                self.add_rigidbody_constraint(o, bobject, rbc)
 
         # Camera traits
         if type is NodeType.CAMERA:
@@ -2747,7 +2747,7 @@ Make sure the mesh only has tris/quads.""")
         o['traits'].append(out_trait)
 
     @staticmethod
-    def add_rigidbody_constraint(o, rbc):
+    def add_rigidbody_constraint(o, bobject, rbc):
         rb1 = rbc.object1
         rb2 = rbc.object2
         if rb1 is None or rb2 is None:
@@ -2766,7 +2766,8 @@ Make sure the mesh only has tris/quads.""")
                 "'" + rb1.name + "'",
                 "'" + rb2.name + "'",
                 str(rbc.disable_collisions).lower(),
-                str(breaking_threshold)
+                str(breaking_threshold),
+                str(bobject.arm_relative_physics_constraint).lower()
             ]
         }
         if rbc.type == "FIXED":

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -286,6 +286,7 @@ def init_properties():
             default=(True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False),
             size=20,
             subtype='LAYER')
+    bpy.types.Object.arm_relative_physics_constraint = BoolProperty(name="Relative Physics Constraint", description="Add physics constraint relative to the parent object or collection when spawned", default=False)
     bpy.types.Object.arm_animation_enabled = BoolProperty(name="Animation", description="Enable skinning & timeline animation", default=True)
     bpy.types.Object.arm_tilesheet = StringProperty(name="Tilesheet", description="Set tilesheet animation", default='')
     bpy.types.Object.arm_tilesheet_action = StringProperty(name="Tilesheet Action", description="Set startup action", default='')

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -211,8 +211,11 @@ class ARM_PT_PhysicsPropsPanel(bpy.types.Panel):
             layout.prop(obj, 'arm_rb_trigger')
             layout.prop(obj, 'arm_rb_ccd')
 
-        if obj.soft_body != None:
+        if obj.soft_body is not None:
             layout.prop(obj, 'arm_soft_body_margin')
+        
+        if obj.rigid_body_constraint is not None:
+            layout.prop(obj, 'arm_relative_physics_constraint')
 
 # Menu in data region
 class ARM_PT_DataPropsPanel(bpy.types.Panel):


### PR DESCRIPTION
This PR adds a new property to the physics constraint tab:
![image](https://user-images.githubusercontent.com/55564981/123333548-2f1e3a00-d542-11eb-9884-a665350b77d4.png)


This allows for adding physics constraints relative to its parent object or collection. This way, when a collection with objects having physics constraints is spawned at runtime, the constraint is added between these new objects.

Previously, the constraints were added only between an already existing object and the new object.