### PR TITLE
Fix Geometry and Texture Coordinate nodes for world shaders

### DIFF
--- a/blender/arm/make_world.py
+++ b/blender/arm/make_world.py
@@ -209,7 +209,7 @@ def build_node_tree(world: bpy.types.World, frag: Shader, vert: Shader, con: Sha
         frag.write('fragColor.rgb = pow(fragColor.rgb, vec3(2.2));')
 
     if '_EnvClouds' in world.world_defs:
-        frag.write('if (n.z > 0.0) fragColor.rgb = mix(fragColor.rgb, traceClouds(fragColor.rgb, n), clamp(n.z * 5.0, 0, 1));')
+        frag.write('if (pos.z > 0.0) fragColor.rgb = mix(fragColor.rgb, traceClouds(fragColor.rgb, pos), clamp(pos.z * 5.0, 0, 1));')
 
     if '_EnvLDR' in world.world_defs:
         frag.write('fragColor.rgb = pow(fragColor.rgb, vec3(1.0 / 2.2));')
@@ -217,20 +217,15 @@ def build_node_tree(world: bpy.types.World, frag: Shader, vert: Shader, con: Sha
     # Mark as non-opaque
     frag.write('fragColor.a = 0.0;')
 
-    # Hack to make procedural textures work
-    frag_bpos = (frag.contains('bposition') and not frag.contains('vec3 bposition')) or vert.contains('bposition')
-    if frag_bpos:
-        frag.add_in('vec3 bposition')
-        vert.add_out('vec3 bposition')
-        # Use normals for now
-        vert.write('bposition = nor;')
+    if frag.contains('pos') and not frag.contains('vec3 pos'):
+        frag.write_attrib('vec3 pos = -n;')
 
-    frag_mpos = (frag.contains('mposition') and not frag.contains('vec3 mposition')) or vert.contains('mposition')
-    if frag_mpos:
-        frag.add_in('vec3 mposition')
-        vert.add_out('vec3 mposition')
-        # Use normals for now
-        vert.write('mposition = nor;')
+    # Hack to make procedural textures work
+    for var in ('bposition', 'mposition', 'wposition'):
+        if (frag.contains(var) and not frag.contains(f'vec3 {var}')) or vert.contains(var):
+            frag.add_in(f'vec3 {var}')
+            vert.add_out(f'vec3 {var}')
+            vert.write(f'{var} = pos;')
 
     if frag.contains('texCoord') and not frag.contains('vec2 texCoord'):
         frag.add_in('vec2 texCoord')

--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -273,8 +273,6 @@ def parse_texcoord(node: bpy.types.ShaderNodeTexCoord, out_socket: bpy.types.Nod
     if out_socket == node.outputs[0]: # Generated - bounds
         return 'bposition'
     elif out_socket == node.outputs[1]: # Normal
-        if state.context == ParserContext.WORLD:
-            return '-n'
         return 'n'
     elif out_socket == node.outputs[2]: # UV
         state.con.add_elem('tex', 'short2norm')

--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -278,6 +278,8 @@ def parse_texcoord(node: bpy.types.ShaderNodeTexCoord, out_socket: bpy.types.Nod
     elif out_socket == node.outputs[1]: # Normal
         return 'n'
     elif out_socket == node.outputs[2]: # UV
+        if state.context == ParserContext.WORLD:
+            return 'vec3(0.0)'
         state.con.add_elem('tex', 'short2norm')
         return 'vec3(texCoord.x, 1.0 - texCoord.y, 0.0)'
     elif out_socket == node.outputs[3]: # Object
@@ -289,6 +291,8 @@ def parse_texcoord(node: bpy.types.ShaderNodeTexCoord, out_socket: bpy.types.Nod
         state.frag.add_uniform('vec2 screenSize', link='_screenSize')
         return f'vec3(gl_FragCoord.xy / screenSize, 0.0)'
     elif out_socket == node.outputs[6]: # Reflection
+        if state.context == ParserContext.WORLD:
+            return 'n'
         return 'vec3(0.0)'
 
 

--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -159,9 +159,12 @@ def parse_geometry(node: bpy.types.ShaderNodeNewGeometry, out_socket: bpy.types.
         return 'mposition'
     # Backfacing
     elif out_socket == node.outputs[6]:
-        return '(1.0 - float(gl_FrontFacing))'
+        return '(1.0 - float(gl_FrontFacing))' if state.context == ParserContext.OBJECT else '0.0'
     # Pointiness
     elif out_socket == node.outputs[7]:
+        return '0.0'
+    # Random Per Island
+    elif out_socket == node.outputs[8]:
         return '0.0'
 
 

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -384,8 +384,8 @@ def parse_sky_hosekwilkie(node: bpy.types.ShaderNodeTexSky, state: ParserState) 
 
         state.radiance_written = True
 
-    curshader.write('float cos_theta = clamp(n.z, 0.0, 1.0);')
-    curshader.write('float cos_gamma = dot(n, hosekSunDirection);')
+    curshader.write('float cos_theta = clamp(pos.z, 0.0, 1.0);')
+    curshader.write('float cos_gamma = dot(pos, hosekSunDirection);')
     curshader.write('float gamma_val = acos(cos_gamma);')
 
     return 'Z * hosekWilkie(cos_theta, gamma_val, cos_gamma) * envmapStrength;'
@@ -420,9 +420,9 @@ def parse_sky_nishita(node: bpy.types.ShaderNodeTexSky, state: ParserState) -> v
         # sun_size is already in radians despite being degrees in the UI
         theta = 0.5 * (math.pi - node.sun_size)
         size = math.cos(theta)
-        sun = f'* sun_disk(n, sunDir, {size}, {node.sun_intensity})'
+        sun = f'* sun_disk(pos, sunDir, {size}, {node.sun_intensity})'
 
-    return f'nishita_atmosphere(n, vec3(0, 0, {ray_origin_z}), sunDir, {planet_radius}){sun}'
+    return f'nishita_atmosphere(pos, vec3(0, 0, {ray_origin_z}), sunDir, {planet_radius}){sun}'
 
 
 def parse_tex_environment(node: bpy.types.ShaderNodeTexEnvironment, out_socket: bpy.types.NodeSocket, state: ParserState) -> vec3str:
@@ -524,7 +524,7 @@ def parse_tex_environment(node: bpy.types.ShaderNodeTexEnvironment, out_socket: 
     if rpdat.arm_irradiance and rpdat.arm_radiance and not mobile_mat:
         wrd.world_defs += '_Rad'
 
-    return 'texture(envmap, envMapEquirect(n)).rgb * envmapStrength'
+    return 'texture(envmap, envMapEquirect(pos)).rgb * envmapStrength'
 
 
 def parse_tex_voronoi(node: bpy.types.ShaderNodeTexVoronoi, out_socket: bpy.types.NodeSocket, state: ParserState) -> Union[floatstr, vec3str]:


### PR DESCRIPTION
Requires https://github.com/armory3d/iron/pull/140.

The world normals in Armory were the opposite of how Blender works (which is actually the correct way), the zenith had normals (0, 0, 1) which rather is the _position_ of the zenith but _not its normal vector_ (0, 0, -1). This resulted in worlds looking different than in Blender if the Geometry node was used. Now there is a differentiation between normals and position and all usages should be updated accordingly. Tested it with both sky types, clouds, environment maps and all outputs of the Texture Coordinate and Geometry nodes.

Also fixed in the Geometry node:
- `Tangent`, `Incoming` and `Backfacing` outputs in world shaders
- Added fake support for the new `Random Per Island` output (Cycles only, so it just returns 0.0 like in Eevee)

Fixed in the Texture Coordinate node:
- The `UV` output now outputs (0,0,0) like in Blender, before it was (1,0,0).
- The `Reflection` output returns the normals like in Blender

Still not correct: the `Camera` output in the Texture Coordinate node doesn't work and just outputs (0,0,0) and the `Window` output is the wrong way around (might be DirectX only, I can't test html5 right now due to a bug).

@luboslenco Maybe the environment map coords of ArmorPaint worlds need to be updated if the linked Iron PR is merged.