### PR TITLE
Introducing Node Groups

### DIFF
--- a/Sources/armory/logicnode/CallGroupNode.hx
+++ b/Sources/armory/logicnode/CallGroupNode.hx
@@ -19,8 +19,14 @@ class CallGroupNode extends LogicNode {
 			callTree.add();
 		}
 
-		if (callTree._init != null) callTree._init[0]();
-
+		var args = [];
+		args.push(from);
+		var func = Reflect.field(callTree, "runGroupInput");
+		Reflect.callMethod(callTree, func, args);
 		runOutput(0);
+	}
+
+	override function get(from:Int):Dynamic {
+		return inputs[from].get();
 	}
 }

--- a/Sources/armory/logicnode/CallGroupNode.hx
+++ b/Sources/armory/logicnode/CallGroupNode.hx
@@ -3,30 +3,7 @@ package armory.logicnode;
 class CallGroupNode extends LogicNode {
 
 	public var property0: String;
-	var callTree: LogicTree = null;
-
 	public function new(tree: LogicTree) {
 		super(tree);
-	}
-
-	@:access(iron.Trait)
-	override function run(from: Int) {
-
-		if (callTree == null) {
-			var classType = Type.resolveClass(property0);
-			callTree = Type.createInstance(classType, []);
-			callTree.object = tree.object;
-			callTree.add();
-		}
-
-		var args = [];
-		args.push(from);
-		var func = Reflect.field(callTree, "runGroupInput");
-		Reflect.callMethod(callTree, func, args);
-		runOutput(0);
-	}
-
-	override function get(from:Int):Dynamic {
-		return inputs[from].get();
 	}
 }

--- a/Sources/armory/logicnode/GroupInputNode.hx
+++ b/Sources/armory/logicnode/GroupInputNode.hx
@@ -6,8 +6,8 @@ class GroupInputNode extends LogicNode {
 		super(tree);
 	}
 
-	@:allow(armory.logicnode.LogicTree)
 	override function run(from: Int) {
+		trace("inp called");
 		runOutput(from);
 	}
 

--- a/Sources/armory/logicnode/GroupInputNode.hx
+++ b/Sources/armory/logicnode/GroupInputNode.hx
@@ -7,7 +7,6 @@ class GroupInputNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
-		trace("inp called");
 		runOutput(from);
 	}
 

--- a/Sources/armory/logicnode/GroupInputNode.hx
+++ b/Sources/armory/logicnode/GroupInputNode.hx
@@ -1,0 +1,17 @@
+package armory.logicnode;
+
+class GroupInputNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	@:allow(armory.logicnode.LogicTree)
+	override function run(from: Int) {
+		runOutput(from);
+	}
+
+	override function get(from: Int): Dynamic {
+		return inputs[from].get();
+	}
+}

--- a/Sources/armory/logicnode/GroupInputsNode.hx
+++ b/Sources/armory/logicnode/GroupInputsNode.hx
@@ -1,6 +1,6 @@
 package armory.logicnode;
 
-class GroupOutputNode extends LogicNode {
+class GroupInputsNode extends LogicNode {
 
 	public function new(tree: LogicTree) {
 		super(tree);

--- a/Sources/armory/logicnode/GroupOutputNode.hx
+++ b/Sources/armory/logicnode/GroupOutputNode.hx
@@ -7,7 +7,6 @@ class GroupOutputNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
-		trace("output called");
 		runOutput(from);
 	}
 

--- a/Sources/armory/logicnode/GroupOutputNode.hx
+++ b/Sources/armory/logicnode/GroupOutputNode.hx
@@ -7,7 +7,8 @@ class GroupOutputNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
-		runOutput(0);
+		trace("output called");
+		runOutput(from);
 	}
 
 	override function get(from: Int): Dynamic {

--- a/Sources/armory/logicnode/GroupOutputNode.hx
+++ b/Sources/armory/logicnode/GroupOutputNode.hx
@@ -9,4 +9,8 @@ class GroupOutputNode extends LogicNode {
 	override function run(from: Int) {
 		runOutput(0);
 	}
+
+	override function get(from: Int): Dynamic {
+		return inputs[from].get();
+	}
 }

--- a/Sources/armory/logicnode/GroupOutputsNode.hx
+++ b/Sources/armory/logicnode/GroupOutputsNode.hx
@@ -1,6 +1,6 @@
 package armory.logicnode;
 
-class GroupInputNode extends LogicNode {
+class GroupOutputsNode extends LogicNode {
 
 	public function new(tree: LogicTree) {
 		super(tree);

--- a/blender/arm/logicnode/arm_sockets.py
+++ b/blender/arm/logicnode/arm_sockets.py
@@ -11,6 +11,22 @@ if arm.is_reload(__name__):
 else:
     arm.enable_reload(__name__)
 
+socket_colors = {
+    'ArmNodeSocketAction': (0.8, 0.3, 0.3, 1),
+    'ArmNodeSocketAnimAction': (0.8, 0.8, 0.8, 1),
+    'ArmRotationSocket': (0.68, 0.22, 0.62, 1),
+    'ArmNodeSocketArray': (0.8, 0.4, 0.0, 1),
+    'ArmBoolSocket': (0.8, 0.651, 0.839, 1),
+    'ArmColorSocket': (0.78, 0.78, 0.161, 1),
+    'ArmDynamicSocket': (0.388, 0.78, 0.388, 1),
+    'ArmFloatSocket': (0.631, 0.631, 0.631, 1),
+    'ArmIntSocket': (0.059, 0.522, 0.149, 1),
+    'ArmNodeSocketObject': (0.15, 0.55, 0.75, 1),
+    'ArmStringSocket': (0.439, 0.698, 1, 1),
+    'ArmVectorSocket': (0.388, 0.388, 0.78, 1),
+    'ArmAnySocket': (0.9, 0.9, 0.9, 1)
+
+}
 
 def _on_update_socket(self, context):
     self.node.on_socket_val_update(context, self)
@@ -43,7 +59,7 @@ class ArmActionSocket(ArmCustomSocket):
         layout.label(text=self.name)
 
     def draw_color(self, context, node):
-        return 0.8, 0.3, 0.3, 1
+        return socket_colors[self.bl_idname]
 
 
 class ArmAnimActionSocket(ArmCustomSocket):
@@ -77,7 +93,7 @@ class ArmAnimActionSocket(ArmCustomSocket):
             layout.prop_search(self, 'default_value_raw', bpy.data, 'actions', icon='NONE', text='')
 
     def draw_color(self, context, node):
-        return 0.8, 0.8, 0.8, 1
+        return socket_colors[self.bl_idname]
 
     
 class ArmRotationSocket(ArmCustomSocket):
@@ -227,7 +243,7 @@ class ArmRotationSocket(ArmCustomSocket):
                 coll.prop(self, 'default_value_s3', text='Angle')            
 
     def draw_color(self, context, node):
-        return 0.68, 0.22, 0.62, 1
+        return socket_colors[self.bl_idname]
 
     default_value_mode: EnumProperty(
         items=[('EulerAngles', 'Euler Angles', 'Euler Angles'),
@@ -273,7 +289,7 @@ class ArmArraySocket(ArmCustomSocket):
         layout.label(text=self.name)
 
     def draw_color(self, context, node):
-        return 0.8, 0.4, 0.0, 1
+        return socket_colors[self.bl_idname]
 
 
 class ArmBoolSocket(ArmCustomSocket):
@@ -291,7 +307,7 @@ class ArmBoolSocket(ArmCustomSocket):
         draw_socket_layout(self, layout)
 
     def draw_color(self, context, node):
-        return 0.8, 0.651, 0.839, 1
+        return socket_colors[self.bl_idname]
 
     def get_default_value(self):
         return self.default_value_raw
@@ -317,7 +333,7 @@ class ArmColorSocket(ArmCustomSocket):
         draw_socket_layout_split(self, layout)
 
     def draw_color(self, context, node):
-        return 0.78, 0.78, 0.161, 1
+        return socket_colors[self.bl_idname]
 
     def get_default_value(self):
         return self.default_value_raw
@@ -332,7 +348,27 @@ class ArmDynamicSocket(ArmCustomSocket):
         layout.label(text=self.name)
 
     def draw_color(self, context, node):
-        return 0.388, 0.78, 0.388, 1
+        return socket_colors[self.bl_idname]
+    
+
+class ArmAnySocket(ArmCustomSocket):
+    bl_idname = 'ArmAnySocket'
+    bl_label = 'Any Socket'
+    arm_socket_type = 'NONE'
+
+    def draw(self, context, layout, node, text):
+        if self.is_linked:
+            if self.is_output:
+                layout.label(text=self.links[0].to_socket.name)
+            else:
+                layout.label(text=self.links[0].from_socket.name)
+
+    def draw_color(self, context, node):
+        if self.is_linked:
+            if self.is_output:
+                return socket_colors[self.links[0].to_socket.bl_idname]
+            return socket_colors[self.links[0].from_socket.bl_idname]
+        return socket_colors[self.bl_idname]
 
 
 class ArmFloatSocket(ArmCustomSocket):
@@ -351,7 +387,7 @@ class ArmFloatSocket(ArmCustomSocket):
         draw_socket_layout(self, layout)
 
     def draw_color(self, context, node):
-        return 0.631, 0.631, 0.631, 1
+        return socket_colors[self.bl_idname]
 
     def get_default_value(self):
         return self.default_value_raw
@@ -372,7 +408,7 @@ class ArmIntSocket(ArmCustomSocket):
         draw_socket_layout(self, layout)
 
     def draw_color(self, context, node):
-        return 0.059, 0.522, 0.149, 1
+        return socket_colors[self.bl_idname]
 
     def get_default_value(self):
         return self.default_value_raw
@@ -409,7 +445,7 @@ class ArmObjectSocket(ArmCustomSocket):
             row.prop_search(self, 'default_value_raw', context.scene, 'objects', icon='NONE', text=self.name)
 
     def draw_color(self, context, node):
-        return 0.15, 0.55, 0.75, 1
+        return socket_colors[self.bl_idname]
 
 
 
@@ -428,7 +464,7 @@ class ArmStringSocket(ArmCustomSocket):
         draw_socket_layout_split(self, layout)
 
     def draw_color(self, context, node):
-        return 0.439, 0.698, 1, 1
+        return socket_colors[self.bl_idname]
 
     def get_default_value(self):
         return self.default_value_raw
@@ -456,7 +492,7 @@ class ArmVectorSocket(ArmCustomSocket):
             layout.label(text=self.name)
 
     def draw_color(self, context, node):
-        return 0.388, 0.388, 0.78, 1
+        return socket_colors[self.bl_idname]
 
     def get_default_value(self):
         return self.default_value_raw
@@ -492,5 +528,6 @@ REG_CLASSES = (
     ArmObjectSocket,
     ArmStringSocket,
     ArmVectorSocket,
+    ArmAnySocket,
 )
 register, unregister = bpy.utils.register_classes_factory(REG_CLASSES)

--- a/blender/arm/logicnode/deprecated/LN_group_nodes.py
+++ b/blender/arm/logicnode/deprecated/LN_group_nodes.py
@@ -1,9 +1,14 @@
+import bpy
+from bpy.props import *
+from bpy.types import Node, NodeSocket
 from arm.logicnode.arm_nodes import *
 
+@deprecated('Group Input Node')
 class GroupOutputNode(ArmLogicTreeNode):
     """Sets the connected chain of nodes as a group of nodes."""
     bl_idname = 'LNGroupOutputNode'
     bl_label = 'Group Nodes'
+    arm_category = 'Miscellaneous'
     arm_section = 'group'
     arm_version = 1
 

--- a/blender/arm/logicnode/miscellaneous/LN_call_group.py
+++ b/blender/arm/logicnode/miscellaneous/LN_call_group.py
@@ -36,11 +36,11 @@ class CallGroupNode(ArmLogicTreeNode):
             self.outputs.remove(output)
         if self.property0_ is not None:
             for node in self.property0_.nodes:
-                if (node.bl_idname == 'LNGroupInputNode'):
+                if (node.bl_idname == 'LNGroupInputsNode'):
                     self.update_inputs(node, context)
                     break
             for node in self.property0_.nodes:
-                if (node.bl_idname == 'LNGroupOutputNode'):
+                if (node.bl_idname == 'LNGroupOutputsNode'):
                     self.update_outputs(node, context)
                     break
 

--- a/blender/arm/logicnode/miscellaneous/LN_call_group.py
+++ b/blender/arm/logicnode/miscellaneous/LN_call_group.py
@@ -15,19 +15,19 @@ class CallGroupNode(ArmLogicTreeNode):
     def property0(self):
         return arm.utils.safesrc(bpy.data.worlds['Arm'].arm_project_package) + '.node.' + arm.utils.safesrc(self.property0_.name)
 
-    @property
-    def property1(self):
-        return arm.utils.safesrc(bpy.data.worlds['Arm'].arm_project_package) + '.node.' + arm.utils.safesrc(self.property1_.name)
-
     def update_inputs(self, node, context):
         for output in node.outputs:
-            if(output.is_linked):
+            if output.is_linked:
                 self.add_input(output.links[0].to_socket.bl_idname, output.links[0].to_socket.name)
+            else:
+                self.add_input('ArmAnySocket', '')
 
     def update_outputs(self, node, context):
         for input in node.inputs:
-            if(input.is_linked):
+            if input.is_linked:
                 self.add_output(input.links[0].from_socket.bl_idname, input.links[0].from_socket.name)
+            else:
+                self.add_output('ArmAnySocket', '')
 
     def update_sockets(self, context):
         for input in self.inputs:

--- a/blender/arm/logicnode/miscellaneous/LN_call_group.py
+++ b/blender/arm/logicnode/miscellaneous/LN_call_group.py
@@ -9,18 +9,45 @@ class CallGroupNode(ArmLogicTreeNode):
     bl_idname = 'LNCallGroupNode'
     bl_label = 'Call Node Group'
     arm_section = 'group'
-    arm_version = 1
+    arm_version = 2
 
     @property
     def property0(self):
         return arm.utils.safesrc(bpy.data.worlds['Arm'].arm_project_package) + '.node.' + arm.utils.safesrc(self.property0_.name)
 
-    property0_: HaxePointerProperty('property0', name='Group', type=bpy.types.NodeTree)
+    @property
+    def property1(self):
+        return arm.utils.safesrc(bpy.data.worlds['Arm'].arm_project_package) + '.node.' + arm.utils.safesrc(self.property1_.name)
 
+    def update_inputs(self, node, context):
+        for output in node.outputs:
+            if(output.is_linked):
+                self.add_input(output.links[0].to_socket.bl_idname, output.links[0].to_socket.name)
+
+    def update_outputs(self, node, context):
+        for input in node.inputs:
+            if(input.is_linked):
+                self.add_output(input.links[0].from_socket.bl_idname, input.links[0].from_socket.name)
+
+    def update_sockets(self, context):
+        for input in self.inputs:
+            self.inputs.remove(input)
+        for output in self.outputs:
+            self.outputs.remove(output)
+        if self.property0_ is not None:
+            for node in self.property0_.nodes:
+                if (node.bl_idname == 'LNGroupInputNode'):
+                    self.update_inputs(node, context)
+                    break
+            for node in self.property0_.nodes:
+                if (node.bl_idname == 'LNGroupOutputNode'):
+                    self.update_outputs(node, context)
+                    break
+
+    property0_: HaxePointerProperty('property0', name='Group', type=bpy.types.NodeTree, update=update_sockets)
+    
     def arm_init(self, context):
-        self.add_input('ArmNodeSocketAction', 'In')
-
-        self.add_output('ArmNodeSocketAction', 'Out')
+        pass
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0_', bpy.data, 'node_groups', icon='NONE', text='')

--- a/blender/arm/logicnode/miscellaneous/LN_group_input.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_input.py
@@ -1,5 +1,6 @@
 import bpy
 
+import arm
 import arm.utils
 from arm.logicnode.arm_nodes import *
 
@@ -18,10 +19,10 @@ class GroupInputNode(ArmLogicTreeNode):
         tree = bpy.context.space_data.edit_tree
         nodeCount = 0
         for node in tree.nodes:
-            if (node.bl_idname == 'LNGroupInputNode'):
+            if node.bl_idname == 'LNGroupInputNode':
                 nodeCount += 1
-        if(nodeCount > 1):
-            print("Too many nodes")
+        if nodeCount > 1:
+            arm.log.warn("Only one group input node per node tree is allowed")
             tree.nodes.remove(self)
         else:
             self.arm_init(context)
@@ -30,10 +31,10 @@ class GroupInputNode(ArmLogicTreeNode):
         tree = bpy.context.space_data.edit_tree
         nodeCount = 0
         for node in tree.nodes:
-            if (node.bl_idname == 'LNGroupInputNode'):
+            if node.bl_idname == 'LNGroupInputNode':
                 nodeCount += 1
-        if(nodeCount > 1):
-            print("Too many nodes")
+        if nodeCount > 1:
+            arm.log.warn("Only one group input node per node tree is allowed")
             tree.nodes.remove(self)
 
     def arm_init(self, context):
@@ -45,6 +46,6 @@ class GroupInputNode(ArmLogicTreeNode):
         op = row.operator('arm.node_add_output', text='New', icon='PLUS', emboss=True)
         op.node_index = str(id(self))
         op.socket_type = 'ArmAnySocket'
-        if(len(self.outputs) > 1):
+        if len(self.outputs) > 1:
             op2 = row.operator('arm.node_remove_output', text='', icon='X', emboss=True)
             op2.node_index = str(id(self))

--- a/blender/arm/logicnode/miscellaneous/LN_group_input.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_input.py
@@ -1,0 +1,28 @@
+import bpy
+
+import arm.utils
+from arm.logicnode.arm_nodes import *
+
+
+class GroupInputNode(ArmLogicTreeNode):
+    """Input for a given a node tree."""
+    bl_idname = 'LNGroupInputNode'
+    bl_label = 'Group Input Node'
+    arm_section = 'group'
+    arm_version = 1
+
+    def __init__(self):
+        array_nodes[str(id(self))] = self
+
+    def arm_init(self, context):
+        self.add_output('ArmAnySocket', '')
+    
+    def draw_buttons(self, context, layout):
+        row = layout.row(align=True)
+
+        op = row.operator('arm.node_add_output', text='New', icon='PLUS', emboss=True)
+        op.node_index = str(id(self))
+        op.socket_type = 'ArmAnySocket'
+        if(len(self.outputs) > 1):
+            op2 = row.operator('arm.node_remove_output', text='', icon='X', emboss=True)
+            op2.node_index = str(id(self))

--- a/blender/arm/logicnode/miscellaneous/LN_group_input.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_input.py
@@ -5,9 +5,9 @@ import arm.utils
 from arm.logicnode.arm_nodes import *
 
 
-class GroupInputNode(ArmLogicTreeNode):
+class GroupInputsNode(ArmLogicTreeNode):
     """Input for a given a node tree."""
-    bl_idname = 'LNGroupInputNode'
+    bl_idname = 'LNGroupInputsNode'
     bl_label = 'Group Input Node'
     arm_section = 'group'
     arm_version = 1
@@ -19,7 +19,7 @@ class GroupInputNode(ArmLogicTreeNode):
         tree = bpy.context.space_data.edit_tree
         nodeCount = 0
         for node in tree.nodes:
-            if node.bl_idname == 'LNGroupInputNode':
+            if node.bl_idname == 'LNGroupInputsNode':
                 nodeCount += 1
         if nodeCount > 1:
             arm.log.warn("Only one group input node per node tree is allowed")
@@ -31,7 +31,7 @@ class GroupInputNode(ArmLogicTreeNode):
         tree = bpy.context.space_data.edit_tree
         nodeCount = 0
         for node in tree.nodes:
-            if node.bl_idname == 'LNGroupInputNode':
+            if node.bl_idname == 'LNGroupInputsNode':
                 nodeCount += 1
         if nodeCount > 1:
             arm.log.warn("Only one group input node per node tree is allowed")

--- a/blender/arm/logicnode/miscellaneous/LN_group_input.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_input.py
@@ -13,6 +13,28 @@ class GroupInputNode(ArmLogicTreeNode):
 
     def __init__(self):
         array_nodes[str(id(self))] = self
+    
+    def init(self, context):
+        tree = bpy.context.space_data.edit_tree
+        nodeCount = 0
+        for node in tree.nodes:
+            if (node.bl_idname == 'LNGroupInputNode'):
+                nodeCount += 1
+        if(nodeCount > 1):
+            print("Too many nodes")
+            tree.nodes.remove(self)
+        else:
+            self.arm_init(context)
+    
+    def copy(self, node):
+        tree = bpy.context.space_data.edit_tree
+        nodeCount = 0
+        for node in tree.nodes:
+            if (node.bl_idname == 'LNGroupInputNode'):
+                nodeCount += 1
+        if(nodeCount > 1):
+            print("Too many nodes")
+            tree.nodes.remove(self)
 
     def arm_init(self, context):
         self.add_output('ArmAnySocket', '')

--- a/blender/arm/logicnode/miscellaneous/LN_group_output.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_output.py
@@ -4,9 +4,9 @@ import arm.utils
 from arm.logicnode.arm_nodes import *
 
 
-class GroupOutputNode(ArmLogicTreeNode):
+class GroupOutputsNode(ArmLogicTreeNode):
     """Output for a given a node tree."""
-    bl_idname = 'LNGroupOutputNode'
+    bl_idname = 'LNGroupOutputsNode'
     bl_label = 'Group Output Node'
     arm_section = 'group'
     arm_version = 2
@@ -18,7 +18,7 @@ class GroupOutputNode(ArmLogicTreeNode):
         tree = bpy.context.space_data.edit_tree
         nodeCount = 0
         for node in tree.nodes:
-            if node.bl_idname == 'LNGroupOutputNode':
+            if node.bl_idname == 'LNGroupOutputsNode':
                 nodeCount += 1
         if nodeCount > 1:
             arm.log.warn("Only one group output node per node tree is allowed")
@@ -30,7 +30,7 @@ class GroupOutputNode(ArmLogicTreeNode):
         tree = bpy.context.space_data.edit_tree
         nodeCount = 0
         for node in tree.nodes:
-            if node.bl_idname == 'LNGroupOutputNode':
+            if node.bl_idname == 'LNGroupOutputsNode':
                 nodeCount += 1
         if nodeCount > 1:
             arm.log.warn("Only one group output node per node tree is allowed")

--- a/blender/arm/logicnode/miscellaneous/LN_group_output.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_output.py
@@ -1,0 +1,28 @@
+import bpy
+
+import arm.utils
+from arm.logicnode.arm_nodes import *
+
+
+class GroupOutputNode(ArmLogicTreeNode):
+    """Output for a given a node tree."""
+    bl_idname = 'LNGroupOutputNode'
+    bl_label = 'Group Output Node'
+    arm_section = 'group'
+    arm_version = 2
+
+    def __init__(self):
+        array_nodes[str(id(self))] = self
+
+    def arm_init(self, context):
+        self.add_input('ArmAnySocket', '')
+    
+    def draw_buttons(self, context, layout):
+        row = layout.row(align=True)
+
+        op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
+        op.node_index = str(id(self))
+        op.socket_type = 'ArmAnySocket'
+        if(len(self.inputs) > 1):
+            op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
+            op2.node_index = str(id(self))

--- a/blender/arm/logicnode/miscellaneous/LN_group_output.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_output.py
@@ -14,6 +14,28 @@ class GroupOutputNode(ArmLogicTreeNode):
     def __init__(self):
         array_nodes[str(id(self))] = self
 
+    def init(self, context):
+        tree = bpy.context.space_data.edit_tree
+        nodeCount = 0
+        for node in tree.nodes:
+            if node.bl_idname == 'LNGroupOutputNode':
+                nodeCount += 1
+        if nodeCount > 1:
+            arm.log.warn("Only one group output node per node tree is allowed")
+            tree.nodes.remove(self)
+        else:
+            self.arm_init(context)
+    
+    def copy(self, node):
+        tree = bpy.context.space_data.edit_tree
+        nodeCount = 0
+        for node in tree.nodes:
+            if node.bl_idname == 'LNGroupOutputNode':
+                nodeCount += 1
+        if nodeCount > 1:
+            arm.log.warn("Only one group output node per node tree is allowed")
+            tree.nodes.remove(self)
+
     def arm_init(self, context):
         self.add_input('ArmAnySocket', '')
     

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -155,9 +155,9 @@ def build_node_group_tree(node_group: 'arm.nodes_logic.ArmLogicTree', f: TextIO,
     group_output_name = ""
 
     for node in node_group.nodes:
-        if node.bl_idname == 'LNGroupInputNode':
+        if node.bl_idname == 'LNGroupInputsNode':
             group_input_name = group_node_name + arm.node_utils.get_export_node_name(node)
-        if node.bl_idname == 'LNGroupOutputNode':
+        if node.bl_idname == 'LNGroupOutputsNode':
             group_output_name = group_node_name + arm.node_utils.get_export_node_name(node)
 
     for node in root_nodes:

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -67,6 +67,8 @@ def build_node_tree(node_group: 'arm.nodes_logic.ArmLogicTree'):
     call_group_nodes = dict()
     root_nodes = get_root_nodes(node_group)
 
+    print(node_group)
+
     pack_path = arm.utils.safestr(bpy.data.worlds['Arm'].arm_project_package)
     path = 'Sources/' + pack_path.replace('.', '/') + '/node/'
 
@@ -90,16 +92,12 @@ def build_node_tree(node_group: 'arm.nodes_logic.ArmLogicTree'):
         f.write('@:keep class ' + group_name + ' extends armory.logicnode.LogicTree {\n\n')
         f.write('\tvar functionNodes:Map<String, armory.logicnode.FunctionNode>;\n\n')
         f.write('\tvar functionOutputNodes:Map<String, armory.logicnode.FunctionOutputNode>;\n\n')
-        f.write('\tvar groupInputNodes:Map<String, armory.logicnode.GroupInputNode>;\n\n')
-        f.write('\tvar callGroupNodes:Map<String, armory.logicnode.CallGroupNode>;\n\n')
         f.write('\tpublic function new() {\n')
         f.write('\t\tsuper();\n')
         if wrd.arm_debug_console:
             f.write('\t\tname = "' + group_name + '";\n')
         f.write('\t\tthis.functionNodes = new Map();\n')
         f.write('\t\tthis.functionOutputNodes = new Map();\n')
-        f.write('\t\tthis.groupInputNodes = new Map();\n')
-        f.write('\t\tthis.callGroupNodes = new Map();\n')
         if arm.utils.is_livepatch_enabled():
             # Store a reference to this trait instance in Logictree.nodeTrees
             f.write('\t\tvar nodeTrees = armory.logicnode.LogicTree.nodeTrees;\n')
@@ -133,37 +131,73 @@ def build_node_tree(node_group: 'arm.nodes_logic.ArmLogicTree'):
             if function_node_outputs.get(function_name) != None:
                 f.write('\t\treturn this.functionOutputNodes["' + function_node_outputs[function_name] + '"].result;\n')
             f.write('\t}\n\n')
-
-        # Create node functions
-        for node_name in group_input_nodes:
-            node = group_input_nodes[node_name]
-            f.write('\n\tpublic function runGroupInput (')
-            f.write('args: Dynamic')
-            f.write(') {\n')
-            f.write('\t\tvar inputNode = this.groupInputNodes["' + node_name + '"];\n')
-            f.write('\t\tinputNode.run(args);\n')
-            f.write('\t}\n\n')
-
-        # Create node functions
-        for node_name in call_group_nodes:
-            node = call_group_nodes[node_name]
-            f.write('\n\tpublic function getGroupInput_' + node_name + '(')
-            f.write('args: Dynamic')
-            f.write(') {\n')
-            f.write('\t\tvar inputNode = this.callGroupNodes["' + node_name + '"];\n')
-            f.write('\t\tinputNode.get(args);\n')
-            f.write('\t}\n\n')
-
         f.write('}')
     node_group.arm_cached = True
 
 
-def build_node(node: bpy.types.Node, f: TextIO) -> Optional[str]:
+def build_node_group_tree(node_group: 'arm.nodes_logic.ArmLogicTree', f: TextIO):
+    global parsed_nodes
+    global parsed_ids
+    global function_nodes
+    global function_node_outputs
+    global group_input_nodes
+    global group_output_nodes
+    global call_group_nodes
+    global group_name
+    parsed_nodes = []
+    parsed_ids = dict()
+    function_nodes = dict()
+    function_node_outputs = dict()
+    group_input_nodes = dict()
+    group_output_nodes = dict()
+    call_group_nodes = dict()
+    root_nodes = get_root_nodes(node_group)
+
+    print(node_group)
+
+    group_name = arm.node_utils.get_export_tree_name(node_group, do_warn=True)
+    group_input_name = ""
+    group_output_name = ""
+
+    for node in node_group.nodes:
+        if node.bl_idname == 'LNGroupInputNode':
+            group_input_name = group_name + arm.node_utils.get_export_node_name(node)
+        if node.bl_idname == 'LNGroupOutputNode':
+            group_output_name = group_name + arm.node_utils.get_export_node_name(node)
+
+    for node in root_nodes:
+        build_node(node, f, group_name)
+    # Create node functions
+    for node_name in function_nodes:
+        node = function_nodes[node_name]
+        function_name = node.function_name
+        f.write('\n\tpublic function ' + function_name + '(')
+        for i in range(0, len(node.outputs) - 1):
+            if i != 0: f.write(', ')
+            f.write('arg' + str(i) + ':Dynamic')
+        f.write(') {\n')
+        f.write('\t\tvar functionNode = this.functionNodes["' + node_name + '"];\n')
+        f.write('\t\tfunctionNode.args = [];\n')
+        for i in range(0, len(node.outputs) - 1):
+            f.write('\t\tfunctionNode.args.push(arg' + str(i) + ');\n')
+        f.write('\t\tfunctionNode.run(0);\n')
+        if function_node_outputs.get(function_name) != None:
+            f.write('\t\treturn this.functionOutputNodes["' + function_node_outputs[function_name] + '"].result;\n')
+        f.write('\t}\n\n')
+    node_group.arm_cached = True
+    return group_input_name, group_output_name
+
+
+def build_node(node: bpy.types.Node, f: TextIO, name_prefix: str = None) -> Optional[str]:
+    print(node)
     """Builds the given node and returns its name. f is an opened file object."""
     global parsed_nodes
     global parsed_ids
 
+    print("A")
     use_live_patch = arm.utils.is_livepatch_enabled()
+
+    link_group = False
 
     if node.type == 'REROUTE':
         if len(node.inputs) > 0 and len(node.inputs[0].links) > 0:
@@ -171,9 +205,22 @@ def build_node(node: bpy.types.Node, f: TextIO) -> Optional[str]:
         else:
             return None
 
+    print("B")
+    if node.bl_idname == 'LNCallGroupNode':
+            prop =node.property0_
+            group_input_name = build_node_group_tree(prop, f)[0]
+            group_output_name = build_node_group_tree(prop, f)[1]
+            link_group = True
+    
+    print("C")
+
     # Get node name
     name = arm.node_utils.get_export_node_name(node)
+    if name_prefix is not None:
+        name = name_prefix + name
 
+    
+    print("D")
     # Link nodes using IDs
     if node.arm_logic_id != '':
         if node.arm_logic_id in parsed_ids:
@@ -183,56 +230,57 @@ def build_node(node: bpy.types.Node, f: TextIO) -> Optional[str]:
     # Check if node already exists
     if name in parsed_nodes:
         return name
+    print("F")
+    
 
     parsed_nodes.append(name)
 
-    # Create node
-    node_type = node.bl_idname[2:]  # Discard 'LN' prefix
-    f.write('\t\tvar ' + name + ' = new armory.logicnode.' + node_type + '(this);\n')
+    if not link_group:
+        print("G")
+        # Create node
+        node_type = node.bl_idname[2:]  # Discard 'LN' prefix
+        f.write('\t\tvar ' + name + ' = new armory.logicnode.' + node_type + '(this);\n')
 
-    # Handle Function Nodes
-    if node_type == 'FunctionNode':
-        f.write('\t\tthis.functionNodes.set("' + name + '", ' + name + ');\n')
-        function_nodes[name] = node
-    elif node_type == 'FunctionOutputNode':
-        f.write('\t\tthis.functionOutputNodes.set("' + name + '", ' + name + ');\n')
-        # Index function output name by corresponding function name
-        function_node_outputs[node.function_name] = name
-    elif node_type == 'GroupInputNode':
-        f.write('\t\tthis.groupInputNodes.set("' + name + '", ' + name + ');\n')
-        group_input_nodes[name] = node
-    elif node_type == 'CallGroupNode':
-        f.write('\t\tthis.callGroupNodes.set("' + name + '", ' + name + ');\n')
-        call_group_nodes[name] = node
+        # Handle Function Nodes
+        if node_type == 'FunctionNode':
+                f.write('\t\tthis.functionNodes.set("' + name + '", ' + name + ');\n')
+                function_nodes[name] = node
+        elif node_type == 'FunctionOutputNode':
+                f.write('\t\tthis.functionOutputNodes.set("' + name + '", ' + name + ');\n')
+                # Index function output name by corresponding function name
+                function_node_outputs[node.function_name] = name
+        wrd = bpy.data.worlds['Arm']
 
-    wrd = bpy.data.worlds['Arm']
+        # Watch in debug console
+        if node.arm_watch and wrd.arm_debug_console:
+                f.write('\t\t' + name + '.name = "' + name[1:] + '";\n')
+                f.write('\t\t' + name + '.watch(true);\n')
 
-    # Watch in debug console
-    if node.arm_watch and wrd.arm_debug_console:
-        f.write('\t\t' + name + '.name = "' + name[1:] + '";\n')
-        f.write('\t\t' + name + '.watch(true);\n')
+        elif use_live_patch:
+                f.write('\t\t' + name + '.name = "' + name[1:] + '";\n')
+                f.write(f'\t\tthis.nodes["{name[1:]}"] = {name};\n')
 
-    elif use_live_patch:
-        f.write('\t\t' + name + '.name = "' + name[1:] + '";\n')
-        f.write(f'\t\tthis.nodes["{name[1:]}"] = {name};\n')
+        # Properties
+        for prop_py_name, prop_hx_name in arm.node_utils.get_haxe_property_names(node):
+                prop = arm.node_utils.haxe_format_prop_value(node, prop_py_name)
+                f.write('\t\t' + name + '.' + prop_hx_name + ' = ' + prop + ';\n')
 
-    # Properties
-    for prop_py_name, prop_hx_name in arm.node_utils.get_haxe_property_names(node):
-        prop = arm.node_utils.haxe_format_prop_value(node, prop_py_name)
-        f.write('\t\t' + name + '.' + prop_hx_name + ' = ' + prop + ';\n')
-
-    # Avoid unnecessary input/output array resizes
-    f.write(f'\t\t{name}.preallocInputs({len(node.inputs)});\n')
-    f.write(f'\t\t{name}.preallocOutputs({len(node.outputs)});\n')
+        # Avoid unnecessary input/output array resizes
+        f.write(f'\t\t{name}.preallocInputs({len(node.inputs)});\n')
+        f.write(f'\t\t{name}.preallocOutputs({len(node.outputs)});\n')
 
     # Create inputs
+    if(link_group):
+        name = group_input_name
     for idx, inp in enumerate(node.inputs):
         # True if the input is connected to a unlinked reroute
         # somewhere down the reroute line
+        print("H")
         unconnected = False
 
         # Is linked -> find the connected node
         if inp.is_linked:
+            print("I")
             n = inp.links[0].from_node
             socket = inp.links[0].from_socket
 
@@ -244,13 +292,14 @@ def build_node(node: bpy.types.Node, f: TextIO) -> Optional[str]:
 
                 socket = n.inputs[0].links[0].from_socket
                 n = n.inputs[0].links[0].from_node
-
+            print("J")
             if not unconnected:
                 if (inp.bl_idname == 'ArmNodeSocketAction' and socket.bl_idname != 'ArmNodeSocketAction') or \
                         (socket.bl_idname == 'ArmNodeSocketAction' and inp.bl_idname != 'ArmNodeSocketAction'):
                     arm.log.warn(f'Sockets do not match in logic node tree "{group_name}": node "{node.name}", socket "{inp.name}"')
+                    print("K")
 
-                inp_name = build_node(n, f)
+                inp_name = build_node(n, f, name_prefix)
                 for i in range(0, len(n.outputs)):
                     if n.outputs[i] == socket:
                         inp_from = i
@@ -259,12 +308,14 @@ def build_node(node: bpy.types.Node, f: TextIO) -> Optional[str]:
 
         # Not linked -> create node with default values
         else:
+            print("L")
             inp_name = build_default_node(inp)
             inp_from = 0
             from_type = inp.arm_socket_type
 
         # The input is linked to a reroute, but the reroute is unlinked
         if unconnected:
+            print("M")
             inp_name = build_default_node(inp)
             inp_from = 0
             from_type = inp.arm_socket_type
@@ -272,18 +323,23 @@ def build_node(node: bpy.types.Node, f: TextIO) -> Optional[str]:
         # Add input
         f.write(f'\t\t{"var __link = " if use_live_patch else ""}armory.logicnode.LogicNode.addLink({inp_name}, {name}, {inp_from}, {idx});\n')
         if use_live_patch:
+            print("N")
             to_type = inp.arm_socket_type
             f.write(f'\t\t__link.fromType = "{from_type}";\n')
             f.write(f'\t\t__link.toType = "{to_type}";\n')
             f.write(f'\t\t__link.toValue = {arm.node_utils.haxe_format_socket_val(inp.get_default_value())};\n')
 
     # Create outputs
+    if(link_group):
+        name = group_output_name
     for idx, out in enumerate(node.outputs):
         # Linked outputs are already handled after iterating over inputs
         # above, so only unconnected outputs are handled here
         if not out.is_linked:
+            print("O")
             f.write(f'\t\t{"var __link = " if use_live_patch else ""}armory.logicnode.LogicNode.addLink({name}, {build_default_node(out)}, {idx}, 0);\n')
             if use_live_patch:
+                print("P")
                 out_type = out.arm_socket_type
                 f.write(f'\t\t__link.fromType = "{out_type}";\n')
                 f.write(f'\t\t__link.toType = "{out_type}";\n')


### PR DESCRIPTION
This PR introduces `Node Groups` in Armory. `Node Trees` can be used as `Node Groups` to reduce the repetitive usage of logic nodes and make the tree more elegant.

Partially solves https://github.com/armory3d/armory/issues/723.

An example:
<img width="625" alt="node_group_example_1" src="https://user-images.githubusercontent.com/55564981/146993286-23f302e6-47c1-4d9a-8fea-7ee8c8bd7965.png">

Thanks to @knowledgenude and @MoritzBrueckner for their insights on this and @t3du for testing this feature. 

More documentation on this feature:
https://github.com/QuantumCoderQC/armory/wiki#node-groups


