### PR TITLE
Add nodes to get/set global canvas scale

### DIFF
--- a/Sources/armory/logicnode/GetGlobalCanvasScaleNode.hx
+++ b/Sources/armory/logicnode/GetGlobalCanvasScaleNode.hx
@@ -1,0 +1,22 @@
+package armory.logicnode;
+
+import iron.Scene;
+import armory.trait.internal.CanvasScript;
+
+class GetGlobalCanvasScaleNode extends LogicNode {
+
+	var canvas: CanvasScript;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+#if arm_ui
+	override function get(from: Int): Dynamic {
+		canvas = Scene.active.getTrait(CanvasScript);
+		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+
+		return canvas.getUiScale();
+	}
+#end
+}

--- a/Sources/armory/logicnode/SetGlobalCanvasScaleNode.hx
+++ b/Sources/armory/logicnode/SetGlobalCanvasScaleNode.hx
@@ -1,0 +1,25 @@
+package armory.logicnode;
+
+import iron.Scene;
+import armory.trait.internal.CanvasScript;
+
+class SetGlobalCanvasScaleNode extends LogicNode {
+
+	var canvas: CanvasScript;
+	var factor: Float;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+#if arm_ui
+	override function run(from: Int) {
+		factor = inputs[1].get();
+		canvas = Scene.active.getTrait(CanvasScript);
+		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+
+		canvas.setUiScale(factor);
+		runOutput(0);
+	}
+#end
+}

--- a/Sources/armory/trait/internal/CanvasScript.hx
+++ b/Sources/armory/trait/internal/CanvasScript.hx
@@ -114,11 +114,17 @@ class CanvasScript extends Trait {
 	}
 
 	/**
-	 * Set UI scale factor.
-	 * @param factor Scale factor.
-	 */
-	 public function setUiScale(factor:Float) {
+		Set the UI scale factor.
+	**/
+	public inline function setUiScale(factor: Float) {
 		cui.setScale(factor);
+	}
+
+	/**
+		Get the UI scale factor.
+	**/
+	public inline function getUiScale(): Float {
+		return cui.ops.scaleFactor;
 	}
 
 	/**

--- a/blender/arm/logicnode/canvas/LN_get_global_canvas_scale.py
+++ b/blender/arm/logicnode/canvas/LN_get_global_canvas_scale.py
@@ -1,0 +1,11 @@
+from arm.logicnode.arm_nodes import *
+
+
+class GetGlobalCanvasScaleNode(ArmLogicTreeNode):
+    """Returns the scale of the entire UI Canvas."""
+    bl_idname = 'LNGetGlobalCanvasScaleNode'
+    bl_label = 'Get Global Canvas Scale'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_output('ArmFloatSocket', 'Scale')

--- a/blender/arm/logicnode/canvas/LN_set_global_canvas_scale.py
+++ b/blender/arm/logicnode/canvas/LN_set_global_canvas_scale.py
@@ -1,0 +1,14 @@
+from arm.logicnode.arm_nodes import *
+
+
+class SetGlobalCanvasScaleNode(ArmLogicTreeNode):
+    """Sets the scale of the entire UI Canvas."""
+    bl_idname = 'LNSetGlobalCanvasScaleNode'
+    bl_label = 'Set Global Canvas Scale'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmFloatSocket', 'Scale', default_value=1.0)
+
+        self.add_output('ArmNodeSocketAction', 'Out')


### PR DESCRIPTION
This PR adds two new nodes that allow to get/set the scale of the entire canvas, not just of individual elements.