### PR TITLE
fix TransformExtension - Normalize vectors

### DIFF
--- a/Sources/armory/object/TransformExtension.hx
+++ b/Sources/armory/object/TransformExtension.hx
@@ -43,6 +43,15 @@ class TransformExtension {
 	* @return Vec4
 	**/
 	public static inline function worldVecToOrientation(t: Transform, worldVec: Vec4): Vec4 {
-		return t.right().mult(worldVec.x).add(t.look().mult(worldVec.y)).add(t.up().mult(worldVec.z));
+		var right = t.right().normalize();
+		right.mult(worldVec.x);
+
+		var look = t.look().normalize();
+		look.mult(worldVec.y);
+
+		var up = t.up().normalize();
+		up.mult(worldVec.z);
+		
+		return new Vec4().add(right).add(look).add(up);
 	}
 }


### PR DESCRIPTION
The right, look and up vectors were not normalized. This PR fixes that by normalizing the orientation vectors before multiplying world vectors