### PR TITLE
Improve log messages

### DIFF
--- a/blender/arm/assets.py
+++ b/blender/arm/assets.py
@@ -67,7 +67,7 @@ def add(asset_file):
     for f in assets:
         f_file_base = os.path.basename(f)
         if f_file_base == asset_file_base:
-            log.warn(f'Armory Warning: Asset name "{asset_file_base}" already exists, skipping')
+            log.warn(f'Asset name "{asset_file_base}" already exists, skipping')
             return
 
     assets.append(asset_file)
@@ -75,7 +75,7 @@ def add(asset_file):
     # Reserved file name
     for f in reserved_names:
         if f in asset_file:
-            log.warn(f'Armory Warning: File "{asset_file}" contains reserved keyword, this will break C++ builds!')
+            log.warn(f'File "{asset_file}" contains reserved keyword, this will break C++ builds!')
 
 def add_khafile_def(d):
     global khafile_defs

--- a/blender/arm/keymap.py
+++ b/blender/arm/keymap.py
@@ -1,6 +1,7 @@
 import bpy
 
 import arm
+import arm.log as log
 import arm.props_ui as props_ui
 
 if arm.is_reload(__name__):
@@ -20,7 +21,7 @@ def register():
     # is printed
     if addon_keyconfig is None:
         if not bpy.app.background:
-            print("Armory warning: no keyconfig path found")
+            log.warn("No keyconfig path found")
         return
 
     km = addon_keyconfig.keymaps.new(name='Window', space_type='EMPTY', region_type="WINDOW")

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -2172,7 +2172,7 @@ class ArmSyncProxyButton(bpy.types.Operator):
                     arm.proxy.sync_modifiers(obj)
                 if obj.arm_proxy_sync_traits:
                     arm.proxy.sync_traits(obj)
-            print('Armory: Proxy objects synchronized')
+            print('Proxy objects synchronized')
         return{'FINISHED'}
 
 class ArmPrintTraitsButton(bpy.types.Operator):

--- a/blender/arm/write_probes.py
+++ b/blender/arm/write_probes.py
@@ -52,7 +52,7 @@ def setup_envmap_render():
     if bpy.context.preferences.addons["cycles"].preferences.compute_device_type == "CUDA":
         scene.cycles.device = "GPU"
     else:
-        log.info('Armory: Using CPU for environment render (might be slow). Enable CUDA if possible.')
+        log.info('Using CPU for environment render (might be slow). Enable CUDA if possible.')
 
     # One sample is enough for world background only
     scene.cycles.samples = 1


### PR DESCRIPTION
Removes the `Armory Warning:` prefix in log messages as `arm.log.warn` already prefixes it with `WARNING:`