### PR TITLE
Fix is_transluc_type(): do not activate translucency with Principled BSDF emission strength

### DIFF
--- a/blender/arm/material/mat_utils.py
+++ b/blender/arm/material/mat_utils.py
@@ -77,15 +77,12 @@ def is_transluc_traverse(node):
                 return True
     return False
 
-def is_transluc_type(node):
-    if node.type == 'BSDF_GLASS' or \
-       node.type == 'BSDF_TRANSPARENT' or \
-       node.type == 'BSDF_TRANSLUCENT' or \
-       (node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR') and (node.inputs[1].is_linked or node.inputs[1].default_value != 1.0)) or \
-       (node.type == 'BSDF_PRINCIPLED' and len(node.inputs) > 20 and (node.inputs[18].is_linked or node.inputs[18].default_value != 1.0)) or \
-       (node.type == 'BSDF_PRINCIPLED' and len(node.inputs) > 21 and (node.inputs[19].is_linked or node.inputs[19].default_value != 1.0)):
-       return True
-    return False
+
+def is_transluc_type(node: bpy.types.ShaderNode) -> bool:
+    return node.type in ('BSDF_GLASS', 'BSDF_TRANSPARENT', 'BSDF_TRANSLUCENT') \
+        or (node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR') and (node.inputs['Opacity'].is_linked or node.inputs['Opacity'].default_value != 1.0)) \
+        or (node.type == 'BSDF_PRINCIPLED' and (node.inputs['Alpha'].is_linked or node.inputs['Alpha'].default_value != 1.0))
+
 
 def is_emmisive(material):
     nodes = material.node_tree.nodes


### PR DESCRIPTION
This fixes a bug from https://forums.armory3d.org/t/colors-in-blender-and-armory3d-do-sometimes-not-match/4805.

The previous code of `is_transluc_type()` accidentally enabled translucency if the "Emission Strength" input of the principled BSDF node was != 1 (because the compatibility check with `len(node.inputs) > 20` is also true for the current principled bsdf nodes).

Because this function might get overlooked when changing socket indices, I replaced the int indices with string indices. I'm still not sure what is used internally for lookup (see [this comment](https://devtalk.blender.org/t/implement-new-node-parameters-without-breaking-existing-scripts/15433/6) from brecht that leaves room for interpretation), but here it should be safer to do so despite possibly being a little slower.