### PR TITLE
Fix accidental module reloading caused by name conflicts of global vars

### DIFF
--- a/blender/arm/__init__.py
+++ b/blender/arm/__init__.py
@@ -1,8 +1,26 @@
 import importlib
+import sys
 import types
 
 # This gets cleared if this package/the __init__ module is reloaded
 _module_cache: dict[str, types.ModuleType] = {}
+
+
+def enable_reload(module_name: str):
+    """Enable reloading for the next time the module with `module_name`
+    is executed.
+    """
+    mod = sys.modules[module_name]
+    setattr(mod, module_name.replace('.', '_') + "_DO_RELOAD_MODULE", True)
+
+
+def is_reload(module_name: str) -> bool:
+    """True if the module  given by `module_name` should reload the
+    modules it imports. This is the case if `enable_reload()` was called
+    for the module before.
+    """
+    mod = sys.modules[module_name]
+    return hasattr(mod, module_name.replace('.', '_') + "_DO_RELOAD_MODULE")
 
 
 def reload_module(module: types.ModuleType) -> types.ModuleType:

--- a/blender/arm/api.py
+++ b/blender/arm/api.py
@@ -2,16 +2,16 @@ from typing import Callable, Dict, Optional
 
 from bpy.types import Material, UILayout
 
+import arm
 from arm.material.shader import ShaderContext
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     arm.material.shader = arm.reload_module(arm.material.shader)
     from arm.material.shader import ShaderContext
 else:
     drivers: Dict[str, Dict] = dict()
 
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def add_driver(driver_name: str,

--- a/blender/arm/assets.py
+++ b/blender/arm/assets.py
@@ -6,11 +6,11 @@ import bpy
 import arm.log as log
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     log = arm.reload_module(log)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 assets = []
 reserved_names = ['return.']

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -32,7 +32,7 @@ import arm.material.mat_batch as mat_batch
 import arm.utils
 import arm.profiler
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     assets = arm.reload_module(assets)
     exporter_opt = arm.reload_module(exporter_opt)
     log = arm.reload_module(log)
@@ -43,7 +43,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.utils = arm.reload_module(arm.utils)
     arm.profiler = arm.reload_module(arm.profiler)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 @unique

--- a/blender/arm/exporter_opt.py
+++ b/blender/arm/exporter_opt.py
@@ -9,11 +9,11 @@ import numpy as np
 import arm.log as log
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     log = arm.reload_module(log)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 class Vertex:

--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -6,6 +6,7 @@ import sys
 import bpy
 from bpy.app.handlers import persistent
 
+import arm
 import arm.api
 import arm.live_patch as live_patch
 import arm.logicnode.arm_nodes as arm_nodes
@@ -15,7 +16,7 @@ import arm.make_state as state
 import arm.props as props
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.api = arm.reload_module(arm.api)
     live_patch = arm.reload_module(live_patch)
     arm_nodes = arm.reload_module(arm_nodes)
@@ -25,7 +26,7 @@ if "DO_RELOAD_MODULE" in locals():
     props = arm.reload_module(props)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 @persistent

--- a/blender/arm/keymap.py
+++ b/blender/arm/keymap.py
@@ -1,12 +1,12 @@
 import bpy
 
+import arm
 import arm.props_ui as props_ui
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     props_ui = arm.reload_module(props_ui)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 arm_keymaps = []
 

--- a/blender/arm/live_patch.py
+++ b/blender/arm/live_patch.py
@@ -13,7 +13,7 @@ import arm.make_state as state
 import arm.node_utils
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.assets = arm.reload_module(arm.assets)
     arm.exporter = arm.reload_module(arm.exporter)
     from arm.exporter import ArmoryExporter
@@ -25,7 +25,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.node_utils = arm.reload_module(arm.node_utils)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
     patch_id = 0
     """Current patch id"""

--- a/blender/arm/logicnode/__init__.py
+++ b/blender/arm/logicnode/__init__.py
@@ -9,7 +9,7 @@ from arm.logicnode.arm_props import *
 import arm.logicnode.arm_sockets as arm_sockets
 from arm.logicnode.replacement import NodeReplacement
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm_nodes = arm.reload_module(arm_nodes)
     arm.logicnode.arm_props = arm.reload_module(arm.logicnode.arm_props)
     from arm.logicnode.arm_props import *
@@ -19,7 +19,7 @@ if "DO_RELOAD_MODULE" in locals():
 
     HAS_RELOADED = True
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def init_categories():

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -14,14 +14,14 @@ from arm.logicnode.arm_props import *
 from arm.logicnode.replacement import NodeReplacement
 import arm.node_utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.logicnode.arm_props = arm.reload_module(arm.logicnode.arm_props)
     from arm.logicnode.arm_props import *
     arm.logicnode.replacement = arm.reload_module(arm.logicnode.replacement)
     from arm.logicnode.replacement import NodeReplacement
     arm.node_utils = arm.reload_module(arm.node_utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 # When passed as a category to add_node(), this will use the capitalized
 # name of the package of the node as the category to make renaming

--- a/blender/arm/logicnode/arm_sockets.py
+++ b/blender/arm/logicnode/arm_sockets.py
@@ -4,10 +4,10 @@ from bpy.types import NodeSocket
 
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def _on_update_socket(self, context):

--- a/blender/arm/logicnode/replacement.py
+++ b/blender/arm/logicnode/replacement.py
@@ -20,13 +20,13 @@ import arm.logicnode.arm_nodes as arm_nodes
 import arm.logicnode.arm_sockets
 import arm.node_utils as node_utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     log = arm.reload_module(log)
     arm_nodes = arm.reload_module(arm_nodes)
     arm.logicnode.arm_sockets = arm.reload_module(arm.logicnode.arm_sockets)
     node_utils = arm.reload_module(node_utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 # List of errors that occurred during the replacement
 # Format: (error identifier, node.bl_idname (or None), tree name, exception traceback (optional))

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -27,7 +27,7 @@ import arm.make_world as make_world
 import arm.utils
 import arm.write_data as write_data
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     assets = arm.reload_module(assets)
     arm.exporter = arm.reload_module(arm.exporter)
     from arm.exporter import ArmoryExporter
@@ -42,7 +42,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.utils = arm.reload_module(arm.utils)
     write_data = arm.reload_module(write_data)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 scripts_mtime = 0 # Monitor source changes
 profile_time = 0

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -8,14 +8,14 @@ import arm.log
 import arm.node_utils
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.exporter = arm.reload_module(arm.exporter)
     from arm.exporter import ArmoryExporter
     arm.log = arm.reload_module(arm.log)
     arm.node_utils = arm.reload_module(arm.node_utils)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 parsed_nodes = []
 parsed_ids = dict() # Sharing node data

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -6,14 +6,14 @@ import arm.log as log
 import arm.make_state as state
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.api = arm.reload_module(arm.api)
     assets = arm.reload_module(assets)
     log = arm.reload_module(log)
     state = arm.reload_module(state)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 callback = None
 

--- a/blender/arm/make_state.py
+++ b/blender/arm/make_state.py
@@ -1,5 +1,7 @@
-if "DO_RELOAD_MODULE" not in locals():
-    DO_RELOAD_MODULE = True
+import arm
+
+if not arm.is_reload(__name__):
+    arm.enable_reload(__name__)
 
     redraw_ui = False
     target = 'krom'

--- a/blender/arm/make_world.py
+++ b/blender/arm/make_world.py
@@ -12,7 +12,7 @@ import arm.node_utils as node_utils
 import arm.utils
 import arm.write_probes as write_probes
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.assets = arm.reload_module(arm.assets)
     arm.log = arm.reload_module(arm.log)
     arm.material = arm.reload_module(arm.material)
@@ -25,7 +25,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.utils = arm.reload_module(arm.utils)
     write_probes = arm.reload_module(write_probes)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 callback = None
 shader_datas = []

--- a/blender/arm/material/arm_nodes/custom_particle_node.py
+++ b/blender/arm/material/arm_nodes/custom_particle_node.py
@@ -5,7 +5,7 @@ from arm.material.arm_nodes.arm_nodes import add_node
 from arm.material.shader import Shader
 from arm.material.cycles import *
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     import arm
     arm.material.arm_nodes.arm_nodes = arm.reload_module(arm.material.arm_nodes.arm_nodes)
     from arm.material.arm_nodes.arm_nodes import add_node
@@ -14,7 +14,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.material.cycles = arm.reload_module(arm.material.cycles)
     from arm.material.cycles import *
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 class CustomParticleNode(Node):

--- a/blender/arm/material/arm_nodes/shader_data_node.py
+++ b/blender/arm/material/arm_nodes/shader_data_node.py
@@ -1,17 +1,17 @@
 from bpy.props import *
 from bpy.types import Node
 
+import arm
 from arm.material.arm_nodes.arm_nodes import add_node
 from arm.material.shader import Shader
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     arm.material.arm_nodes.arm_nodes = arm.reload_module(arm.material.arm_nodes.arm_nodes)
     from arm.material.arm_nodes.arm_nodes import add_node
     arm.material.shader = arm.reload_module(arm.material.shader)
     from arm.material.shader import Shader
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 class ShaderDataNode(Node):

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -30,7 +30,7 @@ from arm.material.parser_state import ParserState, ParserContext
 from arm.material.shader import Shader, ShaderContext, floatstr, vec3str
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.assets = arm.reload_module(arm.assets)
     log = arm.reload_module(log)
     arm.make_state = arm.reload_module(arm.make_state)
@@ -44,7 +44,7 @@ if "DO_RELOAD_MODULE" in locals():
     from arm.material.shader import Shader, ShaderContext, floatstr, vec3str
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 # Particle info export

--- a/blender/arm/material/cycles_nodes/nodes_color.py
+++ b/blender/arm/material/cycles_nodes/nodes_color.py
@@ -1,13 +1,13 @@
 import bpy
 
+import arm
 import arm.log as log
 import arm.material.cycles as c
 import arm.material.cycles_functions as c_functions
 from arm.material.parser_state import ParserState
 from arm.material.shader import floatstr, vec3str
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     log = arm.reload_module(log)
     c = arm.reload_module(c)
     c_functions = arm.reload_module(c_functions)
@@ -16,7 +16,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.material.shader = arm.reload_module(arm.material.shader)
     from arm.material.shader import floatstr, vec3str
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def parse_brightcontrast(node: bpy.types.ShaderNodeBrightContrast, out_socket: bpy.types.NodeSocket, state: ParserState) -> vec3str:

--- a/blender/arm/material/cycles_nodes/nodes_converter.py
+++ b/blender/arm/material/cycles_nodes/nodes_converter.py
@@ -2,14 +2,14 @@ from typing import Union
 
 import bpy
 
+import arm
 import arm.log as log
 import arm.material.cycles as c
 import arm.material.cycles_functions as c_functions
 from arm.material.parser_state import ParserState
 from arm.material.shader import floatstr, vec3str
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     log = arm.reload_module(log)
     c = arm.reload_module(c)
     c_functions = arm.reload_module(c_functions)
@@ -18,7 +18,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.material.shader = arm.reload_module(arm.material.shader)
     from arm.material.shader import floatstr, vec3str
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def parse_maprange(node: bpy.types.ShaderNodeMapRange, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:

--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -10,7 +10,7 @@ from arm.material.parser_state import ParserState, ParserContext
 from arm.material.shader import floatstr, vec3str
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     log = arm.reload_module(log)
     c = arm.reload_module(c)
     c_functions = arm.reload_module(c_functions)
@@ -20,7 +20,7 @@ if "DO_RELOAD_MODULE" in locals():
     from arm.material.shader import floatstr, vec3str
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def parse_attribute(node: bpy.types.ShaderNodeAttribute, out_socket: bpy.types.NodeSocket, state: ParserState) -> Union[floatstr, vec3str]:

--- a/blender/arm/material/cycles_nodes/nodes_shader.py
+++ b/blender/arm/material/cycles_nodes/nodes_shader.py
@@ -1,16 +1,16 @@
 import bpy
 from bpy.types import NodeSocket
 
+import arm
 import arm.material.cycles as c
 from arm.material.parser_state import ParserState
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     c = arm.reload_module(c)
     arm.material.parser_state = arm.reload_module(arm.material.parser_state)
     from arm.material.parser_state import ParserState
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket, state: ParserState) -> None:

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -13,7 +13,7 @@ from arm.material.shader import floatstr, vec3str
 import arm.utils
 import arm.write_probes as write_probes
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     assets = arm.reload_module(assets)
     log = arm.reload_module(log)
     c = arm.reload_module(c)
@@ -25,7 +25,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.utils = arm.reload_module(arm.utils)
     write_probes = arm.reload_module(write_probes)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def parse_tex_brick(node: bpy.types.ShaderNodeTexBrick, out_socket: bpy.types.NodeSocket, state: ParserState) -> Union[floatstr, vec3str]:

--- a/blender/arm/material/cycles_nodes/nodes_vector.py
+++ b/blender/arm/material/cycles_nodes/nodes_vector.py
@@ -3,13 +3,13 @@ from typing import Union
 import bpy
 from mathutils import Euler, Vector
 
+import arm
 import arm.material.cycles as c
 import arm.material.cycles_functions as c_functions
 from arm.material.parser_state import ParserState
 from arm.material.shader import floatstr, vec3str
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     c = arm.reload_module(c)
     c_functions = arm.reload_module(c_functions)
     arm.material.parser_state = arm.reload_module(arm.material.parser_state)
@@ -17,7 +17,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.material.shader = arm.reload_module(arm.material.shader)
     from arm.material.shader import floatstr, vec3str
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def parse_curvevec(node: bpy.types.ShaderNodeVectorCurve, out_socket: bpy.types.NodeSocket, state: ParserState) -> vec3str:

--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -10,14 +10,14 @@ import arm.material.mat_batch as mat_batch
 import arm.node_utils
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     cycles = arm.reload_module(cycles)
     make_shader = arm.reload_module(make_shader)
     mat_batch = arm.reload_module(mat_batch)
     arm.node_utils = arm.reload_module(arm.node_utils)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def glsl_value(val):

--- a/blender/arm/material/make_attrib.py
+++ b/blender/arm/material/make_attrib.py
@@ -9,7 +9,7 @@ import arm.material.make_tess as make_tess
 from arm.material.shader import Shader, ShaderContext
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     cycles = arm.reload_module(cycles)
     mat_state = arm.reload_module(mat_state)
     make_skin = arm.reload_module(make_skin)
@@ -20,7 +20,7 @@ if "DO_RELOAD_MODULE" in locals():
     from arm.material.shader import Shader, ShaderContext
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def write_vertpos(vert):

--- a/blender/arm/material/make_decal.py
+++ b/blender/arm/material/make_decal.py
@@ -5,13 +5,13 @@ import arm.material.mat_state as mat_state
 import arm.material.make_finalize as make_finalize
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     cycles = arm.reload_module(cycles)
     mat_state = arm.reload_module(mat_state)
     make_finalize = arm.reload_module(make_finalize)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def make(context_id):

--- a/blender/arm/material/make_depth.py
+++ b/blender/arm/material/make_depth.py
@@ -11,7 +11,7 @@ import arm.material.make_finalize as make_finalize
 import arm.assets as assets
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     cycles = arm.reload_module(cycles)
     mat_state = arm.reload_module(mat_state)
     mat_utils = arm.reload_module(mat_utils)
@@ -23,7 +23,7 @@ if "DO_RELOAD_MODULE" in locals():
     assets = arm.reload_module(assets)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def make(context_id, rpasses, shadowmap=False):

--- a/blender/arm/material/make_finalize.py
+++ b/blender/arm/material/make_finalize.py
@@ -1,15 +1,15 @@
 import bpy
 
+import arm
 import arm.material.make_tess as make_tess
 from arm.material.shader import ShaderContext
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     make_tess = arm.reload_module(make_tess)
     arm.material.shader = arm.reload_module(arm.material.shader)
     from arm.material.shader import ShaderContext
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def make(con_mesh: ShaderContext):

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -11,7 +11,7 @@ import arm.material.make_finalize as make_finalize
 import arm.material.make_attrib as make_attrib
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     assets = arm.reload_module(assets)
     mat_state = arm.reload_module(mat_state)
     mat_utils = arm.reload_module(mat_utils)
@@ -23,7 +23,7 @@ if "DO_RELOAD_MODULE" in locals():
     make_attrib = arm.reload_module(make_attrib)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 is_displacement = False
 write_material_attribs = None

--- a/blender/arm/material/make_overlay.py
+++ b/blender/arm/material/make_overlay.py
@@ -1,16 +1,16 @@
+import arm
 import arm.material.make_finalize as make_finalize
 import arm.material.make_mesh as make_mesh
 import arm.material.mat_state as mat_state
 import arm.material.mat_utils as mat_utils
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     make_finalize = arm.reload_module(make_finalize)
     make_mesh = arm.reload_module(make_mesh)
     mat_state = arm.reload_module(mat_state)
     mat_utils = arm.reload_module(mat_utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def make(context_id):

--- a/blender/arm/material/make_particle.py
+++ b/blender/arm/material/make_particle.py
@@ -1,11 +1,11 @@
 import arm.utils
 import arm.material.mat_state as mat_state
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.utils = arm.reload_module(arm.utils)
     mat_state = arm.reload_module(mat_state)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def write(vert, particle_info=None, shadowmap=False):

--- a/blender/arm/material/make_shader.py
+++ b/blender/arm/material/make_shader.py
@@ -22,7 +22,7 @@ import arm.material.mat_utils as mat_utils
 from arm.material.shader import Shader, ShaderContext, ShaderData
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.api = arm.reload_module(arm.api)
     assets = arm.reload_module(assets)
     arm.exporter = arm.reload_module(arm.exporter)
@@ -40,7 +40,7 @@ if "DO_RELOAD_MODULE" in locals():
     from arm.material.shader import Shader, ShaderContext, ShaderData
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 rpass_hook = None
 

--- a/blender/arm/material/make_skin.py
+++ b/blender/arm/material/make_skin.py
@@ -1,9 +1,9 @@
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def skin_pos(vert):

--- a/blender/arm/material/make_transluc.py
+++ b/blender/arm/material/make_transluc.py
@@ -1,20 +1,20 @@
 import bpy
 
+import arm
 import arm.material.cycles as cycles
 import arm.material.mat_state as mat_state
 import arm.material.make_mesh as make_mesh
 import arm.material.make_finalize as make_finalize
 import arm.assets as assets
 
-if "DO_RELOAD_MODULE" in locals():
-	import arm
+if arm.is_reload(__name__):
 	cycles = arm.reload_module(cycles)
 	mat_state = arm.reload_module(mat_state)
 	make_mesh = arm.reload_module(make_mesh)
 	make_finalize = arm.reload_module(make_finalize)
 	assets = arm.reload_module(assets)
 else:
-	DO_RELOAD_MODULE = True
+	arm.enable_reload(__name__)
 
 
 def make(context_id):

--- a/blender/arm/material/make_voxel.py
+++ b/blender/arm/material/make_voxel.py
@@ -4,12 +4,12 @@ import arm.utils
 import arm.assets as assets
 import arm.material.mat_state as mat_state
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.utils = arm.reload_module(arm.utils)
     assets = arm.reload_module(assets)
     mat_state = arm.reload_module(mat_state)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def make(context_id):

--- a/blender/arm/material/mat_batch.py
+++ b/blender/arm/material/mat_batch.py
@@ -1,14 +1,14 @@
+import arm
 import arm.material.cycles as cycles
 import arm.material.make_shader as make_shader
 import arm.material.mat_state as mat_state
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     cycles = arm.reload_module(cycles)
     make_shader = arm.reload_module(make_shader)
     mat_state = arm.reload_module(mat_state)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 # TODO: handle groups
 # TODO: handle cached shaders

--- a/blender/arm/material/mat_utils.py
+++ b/blender/arm/material/mat_utils.py
@@ -5,13 +5,13 @@ import arm.make_state as make_state
 import arm.material.cycles as cycles
 import arm.log as log
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.utils = arm.reload_module(arm.utils)
     make_state = arm.reload_module(make_state)
     cycles = arm.reload_module(cycles)
     log = arm.reload_module(log)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 add_mesh_contexts = []
 

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -3,14 +3,14 @@ from typing import List, Set, Tuple, Union, Optional
 
 import bpy
 
+import arm
 from arm.material.shader import Shader, ShaderContext, vec3str, floatstr
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     arm.material.shader = arm.reload_module(arm.material.shader)
     from arm.material.shader import Shader, ShaderContext, vec3str, floatstr
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 class ParserContext(Enum):

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -1,9 +1,9 @@
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 # Type aliases for type hints to make it easier to see which kind of
 # shader data type is stored in a string

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -10,12 +10,12 @@ import arm.log
 import arm.logicnode.arm_sockets
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.log = arm.reload_module(arm.log)
     arm.logicnode.arm_sockets = arm.reload_module(arm.logicnode.arm_sockets)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def find_node_by_link(node_group, to_node, inp):

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -11,7 +11,7 @@ import arm.props_traits
 import arm.ui_icons as ui_icons
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm_nodes = arm.reload_module(arm_nodes)
     arm.logicnode.replacement = arm.reload_module(arm.logicnode.replacement)
     arm.logicnode = arm.reload_module(arm.logicnode)
@@ -19,7 +19,7 @@ if "DO_RELOAD_MODULE" in locals():
     ui_icons = arm.reload_module(ui_icons)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 registered_nodes = []
 registered_categories = []

--- a/blender/arm/nodes_material.py
+++ b/blender/arm/nodes_material.py
@@ -2,18 +2,18 @@ import bpy
 import nodeitems_utils
 from nodeitems_utils import NodeCategory
 
+import arm
 import arm.material.arm_nodes.arm_nodes as arm_nodes
 # Import all nodes so that they register. Do not remove this import
 # even if it looks unused
 from arm.material.arm_nodes import *
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     arm_nodes = arm.reload_module(arm_nodes)
     arm.material.arm_nodes = arm.reload_module(arm.material.arm_nodes)
     from arm.material.arm_nodes import *
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 registered_nodes = []
 

--- a/blender/arm/profiler.py
+++ b/blender/arm/profiler.py
@@ -2,15 +2,15 @@ import cProfile
 import os
 import pstats
 
+import arm
 import arm.log as log
 import arm.utils as utils
 
-if "DO_RELOAD_MODULE" in locals():
-    import arm
+if arm.is_reload(__name__):
     log = arm.reload_module(log)
     utils = arm.reload_module(utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 class Profile:

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -10,7 +10,7 @@ import arm.nodes_logic
 import arm.proxy
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     assets = arm.reload_module(assets)
     arm.logicnode.replacement = arm.reload_module(arm.logicnode.replacement)
     arm.make = arm.reload_module(arm.make)
@@ -18,7 +18,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.proxy = arm.reload_module(arm.proxy)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 # Armory version
 arm_version = '2021.8'

--- a/blender/arm/props_bake.py
+++ b/blender/arm/props_bake.py
@@ -7,11 +7,11 @@ from arm.lightmapper import operators, properties, utility
 import arm.assets
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.assets = arm.reload_module(arm.assets)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 class ArmBakeListItem(bpy.types.PropertyGroup):

--- a/blender/arm/props_exporter.py
+++ b/blender/arm/props_exporter.py
@@ -11,11 +11,11 @@ from bpy.props import *
 import arm.assets as assets
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     assets = arm.reload_module(assets)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def remove_readonly(func, path, excinfo):

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -4,11 +4,11 @@ from bpy.props import *
 import arm.assets as assets
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     assets = arm.reload_module(assets)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 atlas_sizes = [ ('256', '256', '256'),
                 ('512', '512', '512'),

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -16,7 +16,7 @@ import arm.ui_icons as ui_icons
 import arm.utils
 import arm.write_data as write_data
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.make = arm.reload_module(arm.make)
     arm.props_traits_props = arm.reload_module(arm.props_traits_props)
     from arm.props_traits_props import *
@@ -25,7 +25,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.utils = arm.reload_module(arm.utils)
     arm.write_data = arm.reload_module(arm.write_data)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 ICON_HAXE = ui_icons.get_id('haxe')
 ICON_NODES = 'NODETREE'

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -22,7 +22,8 @@ import arm.proxy
 import arm.ui_icons as ui_icons
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+
+if arm.is_reload(__name__):
     arm.api = arm.reload_module(arm.api)
     assets = arm.reload_module(assets)
     arm.exporter = arm.reload_module(arm.exporter)
@@ -39,7 +40,7 @@ if "DO_RELOAD_MODULE" in locals():
     ui_icons = arm.reload_module(ui_icons)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 class ARM_PT_ObjectPropsPanel(bpy.types.Panel):

--- a/blender/arm/ui_icons.py
+++ b/blender/arm/ui_icons.py
@@ -6,7 +6,9 @@ from typing import Optional
 
 import bpy.utils.previews
 
-if "DO_RELOAD_MODULE" in locals():
+import arm
+
+if arm.is_reload(__name__):
     # _unload_icons is not available in the module scope yet
     def __unload():
         _unload_icons()
@@ -14,7 +16,7 @@ if "DO_RELOAD_MODULE" in locals():
     # Refresh icons after reload
     __unload()
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 __all__ = ["get_id"]

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -20,7 +20,7 @@ import arm.log as log
 import arm.make_state as state
 import arm.props_renderpath
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.lib.armpack = arm.reload_module(arm.lib.armpack)
     arm.lib.lz4 = arm.reload_module(arm.lib.lz4)
     from arm.lib.lz4 import LZ4
@@ -28,7 +28,7 @@ if "DO_RELOAD_MODULE" in locals():
     state = arm.reload_module(state)
     arm.props_renderpath = arm.reload_module(arm.props_renderpath)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 class NumpyEncoder(json.JSONEncoder):

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -11,13 +11,13 @@ import arm.assets as assets
 import arm.make_state as state
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     import arm
     assets = arm.reload_module(assets)
     state = arm.reload_module(state)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def on_same_drive(path1: str, path2: str) -> bool:

--- a/blender/arm/write_probes.py
+++ b/blender/arm/write_probes.py
@@ -11,13 +11,13 @@ import arm.assets as assets
 import arm.log as log
 import arm.utils
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     import arm
     assets = arm.reload_module(assets)
     log = arm.reload_module(log)
     arm.utils = arm.reload_module(arm.utils)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 
 def add_irr_assets(output_file_irr):

--- a/blender/start.py
+++ b/blender/start.py
@@ -21,7 +21,7 @@ import arm.keymap
 
 reload_started = 0
 
-if "DO_RELOAD_MODULE" in locals():
+if arm.is_reload(__name__):
     arm.log.debug('Reloading Armory SDK...')
     reload_started = time.time()
 
@@ -46,7 +46,7 @@ if "DO_RELOAD_MODULE" in locals():
     arm.utils = arm.reload_module(arm.utils)
     arm.keymap = arm.reload_module(arm.keymap)
 else:
-    DO_RELOAD_MODULE = True
+    arm.enable_reload(__name__)
 
 registered = False
 


### PR DESCRIPTION
This PR fixes issue https://github.com/armory3d/armory/issues/2301 in cases in which the Armory addon isn't reloaded. Due to some `from ... import *` statements, the global `"DO_RELOAD_MODULE"` flags were imported from already loaded modules which falsely led to a reload for some other modules. Now there is some custom name mangling to ensure that each module gets its own flag.

The actual issue still persists after reloading (which was expected, there will be more errors like this), but it is no longer critical as everything works again when using Armory the regular way without reloading :)