### PR TITLE
Fix CPU count parameter for cmft

### DIFF
--- a/blender/arm/write_probes.py
+++ b/blender/arm/write_probes.py
@@ -187,7 +187,10 @@ def write_probes(image_filepath: str, disable_hdr: bool, cached_num_mips: int, a
 
     wrd = bpy.data.worlds['Arm']
     use_opencl = 'true'
-    cpu_count = multiprocessing.cpu_count()
+
+    # cmft doesn't work correctly when passing the number of logical
+    # CPUs if there are more logical than physical CPUs on a machine
+    cpu_count = arm.utils.cpu_count(physical_only=True)
 
     if arm.utils.get_os() == 'win':
         cmd = [


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2344.

The CMFT sources state the following about the `--numCpuProcessing` parameter:

> Should not be bigger than the number of physical CPU cores/threads.

Both `multiprocessing.cpu_count()` and `os.cpu_count()` return the number of logical CPU cores, which can be larger than the number of physical ones. Because the Python standard library doesn't provide a function for this, we need our own function that relies on some shell commands. In theory the Linux command can be executed without `shell=True` if you correctly pipe together the individual programs used in the command ([like this](https://docs.python.org/3/library/subprocess.html#replacing-shell-pipeline)), but my Ubuntu VM lags as hell and I didn't get it to work that way.

Tested on Windows 10 and a Ubuntu VM. I really appreciate if someone would test this on MacOS or another Linux distro.