### PR TITLE
Add detailed documentation for read/write json/file/storage nodes

### DIFF
--- a/blender/arm/logicnode/logic/LN_merge.py
+++ b/blender/arm/logicnode/logic/LN_merge.py
@@ -12,10 +12,8 @@ class MergeNode(ArmLogicTreeNode):
 
     @option Execution Mode: The node's behaviour if multiple inputs are
         active on the same frame.
-
         - `Once Per Input`: If multiple inputs are active on one frame, activate
             the output for each active input individually (simple forwarding).
-
         - `Once Per Frame`: If multiple inputs are active on one frame,
             trigger the output only once.
 

--- a/blender/arm/logicnode/logic/LN_select.py
+++ b/blender/arm/logicnode/logic/LN_select.py
@@ -16,11 +16,9 @@ class SelectNode(ArmLogicTreeNode):
 
     @option Execution Mode: Specifies the condition that determines
         what value to choose.
-
         - `From Index`: Select the value at the given index. If there is
             no value at that index, the value plugged in to the
             `Default` input is used instead (`null` if unconnected).
-
         - `From Input`: This mode uses input pairs of one action socket
             and one value socket. Depending on which action socket is
             activated, the associated value socket (the value with the

--- a/blender/arm/logicnode/native/LN_read_file.py
+++ b/blender/arm/logicnode/native/LN_read_file.py
@@ -1,9 +1,20 @@
 from arm.logicnode.arm_nodes import *
 
-class ReadFileNode(ArmLogicTreeNode):
-    """Returns the content of the given file.
 
-    @seeNode Write File"""
+class ReadFileNode(ArmLogicTreeNode):
+    """Reads the given file and returns its content.
+
+    @input File: the asset name of the file as used by Kha.
+    @input Use cache: if unchecked, re-read the file from disk every
+        time the node is executed. Otherwise, cache the file after the
+        first read and return the cached content.
+
+    @output Loaded: activated after the file has been read. If the file
+        doesn't exist, the output is not activated.
+    @output Content: the content of the file.
+
+    @seeNode Write File
+    """
     bl_idname = 'LNReadFileNode'
     bl_label = 'Read File'
     arm_section = 'file'
@@ -12,7 +23,7 @@ class ReadFileNode(ArmLogicTreeNode):
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmStringSocket', 'File')
-        self.add_input('ArmBoolSocket', 'Use cache', default_value=1)
+        self.add_input('ArmBoolSocket', 'Use cache', default_value=True)
 
         self.add_output('ArmNodeSocketAction', 'Loaded')
-        self.add_output('ArmStringSocket', 'String')
+        self.add_output('ArmStringSocket', 'Content')

--- a/blender/arm/logicnode/native/LN_read_json.py
+++ b/blender/arm/logicnode/native/LN_read_json.py
@@ -1,9 +1,20 @@
 from arm.logicnode.arm_nodes import *
 
-class ReadJsonNode(ArmLogicTreeNode):
-    """Returns the content of the given JSON file.
 
-    @seeNode Write JSON"""
+class ReadJsonNode(ArmLogicTreeNode):
+    """Reads the given JSON file and returns its content.
+
+    @input File: the asset name of the file as used by Kha.
+    @input Use cache: if unchecked, re-read the file from disk every
+        time the node is executed. Otherwise, cache the file after the
+        first read and return the cached content.
+
+    @output Loaded: activated after the file has been read. If the file
+        doesn't exist, the output is not activated.
+    @output Dynamic: the content of the file.
+
+    @seeNode Write JSON
+    """
     bl_idname = 'LNReadJsonNode'
     bl_label = 'Read JSON'
     arm_section = 'file'

--- a/blender/arm/logicnode/native/LN_read_storage.py
+++ b/blender/arm/logicnode/native/LN_read_storage.py
@@ -1,9 +1,15 @@
 from arm.logicnode.arm_nodes import *
 
-class ReadStorageNode(ArmLogicTreeNode):
-    """Reads a stored content.
 
-    @seeNode Write Storage"""
+class ReadStorageNode(ArmLogicTreeNode):
+    """Reads a value from the application's default storage file. Each
+    value is uniquely identified by a key.
+
+    For a detailed explanation of the storage system, please read the
+    documentation for the [`Write Storage`](#write-storage) node.
+
+    @seeNode Write Storage
+    """
     bl_idname = 'LNReadStorageNode'
     bl_label = 'Read Storage'
     arm_section = 'file'

--- a/blender/arm/logicnode/native/LN_write_file.py
+++ b/blender/arm/logicnode/native/LN_write_file.py
@@ -1,9 +1,17 @@
 from arm.logicnode.arm_nodes import *
 
-class WriteFileNode(ArmLogicTreeNode):
-    """Writes the given content in the given file.
 
-    @seeNode Read File"""
+class WriteFileNode(ArmLogicTreeNode):
+    """Writes the given string content to the given file. If the file
+    already exists, the existing content of the file is overwritten.
+
+    > **This node is currently only implemented on Krom**
+
+    @input File: the name of the file, relative to `Krom.getFilesLocation()`
+    @input Content: the content to write to the file.
+
+    @seeNode Read File
+    """
     bl_idname = 'LNWriteFileNode'
     bl_label = 'Write File'
     arm_section = 'file'
@@ -12,4 +20,4 @@ class WriteFileNode(ArmLogicTreeNode):
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmStringSocket', 'File')
-        self.add_input('ArmStringSocket', 'String')
+        self.add_input('ArmStringSocket', 'Content')

--- a/blender/arm/logicnode/native/LN_write_json.py
+++ b/blender/arm/logicnode/native/LN_write_json.py
@@ -1,9 +1,19 @@
 from arm.logicnode.arm_nodes import *
 
-class WriteJsonNode(ArmLogicTreeNode):
-    """Writes the given content in the given JSON file.
 
-    @seeNode Read JSON"""
+class WriteJsonNode(ArmLogicTreeNode):
+    """Writes the given content to the given JSON file. If the file
+    already exists, the existing content of the file is overwritten.
+
+    > **This node is currently only implemented on Krom**
+
+    @input File: the name of the file, relative to `Krom.getFilesLocation()`,
+        including the file extension.
+    @input Dynamic: the content to write to the file. Can be any type that can
+        be serialized to JSON.
+
+    @seeNode Read JSON
+    """
     bl_idname = 'LNWriteJsonNode'
     bl_label = 'Write JSON'
     arm_section = 'file'

--- a/blender/arm/logicnode/native/LN_write_storage.py
+++ b/blender/arm/logicnode/native/LN_write_storage.py
@@ -1,9 +1,29 @@
 from arm.logicnode.arm_nodes import *
 
-class WriteStorageNode(ArmLogicTreeNode):
-    """Writes the given content in the given key.
 
-    @seeNode Read Storage"""
+class WriteStorageNode(ArmLogicTreeNode):
+    """Writes a given value to the application's default storage file.
+    Each value is uniquely identified by a key, which can be used to
+    later read the value from the storage file.
+
+    Each key can only refer to one value, so writing a second value with
+    a key that is already used overwrites the already stored value with
+    the second value.
+
+    The location of the default storage file varies on different
+    platforms, as implemented by the Kha storage API:
+    - *Windows*: `%USERPROFILE%/Saved Games/<application name>/default.kha`
+    - *Linux*: one of `$HOME/.<application name>/default.kha`, `$XDG_DATA_HOME/.<application name>/default.kha` or `$HOME/.local/share/default.kha`
+    - *MacOS*: `~/Library/Application Support/<application name>/default.kha`
+    - *iOS*: `~/Library/Application Support/<application name>/default.kha`
+    - *Android*: `<internalDataPath>/<application package name>/files/default.kha`
+    - *HTML 5*: saved in the local storage (web storage API) for the project's [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin).
+
+    `<application name>` refers to the name set at `Armory Exporter > Name`,
+    `<application package name>` is the generated package name on Android.
+
+    @seeNode Read Storage
+    """
     bl_idname = 'LNWriteStorageNode'
     bl_label = 'Write Storage'
     arm_section = 'file'


### PR DESCRIPTION
Implements the documentation part of https://github.com/armory3d/armory/issues/2070 and requires https://github.com/armory3d/armory_tools/pull/12 for proper layout in the GitHub wiki.

For the Write Storage node I had to look up some of the save file paths in the Kinc sources because I can't test all targets. This however means that some of the paths might not be correct or formatted in a wrong way that isn't used on that particular platform. So if someone sees a mistake, please let me know :) Also, I know that the paths are internal Kha stuff that may change any time, but as Kha's documentation is rather non-existent or extremely well hidden I think it is good to write it down somewhere as it might be of interest for developers.