### PR TITLE
HTML5 webserver log, port prefs

### DIFF
--- a/blender/arm/lib/server.py
+++ b/blender/arm/lib/server.py
@@ -1,3 +1,4 @@
+import arm.utils
 import atexit
 import http.server
 import socketserver
@@ -6,12 +7,17 @@ import subprocess
 haxe_server = None
 
 def run_tcp():
-    Handler = http.server.SimpleHTTPRequestHandler
-    try:
-        httpd = socketserver.TCPServer(("", 8040), Handler)
-        httpd.serve_forever()
-    except:
-        print('Server already running')
+	prefs = arm.utils.get_arm_preferences()
+	port = prefs.html5_server_port
+	do_log = prefs.html5_server_log
+	class HTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+		def log_message(self,format,*args):
+			if do_log: print(format % args)
+	try:
+		http_server = socketserver.TCPServer(("",port), HTTPRequestHandler)
+		http_server.serve_forever()
+	except:
+		print('Server already running')
 
 def run_haxe(haxe_path, port=6000):
 	global haxe_server


### PR DESCRIPTION
Allows to:
- Disable logging of http requests to terminal as it is redundant with devtools
- Change the webserver port in case already used

Related PR in armsdk: https://github.com/armory3d/armsdk/pull/30
