### PR TITLE
Fix environment gamma and improve handling of envmap file formats

### DIFF
--- a/blender/arm/make_world.py
+++ b/blender/arm/make_world.py
@@ -76,7 +76,7 @@ def build():
                         world.arm_envtex_irr_name = os.path.basename(image_filepath).rsplit('.', 1)[0]
 
                         write_radiance = rpdat.arm_radiance and not mobile_mat
-                        mip_count = write_probes.write_probes(image_filepath, write_probes.ENVMAP_FORMAT == 'JPEG', world.arm_envtex_num_mips, write_radiance)
+                        mip_count = write_probes.write_probes(image_filepath, write_probes.ENVMAP_FORMAT == 'JPEG', False, world.arm_envtex_num_mips, write_radiance)
                         world.arm_envtex_num_mips = mip_count
 
                         if write_radiance:

--- a/blender/arm/make_world.py
+++ b/blender/arm/make_world.py
@@ -69,17 +69,14 @@ def build():
                     # Render world to envmap for (ir)radiance, if no
                     # other probes are exported
                     elif world.arm_envtex_name == '':
-                        write_probes.render_envmap(envpath, world)
-
-                        filename = f'env_{arm.utils.safesrc(world.name)}'
-                        image_file = f'{filename}.jpg'
+                        image_file = write_probes.render_envmap(envpath, world)
                         image_filepath = os.path.join(envpath, image_file)
 
                         world.arm_envtex_name = image_file
                         world.arm_envtex_irr_name = os.path.basename(image_filepath).rsplit('.', 1)[0]
 
                         write_radiance = rpdat.arm_radiance and not mobile_mat
-                        mip_count = write_probes.write_probes(image_filepath, True, world.arm_envtex_num_mips, write_radiance)
+                        mip_count = write_probes.write_probes(image_filepath, write_probes.ENVMAP_FORMAT == 'JPEG', world.arm_envtex_num_mips, write_radiance)
                         world.arm_envtex_num_mips = mip_count
 
                         if write_radiance:

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -214,10 +214,11 @@ def parse_tex_image(node: bpy.types.ShaderNodeTexImage, out_socket: bpy.types.No
         world.arm_envtex_irr_name = tex_file.rsplit('.', 1)[0]
 
         disable_hdr = target_format == 'JPEG'
+        from_srgb = image.colorspace_settings.name == "sRGB"
 
         rpdat = arm.utils.get_rp()
         mip_count = world.arm_envtex_num_mips
-        mip_count = write_probes.write_probes(filepath, disable_hdr, mip_count, arm_radiance=rpdat.arm_radiance)
+        mip_count = write_probes.write_probes(filepath, disable_hdr, from_srgb, mip_count, arm_radiance=rpdat.arm_radiance)
 
         world.arm_envtex_num_mips = mip_count
 
@@ -505,9 +506,10 @@ def parse_tex_environment(node: bpy.types.ShaderNodeTexEnvironment, out_socket: 
         world.arm_envtex_name = tex_file
         world.arm_envtex_irr_name = tex_file.rsplit('.', 1)[0]
         disable_hdr = target_format == 'JPEG'
+        from_srgb = image.colorspace_settings.name == "sRGB"
 
         mip_count = world.arm_envtex_num_mips
-        mip_count = write_probes.write_probes(filepath, disable_hdr, mip_count, arm_radiance=rpdat.arm_radiance)
+        mip_count = write_probes.write_probes(filepath, disable_hdr, from_srgb, mip_count, arm_radiance=rpdat.arm_radiance)
 
         world.arm_envtex_num_mips = mip_count
 


### PR DESCRIPTION
- This PR tries to fix the overly strong irradiance brightness that was introduced by using a world render as the input to cmft. The biggest problem was that the environment render wasn't properly gamma corrected/in the wrong color space and thus too bright.

  Unfortunately there are still some visible differences to Blender depending on the situation, even though they are much less extreme now. Apparently cmft's calculations differ from Blender's calculations, when comparing the output of cmft for a given (color-correct) render of a plain color in [this SH viewer](https://ed.ilogues.com/2016/02/19/interactive-spherical-harmonic-visualization) with Blender there are still slight differences (without any tonemapping/color grading active).

  For more details please see https://forums.armory3d.org/t/render-too-bright/4666.

- If there is a `Enviroment Texture` or a `Image Texture` node with `sRGB` color space, there is now gamma correction when calculating the SH coeffs.

- Some minor handling improvements of envmap file formats