### PR TITLE
Fix nishita artifacts and improve LUT value range

### DIFF
--- a/Shaders/std/math.glsl
+++ b/Shaders/std/math.glsl
@@ -23,7 +23,7 @@ vec2 rand2(const vec2 coord) {
 	const float width = 1100.0;
 	const float height = 500.0;
 	float noiseX = ((fract(1.0 - coord.s * (width / 2.0)) * 0.25) + (fract(coord.t * (height / 2.0)) * 0.75)) * 2.0 - 1.0;
-	float noiseY = ((fract(1.0 - coord.s * (width / 2.0)) * 0.75) + (fract(coord.t * (height / 2.0)) * 0.25)) * 2.0 - 1.0;	
+	float noiseY = ((fract(1.0 - coord.s * (width / 2.0)) * 0.75) + (fract(coord.t * (height / 2.0)) * 0.25)) * 2.0 - 1.0;
 	return vec2(noiseX, noiseY);
 }
 

--- a/Shaders/std/math.glsl
+++ b/Shaders/std/math.glsl
@@ -40,4 +40,9 @@ float attenuate(const float dist) {
 	// 1.0 / (quadratic * dist * dist);
 }
 
+float safe_acos(const float x) {
+	// acos is undefined if |x| > 1
+	return acos(clamp(x, -1.0, 1.0));
+}
+
 #endif

--- a/Shaders/std/sky.glsl
+++ b/Shaders/std/sky.glsl
@@ -46,14 +46,8 @@ uniform vec2 nishitaDensity;
 #define nishita_mie_dir 0.76 // Aerosols anisotropy ("direction")
 #define nishita_mie_dir_sq 0.5776 // Squared aerosols anisotropy
 
-
 // Values from [Hill: 60]
 #define sun_limb_darkening_col vec3(0.397, 0.503, 0.652)
-
-float random(vec2 coords) {
-	// Returned value is in [0, 1]
-	return fract(sin(dot(coords.xy, vec2(12.9898,78.233))) * 43758.5453);
-}
 
 vec3 nishita_lookupLUT(const float height, const float sunTheta) {
 	vec2 coords = vec2(
@@ -133,7 +127,7 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 		vec3 attn = iAttn * jAttn;
 
 		// Apply dithering to reduce visible banding
-		attn *= 0.98 + random(r.xy) * 0.04;
+		attn *= 0.98 + rand(r.xy) * 0.04;
 
 		// Accumulate scattering
 		totalRlh += odStepRlh * attn;

--- a/Shaders/std/sky.glsl
+++ b/Shaders/std/sky.glsl
@@ -20,6 +20,8 @@
 #ifndef _SKY_GLSL_
 #define _SKY_GLSL_
 
+#include "std/math.glsl"
+
 uniform sampler2D nishitaLUT;
 uniform vec2 nishitaDensity;
 
@@ -119,7 +121,7 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 
 		// Idea behind this: "Rotate" everything by iPos (-> iPos is the new zenith) and then all calculations for the
 		// inner integral only depend on the sample height (iHeight) and sunTheta (angle between sun and new zenith).
-		float sunTheta = acos(dot(normalize(iPos), normalize(pSun)));
+		float sunTheta = safe_acos(dot(normalize(iPos), normalize(pSun)));
 		vec3 jAttn = nishita_lookupLUT(iHeight, sunTheta);
 
 		// Calculate attenuation

--- a/Shaders/std/sky.glsl
+++ b/Shaders/std/sky.glsl
@@ -44,17 +44,12 @@ uniform vec2 nishitaDensity;
 #define nishita_mie_dir 0.76 // Aerosols anisotropy ("direction")
 #define nishita_mie_dir_sq 0.5776 // Squared aerosols anisotropy
 
-// The ozone absorption coefficients are taken from Cycles code.
-// Because Cycles calculates 21 wavelengths, we use the coefficients
-// which are closest to the RGB wavelengths (645nm, 510nm, 440nm).
-// Precalculating values by simulating Blender's spec_to_xyz() function
-// to include all 21 wavelengths gave unrealistic results
-#define nishita_ozone_coeff vec3(1.59051840791988e-6, 0.00000096707041180970, 0.00000007309568762914)
 
 // Values from [Hill: 60]
 #define sun_limb_darkening_col vec3(0.397, 0.503, 0.652)
 
 float random(vec2 coords) {
+	// Returned value is in [0, 1]
 	return fract(sin(dot(coords.xy, vec2(12.9898,78.233))) * 43758.5453);
 }
 
@@ -125,17 +120,18 @@ vec3 nishita_atmosphere(const vec3 r, const vec3 r0, const vec3 pSun, const floa
 		// Idea behind this: "Rotate" everything by iPos (-> iPos is the new zenith) and then all calculations for the
 		// inner integral only depend on the sample height (iHeight) and sunTheta (angle between sun and new zenith).
 		float sunTheta = acos(dot(normalize(iPos), normalize(pSun)));
-		vec3 jODepth = nishita_lookupLUT(iHeight, sunTheta);
-
-		// Apply dithering to reduce visible banding
-		jODepth += mix(-1000, 1000, random(r.xy));
+		vec3 jAttn = nishita_lookupLUT(iHeight, sunTheta);
 
 		// Calculate attenuation
-		vec3 attn = exp(-(
-			nishita_mie_coeff * (iOdMie + jODepth.y)
-			+ (nishita_rayleigh_coeff) * (iOdRlh + jODepth.x)
-			+ nishita_ozone_coeff * jODepth.z
+		vec3 iAttn = exp(-(
+			nishita_mie_coeff * iOdMie
+			+ nishita_rayleigh_coeff * iOdRlh
+			// + 0 for ozone
 		));
+		vec3 attn = iAttn * jAttn;
+
+		// Apply dithering to reduce visible banding
+		attn *= 0.98 + random(r.xy) * 0.04;
 
 		// Accumulate scattering
 		totalRlh += odStepRlh * attn;


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2295 and requires https://github.com/armory3d/iron/pull/134.

It could happen that values returned by `dot()` were slightly larger than 1 or less than -1 due to precision errors, but the return value of `acos()` is undefined outside of [-1, 1]. This would lead to NaN values on some GPUs, causing visible artifacts.

Also I moved another calculation of the inner scattering integral into the LUT precalculation, with the big advantage that the LUT no longer contains inf values which could potentially lead to other issues. The values are now only slightly larger than 1 (max) and as a positive side effect we need much less dithering because apparently the interpolation of the LUT works much better in this range. Also, it is a tiny bit faster now.