### PR TITLE
Retain Value Node, Float Delta Interpolation Node

### DIFF
--- a/Sources/armory/logicnode/FloatDeltaInterpolateNode.hx
+++ b/Sources/armory/logicnode/FloatDeltaInterpolateNode.hx
@@ -1,0 +1,23 @@
+package armory.logicnode;
+
+import kha.FastFloat;
+
+class FloatDeltaInterpolateNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+		
+	}
+
+	override function get(from: Int): FastFloat {
+		var fromValue = inputs[0].get();
+		var toValue = inputs[1].get();
+		var deltaTime = inputs[2].get();
+		var rate = inputs[3].get();
+		
+		var value = fromValue + deltaTime * rate;
+		var min = Math.min(fromValue, toValue);
+		var max = Math.max(fromValue, toValue);
+		return value < min ? min : value > max ? max : value;
+	}
+}

--- a/Sources/armory/logicnode/FloatDeltaInterpolateNode.hx
+++ b/Sources/armory/logicnode/FloatDeltaInterpolateNode.hx
@@ -15,7 +15,8 @@ class FloatDeltaInterpolateNode extends LogicNode {
 		var deltaTime = inputs[2].get();
 		var rate = inputs[3].get();
 		
-		var value = fromValue + deltaTime * rate;
+		var sign = toValue > fromValue ? 1.0 : -1.0;
+		var value = fromValue + deltaTime * rate * sign;
 		var min = Math.min(fromValue, toValue);
 		var max = Math.max(fromValue, toValue);
 		return value < min ? min : value > max ? max : value;

--- a/Sources/armory/logicnode/RetainValueNode.hx
+++ b/Sources/armory/logicnode/RetainValueNode.hx
@@ -1,0 +1,20 @@
+package armory.logicnode;
+
+class RetainValueNode extends LogicNode {
+
+	var value: Dynamic = null;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		value = inputs[1].get();
+
+		runOutput(0);
+	}
+
+	override function get(from:Int):Dynamic {
+		return value;
+	}
+}

--- a/blender/arm/logicnode/math/LN_float_delta_interpolate.py
+++ b/blender/arm/logicnode/math/LN_float_delta_interpolate.py
@@ -1,0 +1,20 @@
+from arm.logicnode.arm_nodes import *
+
+class FloatDeltaInterpolateNode(ArmLogicTreeNode):
+    """Linearly interpolate to a new value with specified interpolation `Rate`.
+    @input From: Value to interpolate from
+    @input To: Value to interpolate to
+    @input Delta Time: Delta Time
+    @input Rate: Rate of interpolation 
+    """
+    bl_idname = 'LNFloatDeltaInterpolateNode'
+    bl_label = 'Float Delta Interpolate'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmFloatSocket', 'From', default_value=0.0)
+        self.add_input('ArmFloatSocket', 'To', default_value=1.0)
+        self.add_input('ArmFloatSocket', 'Delta Time')
+        self.add_input('ArmFloatSocket', 'Rate')
+
+        self.add_output('ArmFloatSocket', 'Result')

--- a/blender/arm/logicnode/math/LN_float_delta_interpolate.py
+++ b/blender/arm/logicnode/math/LN_float_delta_interpolate.py
@@ -2,10 +2,10 @@ from arm.logicnode.arm_nodes import *
 
 class FloatDeltaInterpolateNode(ArmLogicTreeNode):
     """Linearly interpolate to a new value with specified interpolation `Rate`.
-    @input From: Value to interpolate from
-    @input To: Value to interpolate to
-    @input Delta Time: Delta Time
-    @input Rate: Rate of interpolation 
+    @input From: Value to interpolate from.
+    @input To: Value to interpolate to.
+    @input Delta Time: Delta Time.
+    @input Rate: Rate of interpolation.
     """
     bl_idname = 'LNFloatDeltaInterpolateNode'
     bl_label = 'Float Delta Interpolate'

--- a/blender/arm/logicnode/variable/LN_retain_value.py
+++ b/blender/arm/logicnode/variable/LN_retain_value.py
@@ -1,0 +1,19 @@
+from arm.logicnode.arm_nodes import *
+
+class RetainValueNode(ArmLogicTreeNode):
+    """Sets the value of the given variable.
+
+    @input Retain: Retains the value when exeuted
+    @input Value: The value that should be retained.
+    """
+    bl_idname = 'LNRetainValueNode'
+    bl_label = 'Retain Value'
+    arm_section = 'set'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'Retain')
+        self.add_input('ArmDynamicSocket', 'Value', is_var=True)
+
+        self.add_output('ArmDynamicSocket', 'Value')
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/blender/arm/logicnode/variable/LN_retain_value.py
+++ b/blender/arm/logicnode/variable/LN_retain_value.py
@@ -1,9 +1,9 @@
 from arm.logicnode.arm_nodes import *
 
 class RetainValueNode(ArmLogicTreeNode):
-    """Sets the value of the given variable.
+    """Retains the input value
 
-    @input Retain: Retains the value when exeuted
+    @input Retain: Retains the value when exeuted.
     @input Value: The value that should be retained.
     """
     bl_idname = 'LNRetainValueNode'


### PR DESCRIPTION
This PR introduces two new nodes. The `Retain Value Node` and `Float Delta Interpolation Node`

![image](https://user-images.githubusercontent.com/55564981/148688375-89f421b7-1d0e-4458-94ac-6485941af515.png)

The `Retain Value Node` may be used to retain some value and reduce repetitive computations.

`Float Delta Interpolation Node` may be used to interpolate between `from` and `to` values linearly with a certain `rate`. The `Delta Time` input takes the system delta time to account for varying frame rates.