### PR TITLE
Canvas: fix using non-default fonts

### DIFF
--- a/Sources/armory/trait/internal/CanvasScript.hx
+++ b/Sources/armory/trait/internal/CanvasScript.hx
@@ -40,20 +40,27 @@ class CanvasScript extends Trait {
 					Canvas.themes.push(armory.ui.Themes.light);
 				}
 
-				iron.data.Data.getFont(font, function(f: kha.Font) {
+				iron.data.Data.getFont(font, function(defaultFont: kha.Font) {
 					var c: TCanvas = haxe.Json.parse(blob.toString());
 					if (c.theme == null) c.theme = Canvas.themes[0].NAME;
-					cui = new Zui({font: f, theme: Canvas.getTheme(c.theme)});
+					cui = new Zui({font: defaultFont, theme: Canvas.getTheme(c.theme)});
 
 					if (c.assets == null || c.assets.length == 0) canvas = c;
 					else { // Load canvas assets
 						var loaded = 0;
 						for (asset in c.assets) {
 							var file = asset.name;
-							iron.data.Data.getImage(file, function(image: kha.Image) {
-								Canvas.assetMap.set(asset.id, image);
-								if (++loaded >= c.assets.length) canvas = c;
-							});
+							if (Canvas.isFontAsset(file)) {
+								iron.data.Data.getFont(file, function(f: kha.Font) {
+									Canvas.assetMap.set(asset.id, f);
+									if (++loaded >= c.assets.length) canvas = c;
+								});
+							} else {
+								iron.data.Data.getImage(file, function(image: kha.Image) {
+									Canvas.assetMap.set(asset.id, image);
+									if (++loaded >= c.assets.length) canvas = c;
+								});
+							}
 						}
 					}
 				});

--- a/Sources/armory/ui/Canvas.hx
+++ b/Sources/armory/ui/Canvas.hx
@@ -258,7 +258,7 @@ class Canvas {
 		return Std.int(f * _ui.SCALE());
 	}
 
-	static inline function isFontAsset(assetName: Null<String>): Bool {
+	public static inline function isFontAsset(assetName: Null<String>): Bool {
 		return assetName != null && StringTools.endsWith(assetName.toLowerCase(), ".ttf");
 	}
 


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2249, non-default fonts were always loaded as a `kha.Image` and thus had no `height()` function.