### PR TITLE
Fix SetRotationNode: don't change rotation of previous objects

### DIFF
--- a/Sources/armory/logicnode/SetRotationNode.hx
+++ b/Sources/armory/logicnode/SetRotationNode.hx
@@ -16,13 +16,13 @@ class SetRotationNode extends LogicNode {
 	override function run(from: Int) {
 		var object: Object = inputs[1].get();
 		if (object == null) return;
-		var q: Quat = inputs[2].get();
-		if (q == null) return;
+		var _q: Quat = inputs[2].get();
+		if (_q == null) return;
 
-		q.normalize();
-		object.transform.rot = q;
+		final q = new Quat(_q.x, _q.y, _q.z, _q.w).normalize();
+		object.transform.rot.setFrom(q);
 		object.transform.buildMatrix();
-		
+
 		#if arm_physics
 		var rigidBody = object.getTrait(RigidBody);
 		if (rigidBody != null) {


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2413.

`Quat` is a mutable type and because the SetRotationNode didn't clone the inputted quaternion, all previous usages of that quaternion were also changed and even if only one object would be used for this node, the inputted quaternion might be used in other places where it would also be changed by this node.

In order to prevent an allocation on the heap, the rotation quat of an object is no longer exchanged, only its values are updated instead (`setFrom()`). Then the cloned quaternion can be inlined by Haxe.