### PR TITLE
Fix dox when using special characters

### DIFF
--- a/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
+++ b/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
@@ -207,7 +207,7 @@ class PhysicsWorld extends Trait {
 	/**
 	   Used to get intersecting rigid bodies with the passed in RigidBody as reference. Often used when checking for object collisions.
 	   @param	body The passed in RigidBody to be checked for intersecting rigid bodies.
-	   @return Array<RigidBody> or null.
+	   @return `Array<RigidBody>`
 	**/
 	public function getContacts(body: RigidBody): Array<RigidBody> {
 		if (contacts.length == 0) return null;

--- a/Sources/armory/ui/Canvas.hx
+++ b/Sources/armory/ui/Canvas.hx
@@ -277,7 +277,7 @@ class Canvas {
 		Returns the positional scaled offset of the given element based on its anchor setting.
 		@param canvas The canvas object
 		@param element The element
-		@return Array<Float> [xOffset, yOffset]
+		@return `Array<Float> [xOffset, yOffset]`
 	**/
 	public static function getAnchorOffset(canvas: TCanvas, element: TElement): Array<Float> {
 		var boxWidth, boxHeight: Float;


### PR DESCRIPTION
Documentation generation in armsdk is cluttered as dox doesn't seem to escape special characters correctly (HaxeFoundation/dox#291).

For example: https://api.armory3d.org/iron/Scene.html#getChildren

This pr fixes dox generation for `armory.*`.
PR for iron https://github.com/armory3d/iron/pull/141
