### PR TITLE
Fix visual artifacts caused by invalid gbuffer2 on OpenGL

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -21,7 +21,9 @@
 uniform sampler2D gbufferD;
 uniform sampler2D gbuffer0;
 uniform sampler2D gbuffer1;
+#ifdef _gbuffer2
 uniform sampler2D gbuffer2;
+#endif
 
 #ifdef _VoxelAOvar
 uniform sampler3D voxels;
@@ -206,7 +208,9 @@ void main() {
 	vec3 v = normalize(eye - p);
 	float dotNV = max(dot(n, v), 0.0);
 
+#ifdef _gbuffer2
 	vec4 g2 = textureLod(gbuffer2, texCoord, 0.0);
+#endif
 
 #ifdef _MicroShadowing
 	occspec.x = mix(1.0, occspec.x, dotNV); // AO Fresnel
@@ -221,14 +225,16 @@ void main() {
 
 	vec3 envl = shIrradiance(n, shirr);
 
-	if (g2.b < 0.5) {
-		envl = envl;
-	} else {
-		envl = vec3(1.0);
-	}
+	#ifdef _gbuffer2
+		if (g2.b < 0.5) {
+			envl = envl;
+		} else {
+			envl = vec3(1.0);
+		}
+	#endif
 
 	#ifdef _EnvTex
-	envl /= PI;
+		envl /= PI;
 	#endif
 #else
 	vec3 envl = vec3(1.0);


### PR DESCRIPTION
This PR fixes the second example from issue https://github.com/armory3d/armory/issues/2166 and probably also the original issue. @knowledgenude can you please test this if you have the project still around?

The reason for the artifacts was that `gbuffer2` could be accessed even if it was not used, thus it was filled with left-over values from other usages on OpenGL. On DirectX this was not an issue (probably undefined behaviour).