### PR TITLE
Update props_ui.py

### DIFF
--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -742,9 +742,9 @@ class ARM_PT_ArmoryExporterAndroidSettingsPanel(ExporterTargetSettingsMixin, bpy
 
         col = layout.column()
         col.prop(wrd, 'arm_winorient')
-        col.prop(wrd, 'arm_project_android_sdk_compile')
         col.prop(wrd, 'arm_project_android_sdk_min')
         col.prop(wrd, 'arm_project_android_sdk_target')
+        col.prop(wrd, 'arm_project_android_sdk_compile')
 
 
 class ARM_PT_ArmoryExporterAndroidPermissionsPanel(bpy.types.Panel):


### PR DESCRIPTION
change the UI to reflect common order to setup Android SDK values
https://developer.android.com/guide/topics/manifest/uses-sdk-element.html
android:minSdkVersion="integer"
then
android:targetSdkVersion="integer"
then
android:maxSdkVersion="integer"