### PR TITLE
Debug console: make log output more readable

### DIFF
--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -25,6 +25,8 @@ class DebugConsole extends Trait {
 #else
 
 	public static var visible = true;
+	public static var traceWithPosition = true;
+
 	static var ui: Zui;
 	var scaleFactor = 1.0;
 
@@ -75,9 +77,11 @@ class DebugConsole extends Trait {
 	#end
 
 	public function new(scaleFactor = 1.0, scaleDebugConsole = 1.0, positionDebugConsole = 2, visibleDebugConsole = 1,
-	keyCodeVisible = kha.input.KeyCode.Tilde, keyCodeScaleIn = kha.input.KeyCode.OpenBracket, keyCodeScaleOut = kha.input.KeyCode.CloseBracket) {
+	traceWithPosition = 1, keyCodeVisible = kha.input.KeyCode.Tilde, keyCodeScaleIn = kha.input.KeyCode.OpenBracket,
+	keyCodeScaleOut = kha.input.KeyCode.CloseBracket) {
 		super();
 		this.scaleFactor = scaleFactor;
+		DebugConsole.traceWithPosition = traceWithPosition == 1;
 
 		iron.data.Data.getFont("font_default.ttf", function(font: kha.Font) {
 			ui = new Zui({scaleFactor: scaleFactor, font: font});
@@ -170,7 +174,7 @@ class DebugConsole extends Trait {
 	static var haxeTrace: Dynamic->haxe.PosInfos->Void = null;
 	static var lastTraces: Array<String> = [""];
 	static function consoleTrace(v: Dynamic, ?inf: haxe.PosInfos) {
-		lastTraces.unshift(haxe.Log.formatOutput(v,inf));
+		lastTraces.unshift(haxe.Log.formatOutput(v, traceWithPosition ? inf : null));
 		if (lastTraces.length > 10) lastTraces.pop();
 		haxeTrace(v, inf);
 	}

--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -783,15 +783,19 @@ class DebugConsole extends Trait {
 					final h = Id.handle();
 					h.selected = DebugConsole.traceWithPosition;
 					DebugConsole.traceWithPosition = ui.check(h, "Print With Position");
+					if (ui.isHovered) ui.tooltip("Whether to prepend the position of print/trace statements to the printed text");
 
 					if (ui.button("Clear")) {
 						lastTraces[0] = "";
 						lastTraces.splice(1, lastTraces.length - 1);
 					}
+					if (ui.isHovered) ui.tooltip("Clear the log output");
+
 					final eh = ui.t.ELEMENT_H;
 					ui.t.ELEMENT_H = ui.fontSize;
 					for (t in lastTraces) ui.text(t);
 					ui.t.ELEMENT_H = eh;
+
 					ui.unindent();
 				}
 			}

--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -84,7 +84,7 @@ class DebugConsole extends Trait {
 			// Set settings
 			setScale(scaleDebugConsole);
 			setVisible(visibleDebugConsole == 1);
-			switch(positionDebugConsole) {
+			switch (positionDebugConsole) {
 				case 0: setPosition(PositionStateEnum.LEFT);
 				case 1: setPosition(PositionStateEnum.CENTER);
 				case 2: setPosition(PositionStateEnum.RIGHT);
@@ -104,11 +104,11 @@ class DebugConsole extends Trait {
 				// DebugFloat
 				if (key == kha.input.KeyCode.OpenBracket) {
 					debugFloat -= 0.1;
-					trace("debugFloat = "+ debugFloat);
+					trace("debugFloat = " + debugFloat);
 				}
 				else if (key == kha.input.KeyCode.CloseBracket){
 					debugFloat += 0.1;
-					trace("debugFloat = "+ debugFloat);
+					trace("debugFloat = " + debugFloat);
 				}
 				// Shortcut - Visible
 				if (key == shortcut_visible) visible = !visible;
@@ -186,10 +186,10 @@ class DebugConsole extends Trait {
 		var wh = iron.App.h();
 		// Check position
 		switch (position_console) {
-            case PositionStateEnum.LEFT: wx = 0;
-            case PositionStateEnum.CENTER: wx = Math.round(iron.App.w() / 2 - ww / 2);
-            case PositionStateEnum.RIGHT: wx = iron.App.w() - ww;
-        }
+			case PositionStateEnum.LEFT: wx = 0;
+			case PositionStateEnum.CENTER: wx = Math.round(iron.App.w() / 2 - ww / 2);
+			case PositionStateEnum.RIGHT: wx = iron.App.w() - ww;
+		}
 
 		// var bindG = ui.windowDirty(hwin, wx, wy, ww, wh) || hwin.redraws > 0;
 		var bindG = true;

--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -779,6 +779,11 @@ class DebugConsole extends Trait {
 				#end
 				if (ui.panel(Id.handle({selected: true}), "Log")) {
 					ui.indent();
+
+					final h = Id.handle();
+					h.selected = DebugConsole.traceWithPosition;
+					DebugConsole.traceWithPosition = ui.check(h, "Print With Position");
+
 					if (ui.button("Clear")) {
 						lastTraces[0] = "";
 						lastTraces.splice(1, lastTraces.length - 1);

--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -788,7 +788,10 @@ class DebugConsole extends Trait {
 						lastTraces[0] = "";
 						lastTraces.splice(1, lastTraces.length - 1);
 					}
+					final eh = ui.t.ELEMENT_H;
+					ui.t.ELEMENT_H = ui.fontSize;
 					for (t in lastTraces) ui.text(t);
+					ui.t.ELEMENT_H = eh;
 					ui.unindent();
 				}
 			}

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2679,13 +2679,16 @@ Make sure the mesh only has tris/quads.""")
             out_trait = {
                 'type': 'Script',
                 'class_name': 'armory.trait.internal.DebugConsole',
-                'parameters': [str(arm.utils.get_ui_scale()),
-                str(wrd.arm_debug_console_scale),
-                str(debug_console_pos_type),
-                str(int(wrd.arm_debug_console_visible)),
-                str(int(arm.utils.get_debug_console_visible_sc())),
-                str(int(arm.utils.get_debug_console_scale_in_sc())),
-                str(int(arm.utils.get_debug_console_scale_out_sc()))]
+                'parameters': [
+                    str(arm.utils.get_ui_scale()),
+                    str(wrd.arm_debug_console_scale),
+                    str(debug_console_pos_type),
+                    str(int(wrd.arm_debug_console_visible)),
+                    str(int(wrd.arm_debug_console_trace_pos)),
+                    str(int(arm.utils.get_debug_console_visible_sc())),
+                    str(int(arm.utils.get_debug_console_scale_in_sc())),
+                    str(int(arm.utils.get_debug_console_scale_out_sc()))
+                ]
             }
             self.output['traits'].append(out_trait)
 

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -256,6 +256,7 @@ def init_properties():
         name="Position", description="Position Debug Console", default='Right', update=assets.invalidate_shader_cache)
     bpy.types.World.arm_debug_console_scale = FloatProperty(name="Scale Console", description="Scale Debug Console", default=1.0, min=0.3, max=10.0, subtype='FACTOR', update=assets.invalidate_shader_cache)
     bpy.types.World.arm_debug_console_visible = BoolProperty(name="Visible", description="Setting the console visibility at application start", default=True, update=assets.invalidate_shader_cache)
+    bpy.types.World.arm_debug_console_trace_pos = BoolProperty(name="Print With Position", description="Whether to prepend the position of print/trace statements to the printed text", default=True)
     bpy.types.World.arm_verbose_output = BoolProperty(name="Verbose Output", description="Print additional information to the console during compilation", default=False)
     bpy.types.World.arm_runtime = EnumProperty(
         items=[('Krom', 'Krom', 'Krom'),

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -969,6 +969,7 @@ class ARM_PT_ProjectFlagsDebugConsolePanel(bpy.types.Panel):
         col.prop(wrd, 'arm_debug_console_position')
         col.prop(wrd, 'arm_debug_console_scale')
         col.prop(wrd, 'arm_debug_console_visible')
+        col.prop(wrd, 'arm_debug_console_trace_pos')
 
 class ARM_PT_ProjectWindowPanel(bpy.types.Panel):
     bl_label = "Window"


### PR DESCRIPTION
Closes https://github.com/armory3d/armory/issues/2190.

- There is now an option in both the Blender UI and the debug console UI to omit the position infos from trace statements, the actual Haxe console output is not affected by that.
  ![Blender UI screenshot](https://user-images.githubusercontent.com/17685000/134923258-b27054d5-dd36-42f7-8823-1ecfbb49719e.png)
- There is now less space between the individual log lines in the UI:
  ![Debug console screenshot](https://user-images.githubusercontent.com/17685000/134922629-31deeb9a-5ad9-4e6d-837d-9f773c743965.png)
- Added some tooltips to the debug console
  