### PR TITLE
add Gamepad Sticks node

### DIFF
--- a/Sources/armory/logicnode/GamepadSticksNode.hx
+++ b/Sources/armory/logicnode/GamepadSticksNode.hx
@@ -1,0 +1,130 @@
+package armory.logicnode;
+
+class GamepadSticksNode extends LogicNode {
+
+	public var property0: String;
+	public var property1: String;
+	public var property2: String;
+	var started = false;
+	var previousb = false;
+	
+	var gstarted = false;
+	var gpreviousb = false;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+
+		tree.notifyOnUpdate(update);
+	}
+
+	function update() {
+		var num: Int = inputs[0].get();
+		var gamepad = iron.system.Input.getGamepad(num);
+		if (gamepad == null) return;
+		var b = false;
+
+		if(property1 == 'LeftStick')
+			switch (property2) {
+			case 'up':
+				b = gamepad.leftStick.y == -1;
+			case 'down':
+				b = gamepad.leftStick.y == 1;
+			case 'left':
+				b = gamepad.leftStick.x == -1;
+			case 'right':
+				b = gamepad.leftStick.x == 1;
+			case 'up-left':
+				b = gamepad.leftStick.y == -1 && gamepad.leftStick.x == -1;
+			case 'up-right':
+				b = gamepad.leftStick.y == -1 && gamepad.leftStick.x == 1;
+			case 'down-left':
+				b = gamepad.leftStick.y == 1 && gamepad.leftStick.x == -1;
+			case 'down-right':
+				b = gamepad.leftStick.y == 1 && gamepad.leftStick.x == 1;
+			}
+		else
+			switch (property2) {
+			case 'up':
+				b = gamepad.rightStick.y == -1;
+			case 'down':
+				b = gamepad.rightStick.y == 1;
+			case 'left':
+				b = gamepad.rightStick.x == -1;
+			case 'right':
+				b = gamepad.rightStick.x == 1;
+			case 'up-left':
+				b = gamepad.rightStick.y == -1 && gamepad.rightStick.x == -1;
+			case 'up-right':
+				b = gamepad.rightStick.y == -1 && gamepad.rightStick.x == 1;
+			case 'down-left':
+				b = gamepad.rightStick.y == 1 && gamepad.rightStick.x == -1;
+			case 'down-right':
+				b = gamepad.rightStick.y == 1 && gamepad.rightStick.x == 1;
+			}
+
+		if (b) previousb = b;
+		if (b != previousb) started = false;
+		
+		if (property0 == 'Started' && b && !started){started = true; runOutput(0);}
+		else if (property0 == 'Down' && b){previousb = b; runOutput(0);}
+		else if (property0 == 'Released' && b != previousb){previousb = b; runOutput(0);}
+	
+	}
+
+	override function get(from: Int): Dynamic {
+		var num: Int = inputs[0].get();
+		var gamepad = iron.system.Input.getGamepad(num);
+		
+		if (gamepad == null) return false;
+		var b = false;
+
+		if(property1 == 'LeftStick')
+			switch (property2) {
+			case 'up':
+				b = gamepad.leftStick.y == -1;
+			case 'down':
+				b = gamepad.leftStick.y == 1;
+			case 'left':
+				b = gamepad.leftStick.x == -1;
+			case 'right':
+				b = gamepad.leftStick.x == 1;
+			case 'up-left':
+				b = gamepad.leftStick.y == -1 && gamepad.leftStick.x == -1;
+			case 'up-right':
+				b = gamepad.leftStick.y == -1 && gamepad.leftStick.x == 1;
+			case 'down-left':
+				b = gamepad.leftStick.y == 1 && gamepad.leftStick.x == -1;
+			case 'down-right':
+				b = gamepad.leftStick.y == 1 && gamepad.leftStick.x == 1;
+			}
+		else
+			switch (property2) {
+			case 'up':
+				b = gamepad.rightStick.y == -1;
+			case 'down':
+				b = gamepad.rightStick.y == 1;
+			case 'left':
+				b = gamepad.rightStick.x == -1;
+			case 'right':
+				b = gamepad.rightStick.x == 1;
+			case 'up-left':
+				b = gamepad.rightStick.y == -1 && gamepad.rightStick.x == -1;
+			case 'up-right':
+				b = gamepad.rightStick.y == -1 && gamepad.rightStick.x == 1;
+			case 'down-left':
+				b = gamepad.rightStick.y == 1 && gamepad.rightStick.x == -1;
+			case 'down-right':
+				b = gamepad.rightStick.y == 1 && gamepad.rightStick.x == 1;
+			}
+		
+		if (b) gpreviousb = b;
+		if (b != gpreviousb) gstarted = false;
+		
+		if (property0 == 'Started' && b && !gstarted){gstarted = true; return true;}
+		else if (property0 == 'Down' && b){gpreviousb = b; return true;}
+		else if (property0 == 'Released' && b != gpreviousb){gpreviousb = b; return true;}
+		
+		return false;
+		
+	}
+}

--- a/blender/arm/logicnode/input/LN_gamepad_sticks.py
+++ b/blender/arm/logicnode/input/LN_gamepad_sticks.py
@@ -1,0 +1,52 @@
+from arm.logicnode.arm_nodes import *
+
+class GamepadSticksNode(ArmLogicTreeNode):
+    """Activates the output on the given gamepad event.
+
+    @seeNode Gamepad Coords
+
+    @input Gamepad: the ID of the gamepad.
+
+    @option state: the state of the gamepad stick to listen to.
+    @option stick: the gamepad stick that should activate the output.
+    @option axis: the gamepad stick axis value
+    """
+    bl_idname = 'LNGamepadSticksNode'
+    bl_label = 'Gamepad Sticks'
+    arm_version = 1
+    arm_section = 'gamepad'
+
+    property0: HaxeEnumProperty(
+        'property0',
+        items = [('Started', 'Started', 'Started'),
+                 ('Down', 'Down', 'Down'),
+                 ('Released', 'Released', 'Released'),],
+        name='', default='Down')
+
+    property1: HaxeEnumProperty(
+        'property1',
+        items = [('LeftStick', 'LeftStick', 'LeftStick'), ('RightStick', 'RightStick', 'RightStick'),],
+        name='', default='LeftStick')
+
+    property2: HaxeEnumProperty(
+        'property2',
+        items = [('up', 'up', 'up'),
+                 ('down', 'down', 'down'),
+                 ('left', 'left', 'left'),
+                 ('right', 'right', 'right'),
+                 ('up-left', 'up-left', 'up-left'),
+                 ('up-right', 'up-right', 'up-right'),
+                 ('down-left', 'down-left', 'down-left'),
+                 ('down-right', 'down-right', 'down-right'),],
+        name='', default='up')
+
+    def arm_init(self, context):
+        self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('ArmBoolSocket', 'State')
+
+        self.add_input('ArmIntSocket', 'Gamepad')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
+        layout.prop(self, 'property1')
+        layout.prop(self, 'property2')


### PR DESCRIPTION
added functionality for retrieving the states, sticks and axis of a gamepad

i did the states logic the best i could maybe that could be improved

i added both sticks to the logic which is basically the same, i tested all the cases only for the leftstick because kha doesnt seem to be retrieving the right stick from my control even though the control is sending the signal

![image](https://user-images.githubusercontent.com/32546729/149010931-5bef8126-9577-4b33-a9f0-879efc818289.png)
![image](https://user-images.githubusercontent.com/32546729/149011009-688a5910-ae86-469e-b8eb-e447430b0527.png)
