### PR TITLE
ArcBall axis trait prop

### DIFF
--- a/Sources/armory/trait/ArcBall.hx
+++ b/Sources/armory/trait/ArcBall.hx
@@ -6,6 +6,9 @@ import iron.math.Vec4;
 
 class ArcBall extends Trait {
 
+	@prop
+	public var axis = new Vec4(0, 0, 1);
+	
 	public function new() {
 		super();
 
@@ -17,10 +20,8 @@ class ArcBall extends Trait {
 
 		var mouse = Input.getMouse();
 		if (mouse.down()) {
-			object.transform.rotate(new Vec4(0, 0, 1), -mouse.movementX / 100);
-			object.transform.buildMatrix();
+			object.transform.rotate(axis, -mouse.movementX / 100);
 			object.transform.rotate(object.transform.world.right(), -mouse.movementY / 100);
-			object.transform.buildMatrix();
 		}
 	}
 }


### PR DESCRIPTION
Minor ArcBall improvements.
- Removes unnecessary calls to `buildMatrix`
- Adds `axis` trait prop to have control over direction and speed of the rotation