### PR TITLE
Fix exporting textures from linked libraries

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -737,7 +737,9 @@ def node_name(s: str) -> str:
 
 ##
 
+
 def make_texture(image_node: bpy.types.ShaderNodeTexImage, tex_name: str, matname: str = None) -> Optional[Dict[str, Any]]:
+    """Creates a texture reference for the export data for a given texture node."""
     tex = {'name': tex_name}
 
     if matname is None:
@@ -768,6 +770,8 @@ def make_texture(image_node: bpy.types.ShaderNodeTexImage, tex_name: str, matnam
         else:
             log.warn(matname + '/' + image.name + ' - invalid file path')
             return None
+    else:
+        filepath = arm.utils.to_absolute_path(filepath, image.library)
 
     # Reference image name
     texpath = arm.utils.asset_path(filepath)

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -104,7 +104,8 @@ def blend_name():
 def build_dir():
     return 'build_' + safestr(blend_name())
 
-def get_fp():
+
+def get_fp() -> str:
     wrd = bpy.data.worlds['Arm']
     if wrd.arm_project_root != '':
         return bpy.path.abspath(wrd.arm_project_root)
@@ -127,8 +128,21 @@ def get_fp():
             s += os.path.sep
         return s
 
+
 def get_fp_build():
     return os.path.join(get_fp(), build_dir())
+
+
+def to_absolute_path(path: str, from_library: Optional[bpy.types.Library] = None) -> str:
+    """Convert the given absolute or relative path into an absolute path.
+
+    - If `from_library` is not set (default), a given relative path will be
+      interpreted as relative to the project directory.
+    - If `from_library` is set, a given relative path will be interpreted as
+      relative to the filepath of the specified library.
+    """
+    return os.path.normpath(bpy.path.abspath(path, start=get_fp(), library=from_library))
+
 
 def get_os() -> str:
     s = platform.system()


### PR DESCRIPTION
Fixes an issue that could happen if a material from a linked library used a texture with a path relative to the library. In this case the relative path would be copied to the khafile and Iron would then try to load a nonexisting texture.

@luboslenco Currently `krom_load_image()` will return `null` when an image doesn't exist which will result in a Kha image object which neither has a `texture_` nor a `renderTarget_` set. Because of that, Amorcore will crash as soon as Iron tries to generate mipmaps for the image. Should there be handling for this in the mipmap generating function? Should `krom_load_image()` instead trigger a failure callback so that those failures can be more easily handled in Iron? I'm not sure what the "design philosophy" of Armorcore or Iron is in this case.