### PR TITLE
Don't count not exported lights when setting shader defines

### DIFF
--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -101,7 +101,7 @@ def add_world_defs():
     # Light defines
     point_lights = 0
     for bo in bpy.data.objects: # TODO: temp
-        if bo.type == 'LIGHT':
+        if bo.arm_export and bo.type == 'LIGHT':
             light = bo.data
             if light.type == 'AREA' and '_LTC' not in wrd.world_defs:
                 point_lights += 1


### PR DESCRIPTION
This prevents the [usual krafix/directx issue](https://github.com/armory3d/armory/issues/1772) in case multiple lights exist in the scene but only one is used for rendering in game (e.g. because the other lights are used for light mapping only).