### PR TITLE
Add option to enable Haxe's --no-traces param

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -260,8 +260,7 @@ def export_data(fp, sdk_path):
         wrd.arm_project_version = arm.utils.arm.utils.change_version_project(wrd.arm_project_version)
 
     # Write khafile.js
-    enable_dce = state.is_publish and wrd.arm_dce
-    write_data.write_khafilejs(state.is_play, export_physics, export_navigation, export_ui, state.is_publish, enable_dce, ArmoryExporter.import_traits)
+    write_data.write_khafilejs(state.is_play, export_physics, export_navigation, export_ui, state.is_publish, ArmoryExporter.import_traits)
 
     # Write Main.hx - depends on write_khafilejs for writing number of assets
     scene_name = arm.utils.get_project_scene_name()
@@ -900,7 +899,7 @@ def clean():
         shutil.rmtree('Sources/' + pkg_dir, onerror=remove_readonly)
         if os.path.exists('Sources') and os.listdir('Sources') == []:
             shutil.rmtree('Sources/', onerror=remove_readonly)
-    
+
     # Remove Shape key Textures
     if os.path.exists('MorphTargets/'):
         shutil.rmtree('MorphTargets/', onerror=remove_readonly)

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -224,6 +224,7 @@ def init_properties():
     bpy.types.World.arm_sound_quality = FloatProperty(name="Sound Quality", default=0.9, min=0.0, max=1.0, subtype='FACTOR', update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_minimize = BoolProperty(name="Binary Scene Data", description="Export scene data in binary", default=True, update=assets.invalidate_compiled_data)
     bpy.types.World.arm_minify_js = BoolProperty(name="Minify JS", description="Minimize JavaScript output when publishing", default=True)
+    bpy.types.World.arm_no_traces = BoolProperty(name="No Traces", description="Don't compile trace calls in the program when publishing", default=False)
     bpy.types.World.arm_optimize_data = BoolProperty(name="Optimize Data", description="Export more efficient geometry and shader data, prolongs build times", default=True, update=assets.invalidate_compiled_data)
     bpy.types.World.arm_deinterleaved_buffers = BoolProperty(name="Deinterleaved Buffers", description="Use deinterleaved vertex buffers", default=False, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_export_tangents = BoolProperty(name="Precompute Tangents", description="Precompute tangents for normal mapping, otherwise computed in shader", default=True, update=assets.invalidate_compiled_data)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -694,12 +694,13 @@ class ARM_PT_ArmoryExporterPanel(bpy.types.Panel):
         col = layout.column()
         col.prop(wrd, 'arm_project_icon')
 
-        col = layout.column(heading='Code Output')
+        col = layout.column(heading='Code Output', align=True)
         col.prop(wrd, 'arm_dce')
         col.prop(wrd, 'arm_compiler_inline')
         col.prop(wrd, 'arm_minify_js')
+        col.prop(wrd, 'arm_no_traces')
 
-        col = layout.column(heading='Data')
+        col = layout.column(heading='Data', align=True)
         col.prop(wrd, 'arm_minimize')
         col.prop(wrd, 'arm_optimize_data')
         col.prop(wrd, 'arm_asset_compression')

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1344,7 +1344,7 @@ class ARM_PT_RenderPathRendererPanel(bpy.types.Panel):
         row.enabled = not rpdat.arm_skin_max_bones_auto
         row.prop(rpdat, 'arm_skin_max_bones')
         layout.separator(factor=0.1)
-        
+
         col = layout.column()
         col.prop(rpdat, 'arm_morph_target')
         col = col.column()

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -63,7 +63,7 @@ def remove_readonly(func, path, excinfo):
 
 
 def write_khafilejs(is_play, export_physics: bool, export_navigation: bool, export_ui: bool, is_publish: bool,
-                    enable_dce: bool, import_traits: List[str]) -> None:
+                    import_traits: List[str]) -> None:
     wrd = bpy.data.worlds['Arm']
 
     sdk_path = arm.utils.get_sdk_path()
@@ -163,10 +163,13 @@ project.addSources('Sources');
 
         if is_publish:
             assets.add_khafile_def('arm_published')
-            if wrd.arm_asset_compression:
-                assets.add_khafile_def('arm_compress')
+            if wrd.arm_dce:
+                khafile.write("project.addParameter('-dce full');\n")
             if wrd.arm_no_traces:
                 khafile.write("project.addParameter('--no-traces');\n")
+            if wrd.arm_asset_compression:
+                assets.add_khafile_def('arm_compress')
+
         else:
             assets.add_khafile_def(f'arm_assert_level={wrd.arm_assert_level}')
             if wrd.arm_assert_quit:
@@ -184,9 +187,6 @@ project.addSources('Sources');
 
         if not wrd.arm_compiler_inline:
             khafile.write("project.addParameter('--no-inline');\n")
-
-        if enable_dce:
-            khafile.write("project.addParameter('-dce full');\n")
 
         use_live_patch = arm.utils.is_livepatch_enabled()
         if wrd.arm_debug_console or use_live_patch:

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -87,7 +87,7 @@ project.addSources('Sources');
             for file in glob.glob("Bundled/**", recursive=True):
                 if os.path.isfile(file):
                     assets.add(file)
-        
+
         # Auto-add shape key textures if exists
         if os.path.exists('MorphTargets'):
             for file in glob.glob("MorphTargets/**", recursive=True):
@@ -305,7 +305,7 @@ project.addSources('Sources');
         rpdat = arm.utils.get_rp()
         if rpdat.arm_skin != 'Off':
             assets.add_khafile_def('arm_skin')
-        
+
         if rpdat.arm_morph_target != 'Off':
             assets.add_khafile_def('arm_morph_target')
 

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -165,6 +165,8 @@ project.addSources('Sources');
             assets.add_khafile_def('arm_published')
             if wrd.arm_asset_compression:
                 assets.add_khafile_def('arm_compress')
+            if wrd.arm_no_traces:
+                khafile.write("project.addParameter('--no-traces');\n")
         else:
             assets.add_khafile_def(f'arm_assert_level={wrd.arm_assert_level}')
             if wrd.arm_assert_quit:


### PR DESCRIPTION
This PR adds a new option to toggle off `trace()` calls in published builds via the `--no-traces` parameter (https://haxe.org/manual/compiler-usage.html#other-global-arguments).

![Screenshot](https://user-images.githubusercontent.com/17685000/142911310-4628e31b-eab9-47e5-87a6-ecbd7da2327e.png)
