### PR TITLE
Improve node library handling

### DIFF
--- a/blender/arm/logicnode/__init__.py
+++ b/blender/arm/logicnode/__init__.py
@@ -64,17 +64,25 @@ def init_categories():
     arm_nodes.add_category_section('default')
 
 
-def init_nodes():
-    """Calls the on_register() method on all logic nodes in order
-    to initialize them and to register them to Armory."""
-    for loader, module_name, is_pkg in pkgutil.walk_packages(__path__, __package__ + '.'):
+def init_nodes(base_path=__path__, base_package=__package__, subpackages_only=False):
+    """Calls the `on_register()` method on all logic nodes in a given
+    `base_package` and all its sub-packages relative to the given
+    `base_path`, in order to initialize them and to register them to Armory.
+
+    Be aware that calling this function will import all modules in the
+    given package, so module-level code will be executed.
+
+    If `subpackages_only` is true, modules directly inside the root of
+    the base package are not searched and imported.
+    """
+    for loader, module_name, is_pkg in pkgutil.walk_packages(base_path, base_package + '.'):
         if is_pkg:
             # The package must be loaded as well so that the modules from that package can be accessed (see the
             # pkgutil.walk_packages documentation for more information on this)
             loader.find_module(module_name).load_module(module_name)
 
-        # Only look at modules in sub packages
-        elif module_name.rsplit('.', 1)[0] != __package__:
+        # Only look at modules in sub packages if specified
+        elif not subpackages_only or module_name.rsplit('.', 1)[0] != base_package:
             if 'HAS_RELOADED' not in globals() or module_name not in sys.modules:
                 _module = importlib.import_module(module_name)
             else:

--- a/blender/arm/logicnode/physics/LN_add_physics_constraint.py
+++ b/blender/arm/logicnode/physics/LN_add_physics_constraint.py
@@ -47,7 +47,7 @@ class AddPhysicsConstraintNode(ArmLogicTreeNode):
 
     bl_idname = 'LNAddPhysicsConstraintNode'
     bl_label = 'Add Physics Constraint'
-    arm_sction = 'add'
+    arm_section = 'add'
     arm_version = 1
 
     @staticmethod

--- a/blender/arm/logicnode/physics/LN_physics_constraint.py
+++ b/blender/arm/logicnode/physics/LN_physics_constraint.py
@@ -21,7 +21,7 @@ class PhysicsConstraintNode(ArmLogicTreeNode):
 
     bl_idname = 'LNPhysicsConstraintNode'
     bl_label = 'Physics Constraint'
-    arm_sction = 'add'
+    arm_section = 'add'
     arm_version = 1
 
     def update_spring(self, context):

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -120,7 +120,7 @@ def register_nodes():
     if len(registered_nodes) > 0 or len(registered_categories) > 0:
         unregister_nodes()
 
-    arm.logicnode.init_nodes()
+    arm.logicnode.init_nodes(subpackages_only=True)
 
     for node_type in arm_nodes.nodes:
         # Don't register internal nodes, they are already registered

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -59,7 +59,8 @@ class ARM_MT_NodeAddOverride(bpy.types.Menu):
                 layout.separator()
 
                 for category in category_section:
-                    layout.menu(f'ARM_MT_{category.name.lower()}_menu', text=category.name, icon=category.icon)
+                    safe_category_name = arm.utils.safesrc(category.name.lower())
+                    layout.menu(f'ARM_MT_{safe_category_name}_menu', text=category.name, icon=category.icon)
 
         else:
             ARM_MT_NodeAddOverride.overridden_draw(self, context)
@@ -136,9 +137,10 @@ def register_nodes():
     for category_section in arm_nodes.category_items.values():
         for category in category_section:
             category.sort_nodes()
-            menu_class = type(f'ARM_MT_{category.name}Menu', (bpy.types.Menu, ), {
+            safe_category_name = arm.utils.safesrc(category.name.lower())
+            menu_class = type(f'ARM_MT_{safe_category_name}Menu', (bpy.types.Menu, ), {
                 'bl_space_type': 'NODE_EDITOR',
-                'bl_idname': f'ARM_MT_{category.name.lower()}_menu',
+                'bl_idname': f'ARM_MT_{safe_category_name}_menu',
                 'bl_label': category.name,
                 'bl_description': category.description,
                 'draw': get_category_draw_func(category)


### PR DESCRIPTION
- External node libraries can now use Armory's `init_nodes()` function that registers all nodes inside of a given package (recursively)
- If node categories had special characters in their name (e.g. spaces), the menu class name and bl_idname would also contain those characters which would lead to warnings (interestingly, there was no _error_ when using spaces before, just a warning...?)
- Also fixed a small typo that is unrelated to this PR, but I didn't want to annoy you with a separate PR for this. @luboslenco it seems that I have write access to this repo, I guess it's ok for you if I would commit such trivial typo fixes directly to master? For everything else I will of course open a PR, but I think stuff like this is just unnecessary work for you.