### PR TITLE
Switch to ES6 on krom target and fix 'armory' define

### DIFF
--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -120,6 +120,9 @@ project.addSources('Sources');
                 if os.path.isdir('Subprojects/' + lib):
                     khafile.write('await project.addProject("Subprojects/{0}");\n'.format(lib))
 
+        if state.target.startswith('krom'):
+            assets.add_khafile_def('js-es=6')
+
         if export_physics:
             assets.add_khafile_def('arm_physics')
             if wrd.arm_physics_engine == 'Bullet':

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -316,14 +316,14 @@ project.addSources('Sources');
         # if bpy.data.scenes[0].unit_settings.system_rotation == 'DEGREES':
             # assets.add_khafile_def('arm_degrees')
 
+        # Allow libraries to recognize Armory
+        assets.add_khafile_def('armory')
+
         for d in assets.khafile_defs:
             khafile.write("project.addDefine('" + d + "');\n")
 
         for p in assets.khafile_params:
             khafile.write("project.addParameter('" + p + "');\n")
-
-        # Let libraries differentiate between Armory and pure Kha
-        assets.add_khafile_def('armory')
 
         if state.target.startswith('android'):
             bundle = 'org.armory3d.' + wrd.arm_project_package if wrd.arm_project_bundle == '' else wrd.arm_project_bundle


### PR DESCRIPTION
Fixes https://github.com/armory3d/armorcore/issues/32. I'm not sure whether ES6 can be enabled for html5 targets as well without loosing support for some target systems, so it's krom-only for now.

Also the 'armory' define wasn't written to the khafile which is fixed now.