### PR TITLE
Fix "Uniform PPCompXX not found" warnings

### DIFF
--- a/Shaders/bloom_pass/bloom_pass.frag.glsl
+++ b/Shaders/bloom_pass/bloom_pass.frag.glsl
@@ -4,7 +4,9 @@
 
 uniform sampler2D tex;
 
+#ifdef _CPostprocess
 uniform vec3 PPComp10;
+#endif
 
 in vec2 texCoord;
 out vec4 fragColor;

--- a/Shaders/bloom_pass/bloom_pass.json
+++ b/Shaders/bloom_pass/bloom_pass.json
@@ -8,7 +8,8 @@
 			"links": [
 				{
 					"name": "PPComp10",
-					"link": "_PPComp10"
+					"link": "_PPComp10",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],

--- a/Shaders/blur_gaus_pass/blur_gaus_pass.frag.glsl
+++ b/Shaders/blur_gaus_pass/blur_gaus_pass.frag.glsl
@@ -28,7 +28,7 @@ void main() {
 		fragColor.rgb += textureLod(tex, texCoord + s, 0.0).rgb * weight[i];
 		fragColor.rgb += textureLod(tex, texCoord - s, 0.0).rgb * weight[i];
 	}
-	
+
 	#ifdef _CPostprocess
 		fragColor.rgb *= PPComp11.x / 5;
 	#else

--- a/Shaders/blur_gaus_pass/blur_gaus_pass.frag.glsl
+++ b/Shaders/blur_gaus_pass/blur_gaus_pass.frag.glsl
@@ -7,7 +7,9 @@ uniform sampler2D tex;
 uniform vec2 dir;
 uniform vec2 screenSize;
 
+#ifdef _CPostprocess
 uniform vec3 PPComp11;
+#endif
 
 in vec2 texCoord;
 out vec4 fragColor;

--- a/Shaders/blur_gaus_pass/blur_gaus_pass.json
+++ b/Shaders/blur_gaus_pass/blur_gaus_pass.json
@@ -16,7 +16,8 @@
 				},
 				{
 					"name": "PPComp11",
-					"link": "_PPComp11"
+					"link": "_PPComp11",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],
@@ -39,7 +40,8 @@
 				},
 				{
 					"name": "PPComp11",
-					"link": "_PPComp11"
+					"link": "_PPComp11",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],
@@ -65,7 +67,8 @@
 				},
 				{
 					"name": "PPComp11",
-					"link": "_PPComp11"
+					"link": "_PPComp11",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],

--- a/Shaders/chromatic_aberration_pass/chromatic_aberration_pass.frag.glsl
+++ b/Shaders/chromatic_aberration_pass/chromatic_aberration_pass.frag.glsl
@@ -3,7 +3,10 @@
 #include "compiled.inc"
 
 uniform sampler2D tex;
+
+#ifdef _CPostprocess
 uniform vec3 PPComp13;
+#endif
 
 in vec2 texCoord;
 out vec4 fragColor;

--- a/Shaders/chromatic_aberration_pass/chromatic_aberration_pass.json
+++ b/Shaders/chromatic_aberration_pass/chromatic_aberration_pass.json
@@ -9,7 +9,8 @@
 			"links": [
 				{
 					"name": "PPComp13",
-					"link": "_PPComp13"
+					"link": "_PPComp13",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],

--- a/Shaders/ssao_pass/ssao_pass.frag.glsl
+++ b/Shaders/ssao_pass/ssao_pass.frag.glsl
@@ -25,12 +25,12 @@ void main() {
 	float depth = textureLod(gbufferD, texCoord, 0.0).r * 2.0 - 1.0;
 	if (depth == 1.0) { fragColor = 1.0; return; }
 
-	vec2 enc = textureLod(gbuffer0, texCoord, 0.0).rg;      
+	vec2 enc = textureLod(gbuffer0, texCoord, 0.0).rg;
 	vec3 n;
 	n.z = 1.0 - abs(enc.x) - abs(enc.y);
 	n.xy = n.z >= 0.0 ? enc.xy : octahedronWrap(enc.xy);
 	n = normalize(n);
-	
+
 	vec3 vray = normalize(viewRay);
 	vec3 currentPos = getPosNoEye(eyeLook, vray, depth, cameraProj);
 	// vec3 currentPos = getPos2NoEye(eye, invVP, depth, texCoord);
@@ -55,7 +55,7 @@ void main() {
 		vec3 pos = getPos2NoEye(eye, invVP, depth, texCoord + k) - currentPos;
 		fragColor += max(0, dot(pos, n) - currentDistanceB) / (dot(pos, pos) + 0.015);
 	}
-	
+
 	#ifdef _CPostprocess
 		fragColor *= (PPComp12.x * 0.3) / samples;
 	#else

--- a/Shaders/ssao_pass/ssao_pass.frag.glsl
+++ b/Shaders/ssao_pass/ssao_pass.frag.glsl
@@ -12,8 +12,10 @@ uniform vec3 eyeLook;
 uniform vec2 screenSize;
 uniform mat4 invVP;
 
+#ifdef _CPostprocess
 uniform vec3 PPComp11;
 uniform vec3 PPComp12;
+#endif
 
 in vec2 texCoord;
 in vec3 viewRay;

--- a/Shaders/ssao_pass/ssao_pass.json
+++ b/Shaders/ssao_pass/ssao_pass.json
@@ -28,11 +28,13 @@
 				},
 				{
 					"name": "PPComp11",
-					"link": "_PPComp11"
+					"link": "_PPComp11",
+					"ifdef":["_CPostprocess"]
 				},
 				{
 					"name": "PPComp12",
-					"link": "_PPComp12"
+					"link": "_PPComp12",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],

--- a/Shaders/ssao_pass/ssao_pass.json
+++ b/Shaders/ssao_pass/ssao_pass.json
@@ -29,7 +29,7 @@
 				{
 					"name": "PPComp11",
 					"link": "_PPComp11",
-					"ifdef":["_CPostprocess"]
+					"ifdef": ["_CPostprocess"]
 				},
 				{
 					"name": "PPComp12",

--- a/Shaders/ssr_pass/ssr_pass.frag.glsl
+++ b/Shaders/ssr_pass/ssr_pass.frag.glsl
@@ -12,8 +12,10 @@ uniform mat4 P;
 uniform mat3 V3;
 uniform vec2 cameraProj;
 
+#ifdef _CPostprocess
 uniform vec3 PPComp9;
 uniform vec3 PPComp10;
+#endif
 
 in vec3 viewRay;
 in vec2 texCoord;

--- a/Shaders/ssr_pass/ssr_pass.json
+++ b/Shaders/ssr_pass/ssr_pass.json
@@ -24,11 +24,13 @@
 				},
 				{
 					"name": "PPComp9",
-					"link": "_PPComp9"
+					"link": "_PPComp9",
+					"ifdef": ["_CPostprocess"]
 				},
 				{
 					"name": "PPComp10",
-					"link": "_PPComp10"
+					"link": "_PPComp10",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],


### PR DESCRIPTION
Potential fix for https://github.com/armory3d/armory/issues/2314.

When `Realtime postprocess` was turned off, some unused uniforms were removed by the compiler but were still referenced from Iron. This led to warnings and maybe even to the blackscreen reported in the above issue. @onelsonic can you please check whether the blackscreen is fixed by this PR?