### PR TITLE
Fix deprecated nodes and improve deprecation handling

### DIFF
--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -602,6 +602,13 @@ def deprecated(*alternatives: str, message=""):
         cls.bl_icon = 'ERROR'
         cls.arm_is_obsolete = True
 
+        # Deprecated nodes must use a category other than PKG_AS_CATEGORY
+        # in order to prevent an empty 'Deprecated' category showing up
+        # in the add node menu and in the generated wiki pages. The
+        # "old" category is still used to put the node into the correct
+        # category in the wiki.
+        assert cls.arm_category != PKG_AS_CATEGORY, f'Deprecated node {cls.__name__} is missing an explicit category definition!'
+
         if cls.__doc__ is None:
             cls.__doc__ = ''
 

--- a/blender/arm/logicnode/deprecated/LN_quaternion.py
+++ b/blender/arm/logicnode/deprecated/LN_quaternion.py
@@ -7,6 +7,7 @@ class QuaternionNode(ArmLogicTreeNode):
     bl_idname = 'LNQuaternionNode'
     bl_label = 'Quaternion'
     bl_description = 'Create a quaternion variable (transported through a vector socket)'
+    arm_category = 'Variable'
     arm_section = 'quaternions'
     arm_version = 2  # deprecate
 

--- a/blender/arm/logicnode/deprecated/LN_quaternion.py
+++ b/blender/arm/logicnode/deprecated/LN_quaternion.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 from mathutils import Vector
 
+
 @deprecated(message='Do not use quaternion sockets')
 class QuaternionNode(ArmLogicTreeNode):
     """TO DO."""
@@ -21,14 +22,12 @@ class QuaternionNode(ArmLogicTreeNode):
         self.add_output('ArmVectorSocket', 'XYZ')
         self.add_output('ArmVectorSocket', 'W')
 
-
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
         if self.arm_version not in (0, 1):
             raise LookupError()
 
         # transition from version 1 to version 2[deprecated]
-        
-        
+
         newnodes = []
 
         rawlinks = self.outputs[0].links
@@ -37,7 +36,7 @@ class QuaternionNode(ArmLogicTreeNode):
         if len(rawlinks)>0 or len(xyzlinks)>0:
             xyzcomb = node_tree.nodes.new('LNVectorNode')
             newnodes.append(xyzcomb)
-            
+
             xyzcomb.inputs[0].default_value = self.inputs[0].default_value
             xyzcomb.inputs[1].default_value = self.inputs[1].default_value
             xyzcomb.inputs[2].default_value = self.inputs[2].default_value
@@ -72,5 +71,5 @@ class QuaternionNode(ArmLogicTreeNode):
         else:
             for link in self.outputs[2].links:
                 link.to_socket.default_value = self.inputs[3].default_value
-        
+
         return newnodes

--- a/blender/arm/logicnode/deprecated/LN_separate_quaternion.py
+++ b/blender/arm/logicnode/deprecated/LN_separate_quaternion.py
@@ -6,6 +6,7 @@ class SeparateQuaternionNode(ArmLogicTreeNode):
     bl_idname = 'LNSeparateQuaternionNode'
     bl_label = "Separate Quaternion (do not use: quaternions sockets have been phased out entirely)"
     bl_description = "Separate a quaternion object (transported through a vector socket) into its four compoents."
+    arm_category = 'Math'
     arm_section = 'quaternions'
     arm_version = 2  # deprecate
     

--- a/blender/arm/logicnode/deprecated/LN_separate_quaternion.py
+++ b/blender/arm/logicnode/deprecated/LN_separate_quaternion.py
@@ -1,5 +1,6 @@
 from arm.logicnode.arm_nodes import *
 
+
 @deprecated(message='Do not use quaternion sockets')
 class SeparateQuaternionNode(ArmLogicTreeNode):
     """Splits the given quaternion into X, Y, Z and W."""
@@ -9,7 +10,6 @@ class SeparateQuaternionNode(ArmLogicTreeNode):
     arm_category = 'Math'
     arm_section = 'quaternions'
     arm_version = 2  # deprecate
-    
 
     def arm_init(self, context):
         self.add_input('ArmVectorSocket', 'Quaternion')
@@ -18,7 +18,6 @@ class SeparateQuaternionNode(ArmLogicTreeNode):
         self.add_output('ArmFloatSocket', 'Y')
         self.add_output('ArmFloatSocket', 'Z')
         self.add_output('ArmFloatSocket', 'W')
-
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
         if self.arm_version not in (0, 1):

--- a/blender/arm/logicnode/deprecated/LN_surface_coords.py
+++ b/blender/arm/logicnode/deprecated/LN_surface_coords.py
@@ -9,7 +9,6 @@ class SurfaceCoordsNode(ArmLogicTreeNode):
     bl_description = "Please use the \"Get Touch Movement\" and \"Get Touch Location\" nodes instead"
     arm_category = 'Input'
     arm_section = 'surface'
-    arm_is_obsolete = 'is_obsolete'
     arm_version = 2
 
     def arm_init(self, context):


### PR DESCRIPTION
There were some deprecated nodes with incorrect categories that led to an empty "Deprecated" menu entry in the add node menu. Deprecated nodes instead have to keep their original category in order to show up in the right category in the wiki, so I also added an assertion to check for this problem.