### PR TITLE
random color node fix

### DIFF
--- a/Sources/armory/logicnode/RandomColorNode.hx
+++ b/Sources/armory/logicnode/RandomColorNode.hx
@@ -4,18 +4,17 @@ import iron.math.Vec4;
 
 class RandomColorNode extends LogicNode {
 
-	var v = new Vec4();
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 	override function get(from: Int): Dynamic {
+		
 		var r = Math.random();
 		var g = Math.random();
 		var b = Math.random();
 		// var a = Math.random();
-		v.set(r, g, b);
+		var v = new Vec4(r, g, b);
 		return v;
 	}
 }


### PR DESCRIPTION
minor fix for the random color node. The mutability of Vec4 caused some issues in a few cases. This PR fixes that by creating a new Vec4 each time.

Thanks to @ The Mask and @ MoritzBrueckner for bringing up the issue. 