### PR TITLE
Fix Bool, Int and Float vector property export from logic nodes

### DIFF
--- a/blender/arm/logicnode/arm_props.py
+++ b/blender/arm/logicnode/arm_props.py
@@ -12,6 +12,7 @@ for parity with the Blender API.
 """
 from typing import Any, Callable, Sequence, Union
 
+import sys
 import bpy
 from bpy.props import *
 
@@ -164,10 +165,10 @@ def HaxeFloatVectorProperty(
         name: str = "",
         description: str = "",
         default: list = (0.0, 0.0, 0.0),
-        min: float = 'sys.float_info.min',
-        max: float = 'sys.float_info.max',
-        soft_min: float = 'sys.float_info.min',
-        soft_max: float = 'sys.float_info.max',
+        min: float = sys.float_info.min,
+        max: float = sys.float_info.max,
+        soft_min: float = sys.float_info.min,
+        soft_max: float = sys.float_info.max,
         step: int = 3,
         precision: int = 2,
         options: set = {'ANIMATABLE'},

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -161,6 +161,21 @@ def haxe_format_socket_val(socket_val: Any, array_outer_brackets=True) -> str:
     return str(socket_val)
 
 
+def haxe_format_val(prop) -> str:
+    """Formats a basic value to be valid Haxe syntax."""
+    if isinstance(prop, str):
+        res = '"' + str(prop) + '"'
+    elif isinstance(prop, bool):
+        res = str(prop).lower()
+    else:
+        if prop is None:
+            res = 'null'
+        else:
+            res = str(prop)
+
+    return str(res)
+
+
 def haxe_format_prop_value(node: bpy.types.Node, prop_name: str) -> str:
     """Formats a property value to be valid Haxe syntax."""
     prop_value = getattr(node, prop_name)
@@ -170,6 +185,8 @@ def haxe_format_prop_value(node: bpy.types.Node, prop_name: str) -> str:
         prop_value = str(prop_value).lower()
     elif hasattr(prop_value, 'name'):  # PointerProperty
         prop_value = '"' + str(prop_value.name) + '"'
+    elif isinstance(prop_value, bpy.types.bpy_prop_array):
+        prop_value = '[' + ','.join(haxe_format_val(prop) for prop in prop_value) + ']'
     else:
         if prop_value is None:
             prop_value = 'null'


### PR DESCRIPTION
Bool, Int and Float Vector properties were not parsed properly for Haxe. This PR fixes this.

Thanks to @MoritzBrueckner for help.