### PR TITLE
Compare node: fix accessing vector methods when DCE is on

### DIFF
--- a/Sources/armory/logicnode/CompareNode.hx
+++ b/Sources/armory/logicnode/CompareNode.hx
@@ -19,11 +19,11 @@ class CompareNode extends LogicNode {
 
 		switch (property0) {
 		case "Equal":
-			cond = Std.isOfType(v1, Vec4) ? v1.equals(v2) : v1 == v2;
+			cond = Std.isOfType(v1, Vec4) ? (v1: Vec4).equals(v2) : v1 == v2;
 		case "Not Equal":
-			cond = Std.isOfType(v1, Vec4) ? !v1.equals(v2) : v1 != v2;
+			cond = Std.isOfType(v1, Vec4) ? !(v1: Vec4).equals(v2) : v1 != v2;
 		case "Almost Equal":
-			cond = Std.isOfType(v1, Vec4) ? v1.almostEquals(v2, property1) : Math.abs(v1 - v2) < property1;
+			cond = Std.isOfType(v1, Vec4) ? (v1: Vec4).almostEquals(v2, property1) : Math.abs(v1 - v2) < property1;
 		case "Greater":
 			cond = v1 > v2;
 		case "Greater Equal":


### PR DESCRIPTION
Fixes https://forums.armory3d.org/t/removing-object-causes-game-to-freeze-only-after-exporting/4742.

Because the objects that are compared by the compare node are typed as `Dynamic`, DCE seems to have some problems and accidentally removes some used vector functions. To not clutter Iron code with `@:keep` metadata that makes it difficult to see why it was used in the first place, I decided to use the [type check syntax](https://haxe.org/manual/expression-type-check.html) instead to take away some work from the compiler.