### PR TITLE
Fix parser context references after reload and make enum values unique

### DIFF
--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import IntEnum, unique
 from typing import List, Set, Tuple, Union, Optional
 
 import bpy
@@ -12,13 +12,13 @@ if arm.is_reload(__name__):
 else:
     arm.enable_reload(__name__)
 
-
-class ParserContext(Enum):
-    """Describes which kind of node tree is parsed."""
-    OBJECT = 0
-    # Texture node trees are not supported yet
-    # TEXTURE = 1
-    WORLD = 2
+    @unique
+    class ParserContext(IntEnum):
+        """Describes which kind of node tree is parsed."""
+        OBJECT = 0
+        # Texture node trees are not supported yet
+        # TEXTURE = 1
+        WORLD = 2
 
 
 class ParserState:


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2301. The `ParserContext` enum was redefined during reload which is no longer the case, and to make things extra-safe the enum is now an `IntEnum` which makes the values comparable.