### PR TITLE
Vscode open error position

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -481,20 +481,12 @@ def build_done():
     if state.proc_build is None:
         return
     result = state.proc_build.poll()
-    # state.proc_build = None
-    # state.redraw_ui = True
-    # if result == 0:
-    #     bpy.data.worlds['Arm'].arm_recompile = False
-    #     build_success()
-    # else:
-    #     log.error('Build failed, check console')
     if result == 0:
         state.proc_build = None
         state.redraw_ui = True
         bpy.data.worlds['Arm'].arm_recompile = False
         build_success()
     else:
-        # log.error('Build failed')
         err = state.proc_build.communicate()[1].decode("utf-8").strip()
         err = err.split("\n")[0]
         log.error(err)
@@ -502,32 +494,14 @@ def build_done():
             try:
                 parts = err.split(":")
                 path = parts[0]
-                linenum = parts[1]
+                line = parts[1]
                 column = parts[2][12:-1].split("-")
-                arm.utils.open_editor(path,linenum,column[0])
             except:
-                log.debug('Failed to parse error position')
-    state.proc_build = None
-    state.redraw_ui = True
-
-# def build_fail(info=None):
-#     if info != None:
-#         log.error(info,'')
-#     if state.proc_build != None:
-#         err = state.proc_build.communicate()[1].decode("utf-8").strip()
-#         err = err.split("\n")[0]
-#         log.error(err)
-#         if arm.utils.get_arm_preferences().open_script_error:
-#             try:
-#                 parts = err.split(":")
-#                 path = parts[0]
-#                 linenum = parts[1]
-#                 column = parts[2][12:-1].split("-")
-#                 arm.utils.open_editor(path,linenum,column[0])
-#             except:
-#                 log.debug('Failed to parse error position')
-#     state.proc_build = None
-#     state.redraw_ui = True
+                log.debug('failed to parse error position')
+            if path != None:
+                arm.utils.open_editor(path,line,column[0])
+        state.proc_build = None
+        state.redraw_ui = True
 
 def runtime_to_target():
     wrd = bpy.data.worlds['Arm']

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -782,7 +782,7 @@ def open_editor(hx_path=None,line=None,pos=None):
             args += ['--project', subl_project_path]
             args.append('--add')
             args.append(hx_path)
-        elif editor == 'code'or ide_bin == 'code' or editor == 'kodestudio':
+        elif editor == 'code' or editor == 'kodestudio':
             args.append('--goto')
             goto = hx_path
             if line != None: goto += ":"+line

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -755,7 +755,7 @@ def open_editor(hx_path=None,line=None,pos=None):
     if hx_path is None:
         hx_path = arm.utils.get_fp()
 
-    if editor == 'default':
+    if ide_bin == None and editor == 'default':
         # Get editor environment variables
         # https://unix.stackexchange.com/q/4859
         env_v_editor = os.environ.get('VISUAL')
@@ -772,35 +772,40 @@ def open_editor(hx_path=None,line=None,pos=None):
             webbrowser.open('file://' + hx_path)
             return
 
-    if os.path.exists(ide_bin):
-        args = [ide_bin, arm.utils.get_fp()]
-        if editor == 'sublime':
-            project_name = arm.utils.safestr(bpy.data.worlds['Arm'].arm_project_name)
-            subl_project_path = arm.utils.get_fp() + f'/{project_name}.sublime-project'
-            if not os.path.exists(subl_project_path):
-                generate_sublime_project(subl_project_path)
-            args += ['--project', subl_project_path]
-            args.append('--add')
-            args.append(hx_path)
-        elif editor == 'code' or editor == 'kodestudio':
-            args.append('--goto')
-            goto = hx_path
-            if line != None: goto += ":"+line
-            if pos != None: goto += ":"+pos
-            args.append(goto)
-        else:
-            args.append(hx_path)
-        if arm.utils.get_os() == 'mac':
-            argstr = ""
-            for arg in args:
-                if not (arg.startswith('-') or arg.startswith('--')):
-                    argstr += '"' + arg + '"'
-                argstr += ' '
-            subprocess.Popen(argstr[:-1], shell=True)
-        else:
-            subprocess.Popen(args)
+    if ide_bin == None or ide_bin == '':
+        log.warn("No code editor executeable set")
+        return
+    if not os.path.exists(ide_bin):
+        log.error(f'Code editor executable not found: {ide_bin}')
+        log.info(' └ You can change the path in the Armory preferences')
+        return
+    
+    args = [ide_bin, arm.utils.get_fp()]
+    if editor == 'sublime':
+        project_name = arm.utils.safestr(bpy.data.worlds['Arm'].arm_project_name)
+        subl_project_path = arm.utils.get_fp() + f'/{project_name}.sublime-project'
+        if not os.path.exists(subl_project_path):
+            generate_sublime_project(subl_project_path)
+        args += ['--project', subl_project_path]
+        args.append('--add')
+        args.append(hx_path)
+    elif editor == 'code' or editor == 'kodestudio':
+        args.append('--goto')
+        goto = hx_path
+        if line != None: goto += ":"+line
+        if pos != None: goto += ":"+pos
+        args.append(goto)
     else:
-        raise FileNotFoundError(f'Code editor executable not found: {ide_bin}. You can change the path in the Armory preferences.')
+        args.append(hx_path)
+    if arm.utils.get_os() == 'mac':
+        argstr = ""
+        for arg in args:
+            if not (arg.startswith('-') or arg.startswith('--')):
+                argstr += '"' + arg + '"'
+            argstr += ' '
+        subprocess.Popen(argstr[:-1], shell=True)
+    else:
+        subprocess.Popen(args)
 
 def open_folder(folder_path: str):
     if arm.utils.get_os() == 'win':


### PR DESCRIPTION
This change opens vscode|kodestudio at error position (line-column) if haxe compilation fails, but only if `open_script_error` is set in prefs.

It's only tested on linux and vscode, but i assume kodestudio has the same cli.

The change in armsdk: https://github.com/armory3d/armsdk/pull/34

