### PR TITLE
Fix add-on reloading when there are new unimported node files

### DIFF
--- a/blender/arm/logicnode/__init__.py
+++ b/blender/arm/logicnode/__init__.py
@@ -75,7 +75,7 @@ def init_nodes():
 
         # Only look at modules in sub packages
         elif module_name.rsplit('.', 1)[0] != __package__:
-            if 'HAS_RELOADED' not in globals():
+            if 'HAS_RELOADED' not in globals() or module_name not in sys.modules:
                 _module = importlib.import_module(module_name)
             else:
                 # Reload the module if the SDK was reloaded at least once


### PR DESCRIPTION
When reloading the add-on via the reload operator, all node modules were reimported even if they were new and not imported before which led to an exception.