### PR TITLE
Decal fix

### DIFF
--- a/Sources/armory/logicnode/GetMaterialNode.hx
+++ b/Sources/armory/logicnode/GetMaterialNode.hx
@@ -1,6 +1,7 @@
 package armory.logicnode;
 
 import iron.object.MeshObject;
+import iron.object.DecalObject;
 
 class GetMaterialNode extends LogicNode {
 
@@ -9,11 +10,27 @@ class GetMaterialNode extends LogicNode {
 	}
 
 	override function get(from: Int): Dynamic {
-		var object: MeshObject = inputs[0].get();
-		var slot: Int = inputs[1].get();
 
-		if (object == null) return null;
+		var object = inputs[0].get();
 
-		return object.materials[slot];
+		assert(Error, object != null, "The object input must not be null");
+
+		#if rp_decals
+		if (Std.isOfType(object, DecalObject)) {
+			var decal = cast(object, DecalObject);
+			return decal.material;
+		}
+		#end
+
+		if (Std.isOfType(object, MeshObject)) {
+			var mesh = cast(object, MeshObject);
+			var slot: Int = inputs[1].get();
+			
+			if (mesh == null) return null;
+			
+			return mesh.materials[slot];
+		}
+
+		return null;
 	}
 }

--- a/Sources/armory/trait/internal/UniformsManager.hx
+++ b/Sources/armory/trait/internal/UniformsManager.hx
@@ -1,5 +1,6 @@
 package armory.trait.internal;
 
+import iron.object.DecalObject;
 import iron.object.MeshObject;
 import iron.Trait;
 import kha.Image;
@@ -39,6 +40,7 @@ class UniformsManager extends Trait{
 	}
 
 	function init() {
+		if(object.raw.type != 'mesh_object') return;
 		var materials = cast(object, MeshObject).materials;
 
 		for (material in materials){

--- a/Sources/armory/trait/internal/UniformsManager.hx
+++ b/Sources/armory/trait/internal/UniformsManager.hx
@@ -40,16 +40,28 @@ class UniformsManager extends Trait{
 	}
 
 	function init() {
-		if(object.raw.type != 'mesh_object') return;
-		var materials = cast(object, MeshObject).materials;
+		if(Std.isOfType(object, MeshObject)){
+			var materials = cast(object, MeshObject).materials;
 
-		for (material in materials){
+			for (material in materials){
+
+				var exists = registerShaderUniforms(material);
+				if(exists) {
+					uniformExists = true;
+				}
+			}
+		}
+		#if rp_decals
+		if(Std.isOfType(object, DecalObject)){
+			var material = cast(object, DecalObject).material;
 
 			var exists = registerShaderUniforms(material);
 			if(exists) {
 				uniformExists = true;
 			}
+			
 		}
+		#end
 	}
 
 	static function removeScene() {


### PR DESCRIPTION
The uniforms manager did not take into account decal objects and caused errors. This PR fixes that by supporting uniforms in decal objects as well.

Requires https://github.com/armory3d/iron/pull/144