### PR TITLE
New logic tree variable system

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -106,9 +106,9 @@ def send_operator(op):
 
 def always() -> float:
     # Force ui redraw
-    if state.redraw_ui and context_screen is not None:
-        for area in context_screen.areas:
-            if area.type == 'VIEW_3D' or area.type == 'PROPERTIES':
+    if state.redraw_ui:
+        for area in bpy.context.screen.areas:
+            if area.type in ('NODE_EDITOR', 'PROPERTIES', 'VIEW_3D'):
                 area.tag_redraw()
         state.redraw_ui = False
     # TODO: depsgraph.updates only triggers material trees

--- a/blender/arm/logicnode/__init__.py
+++ b/blender/arm/logicnode/__init__.py
@@ -90,7 +90,7 @@ def init_nodes(base_path=__path__, base_package=__package__, subpackages_only=Fa
                 _module = importlib.reload(sys.modules[module_name])
 
             for name, obj in inspect.getmembers(_module, inspect.isclass):
-                if name == "ArmLogicTreeNode":
+                if name in ("ArmLogicTreeNode", "ArmLogicVariableNodeMixin"):
                     continue
                 if issubclass(obj, arm_nodes.ArmLogicTreeNode):
                     obj.on_register()

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -307,11 +307,10 @@ class ArmLogicVariableNodeMixin(ArmLogicTreeNode):
 
         if self.arm_logic_id != '':
             target_tree = self.get_tree()
+            lst = target_tree.arm_treevariableslist
 
             self.is_master_node = False  # Ignore this node in get_master_node below
             if self.__class__.get_master_node(target_tree, self.arm_logic_id) is None:
-                lst = target_tree.arm_treevariableslist
-
                 var_item = lst.add()
                 var_item['_name'] = arm.utils.unique_str_for_list(
                     items=lst, name_attr='name', wanted_name=self.arm_logic_id, ignore_item=var_item
@@ -323,6 +322,11 @@ class ArmLogicVariableNodeMixin(ArmLogicTreeNode):
                 arm.make_state.redraw_ui = True
 
                 self.is_master_node = True
+            else:
+                for item in lst:
+                    if item.name == self.arm_logic_id:
+                        self.color = item.color
+                        break
 
         super().copy(src_node)
 

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -288,6 +288,10 @@ class ArmLogicVariableNodeMixin(ArmLogicTreeNode):
                     tree.arm_treevariableslist.remove(idx)
                     break
 
+            max_index = len(tree.arm_treevariableslist) - 1
+            if tree.arm_treevariableslist_index > max_index:
+                tree.arm_treevariableslist_index = max_index
+
         self.arm_logic_id = ''
 
     def free(self):

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -316,7 +316,7 @@ class ArmLogicVariableNodeMixin(ArmLogicTreeNode):
                 var_item['_name'] = arm.utils.unique_str_for_list(
                     items=lst, name_attr='name', wanted_name=self.arm_logic_id, ignore_item=var_item
                 )
-                var_item.type = self.bl_idname
+                var_item.node_type = self.bl_idname
                 var_item.color = arm.utils.get_random_color_rgb()
 
                 target_tree.arm_treevariableslist_index = len(lst) - 1

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import itertools
-from typing import Any, Generator, List, Optional, Type, Union
+import textwrap
+from typing import Any, final, Generator, List, Optional, Type, Union
 from typing import OrderedDict as ODict  # Prevent naming conflicts
 
 import bpy.types
@@ -32,7 +33,7 @@ PKG_AS_CATEGORY = "__pkgcat__"
 nodes = []
 category_items: ODict[str, List['ArmNodeCategory']] = OrderedDict()
 
-array_nodes = dict()
+array_nodes: dict[str, 'ArmLogicTreeNode'] = dict()
 
 # See ArmLogicTreeNode.update()
 # format: [tree pointer => (num inputs, num input links, num outputs, num output links)]
@@ -59,6 +60,15 @@ class ArmLogicTreeNode(bpy.types.Node):
 
         arm.live_patch.send_event('ln_create', self)
 
+    def register_id(self):
+        """Registers a node ID so that the ID can be used by operators
+        to target this node (nodes can't be stored in pointer properties).
+        """
+        array_nodes[self.get_id_str()] = self
+
+    def get_id_str(self) -> str:
+        return str(self.as_pointer())
+
     @classmethod
     def poll(cls, ntree):
         return ntree.bl_idname == 'ArmLogicTreeType'
@@ -73,7 +83,7 @@ class ArmLogicTreeNode(bpy.types.Node):
     def on_unregister(cls):
         pass
 
-    def get_tree(self):
+    def get_tree(self) -> bpy.types.NodeTree:
         return self.id_data
 
     def update(self):
@@ -107,18 +117,19 @@ class ArmLogicTreeNode(bpy.types.Node):
             last_node_state[self_id] = current_state
 
         if last_node_state[self_id] != current_state:
-            arm.live_patch.send_event('ln_update_sockets', self)
+            self.on_socket_state_change()
             last_node_state[self_id] = current_state
 
     def free(self):
         """Called before the node is deleted."""
         arm.live_patch.send_event('ln_delete', self)
 
-    def copy(self, node):
-        """Called if the node was copied. `self` holds the copied node,
-        `node` the original one.
+    def copy(self, src_node):
+        """Called upon node duplication or upon pasting a copied node.
+        `self` holds the copied node and `src_node` a temporal copy of
+        the original node at the time of copying).
         """
-        arm.live_patch.send_event('ln_copy', (self, node))
+        arm.live_patch.send_event('ln_copy', (self, src_node))
 
     def on_prop_update(self, context: bpy.types.Context, prop_name: str):
         """Called if a property created with a function from the
@@ -129,6 +140,16 @@ class ArmLogicTreeNode(bpy.types.Node):
 
     def on_socket_val_update(self, context: bpy.types.Context, socket: bpy.types.NodeSocket):
         arm.live_patch.send_event('ln_socket_val', (self, socket))
+
+    def on_socket_state_change(self):
+        """Called if the state (amount, connection state) of the node's
+        socket changes (see ArmLogicTreeNode.update())
+        """
+        arm.live_patch.send_event('ln_update_sockets', self)
+
+    def on_logic_id_change(self):
+        """Called if the node's arm_logic_id value changes."""
+        arm.live_patch.patch_export()
 
     def insert_link(self, link: bpy.types.NodeLink):
         """Called on *both* nodes when a link between two nodes is created."""
@@ -205,6 +226,186 @@ class ArmLogicTreeNode(bpy.types.Node):
         return socket
 
 
+class ArmLogicVariableNodeMixin(ArmLogicTreeNode):
+    """A mixin class for variable nodes. This class adds functionality
+    that allows variable nodes to
+        1) be identified as such and
+        2) to be promoted to nodes that are linked to a tree variable.
+
+    If a variable node is promoted to a tree variable node and the
+    tree variable does not exist yet, it is created. Each tree variable
+    only exists as long as there are variable nodes that are linked to
+    it. A variable node's links to a tree variables can be removed by
+    calling `make_local()`. If a tree variable node is copied to a
+    different tree where the variable doesn't exist, it is created.
+
+    Tree variable nodes come in two states: master and replica nodes.
+    In order to not having to find memory-intensive and complicated ways
+    for storing every possible variable node data in the tree variable
+    UI list entries themselves (Blender doesn't support dynamically
+    typed properties), we store the data in one of the variable nodes,
+    called the master node. The other nodes are synchronized with the
+    master node and must implement a routine to copy the data from the
+    master node.
+
+    The user doesn't need to know about the master/replica concept, the
+    master node gets chosen automatically and it is made sure that there
+    can be only one master node, even after copying.
+    """
+    is_master_node: BoolProperty(default=False)
+
+    _text_wrapper = textwrap.TextWrapper()
+
+    def synchronize_from_master(self, master_node: 'ArmLogicVariableNodeMixin'):
+        """Called if the node should synchronize its data from the passed
+        master_node. Override this in variable nodes to react to updates
+        made to the master node.
+        """
+        pass
+
+    def _synchronize_to_replicas(self, master_node: 'ArmLogicVariableNodeMixin'):
+        for replica_node in self.get_replica_nodes(self.get_tree(), self.arm_logic_id):
+            replica_node.synchronize_from_master(master_node)
+
+    def make_local(self):
+        """Demotes this node to a local variable node that is not linked
+        to any tree variable.
+        """
+        has_replicas = True
+        if self.is_master_node:
+            self._synchronize_to_replicas(self)
+            has_replicas = self.choose_new_master_node(self.get_tree(), self.arm_logic_id)
+            self.is_master_node = False
+
+        # Remove the tree variable if there are no more nodes that link
+        # to it
+        if not has_replicas:
+            tree = self.get_tree()
+            for idx, item in enumerate(tree.arm_treevariableslist):
+                if item.name == self.arm_logic_id:
+                    tree.arm_treevariableslist.remove(idx)
+                    break
+
+        self.arm_logic_id = ''
+
+    def free(self):
+        self.make_local()
+        super().free()
+
+    def copy(self, src_node: 'ArmLogicVariableNodeMixin'):
+        # Because the `copy()` callback is actually called upon pasting
+        # the node, `src_node` is a temporal copy of the copied node
+        # that retains the state of the node upon copying. This however
+        # means that we can't reliably use the master state of the
+        # pasted node because it might have changed in between, also
+        # `src_node.get_tree()` will return `None`. So if the pasted
+        # node is linked to a tree var, we simply check if the tree of
+        # the pasted node has the tree variable and depending on that we
+        # set `is_master_node`.
+
+        if self.arm_logic_id != '':
+            target_tree = self.get_tree()
+
+            self.is_master_node = False  # Ignore this node in get_master_node below
+            if self.__class__.get_master_node(target_tree, self.arm_logic_id) is None:
+                lst = target_tree.arm_treevariableslist
+
+                var_item = lst.add()
+                var_item['_name'] = arm.utils.unique_str_for_list(
+                    items=lst, name_attr='name', wanted_name=self.arm_logic_id, ignore_item=var_item
+                )
+                var_item.type = self.bl_idname
+
+                target_tree.arm_treevariableslist_index = len(lst) - 1
+                arm.make_state.redraw_ui = True
+
+                self.is_master_node = True
+
+        super().copy(src_node)
+
+    def on_socket_state_change(self):
+        if self.is_master_node:
+            self._synchronize_to_replicas(self)
+        super().on_socket_state_change()
+
+    def on_logic_id_change(self):
+        tree = self.get_tree()
+        is_linked = self.arm_logic_id != ''
+        for inp in self.inputs:
+            if is_linked:
+                for link in inp.links:
+                    tree.links.remove(link)
+
+            inp.hide = is_linked
+            inp.enabled = not is_linked  # Hide in sidebar, see Blender's space_node.py
+        super().on_logic_id_change()
+
+    def on_prop_update(self, context: bpy.types.Context, prop_name: str):
+        if self.is_master_node:
+            self._synchronize_to_replicas(self)
+        super().on_prop_update(context, prop_name)
+
+    def on_socket_val_update(self, context: bpy.types.Context, socket: bpy.types.NodeSocket):
+        if self.is_master_node:
+            self._synchronize_to_replicas(self)
+        super().on_socket_val_update(context, socket)
+
+    def draw_content(self, context, layout):
+        """Override in variable nodes as replacement for draw_buttons()"""
+        pass
+
+    @final
+    def draw_buttons(self, context, layout):
+        if self.arm_logic_id == '':
+            self.draw_content(context, layout)
+        else:
+            txt_wrapper = self.__class__._text_wrapper
+            # Roughly estimate how much text fits in the node's width
+            txt_wrapper.width = self.width / 6
+
+            msg = f'Value linked to tree variable "{self.arm_logic_id}"'
+            lines = txt_wrapper.wrap(msg)
+
+            for line in lines:
+                row = layout.row(align=True)
+                row.alignment = 'EXPAND'
+                row.label(text=line)
+                row.scale_y = 0.4
+
+    @staticmethod
+    def choose_new_master_node(tree: bpy.types.NodeTree, logic_id: str) -> bool:
+        """Choose a new master node from the remaining replica nodes.
+
+        Return `True` if a new master node was found, otherwise return
+        `False`.
+        """
+        try:
+            node = next(ArmLogicVariableNodeMixin.get_replica_nodes(tree, logic_id))
+        except StopIteration:
+            return False  # No replica node found
+
+        node.is_master_node = True
+        return True
+
+    @staticmethod
+    def get_master_node(tree: bpy.types.NodeTree, logic_id: str) -> Optional['ArmLogicVariableNodeMixin']:
+        for node in tree.nodes:
+            if node.arm_logic_id == logic_id and isinstance(node, ArmLogicVariableNodeMixin):
+                if node.is_master_node:
+                    return node
+        return None
+
+    @staticmethod
+    def get_replica_nodes(tree: bpy.types.NodeTree, logic_id: str) -> Generator['ArmLogicVariableNodeMixin', None, None]:
+        """A generator that iterates over all variable nodes for a given
+        ID that are not the master node.
+        """
+        for node in tree.nodes:
+            if node.arm_logic_id == logic_id and isinstance(node, ArmLogicVariableNodeMixin):
+                if not node.is_master_node:
+                    yield node
+
+
 class ArmNodeAddInputButton(bpy.types.Operator):
     """Add a new input socket to the node set by node_index."""
     bl_idname = 'arm.node_add_input'
@@ -218,7 +419,8 @@ class ArmNodeAddInputButton(bpy.types.Operator):
 
     def execute(self, context):
         global array_nodes
-        inps = array_nodes[self.node_index].inputs
+        node = array_nodes[self.node_index]
+        inps = node.inputs
 
         socket_types = self.socket_type.split(';')
         name_formats = self.name_format.split(';')
@@ -226,7 +428,10 @@ class ArmNodeAddInputButton(bpy.types.Operator):
 
         format_index = (len(inps) + self.index_name_offset) // len(socket_types)
         for socket_type, name_format in zip(socket_types, name_formats):
-            inps.new(socket_type, name_format.format(str(format_index)))
+            inp = inps.new(socket_type, name_format.format(str(format_index)))
+            # Make sure inputs don't show up if the node links to a tree variable
+            inp.hide = node.arm_logic_id != ''
+            inp.enabled = node.arm_logic_id == ''
 
         # Reset to default again for subsequent calls of this operator
         self.node_index = ''

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -15,6 +15,7 @@ import arm  # we cannot import arm.livepatch here or we have a circular import
 from arm.logicnode.arm_props import *
 from arm.logicnode.replacement import NodeReplacement
 import arm.node_utils
+import arm.utils
 
 if arm.is_reload(__name__):
     arm.logicnode.arm_props = arm.reload_module(arm.logicnode.arm_props)
@@ -22,6 +23,7 @@ if arm.is_reload(__name__):
     arm.logicnode.replacement = arm.reload_module(arm.logicnode.replacement)
     from arm.logicnode.replacement import NodeReplacement
     arm.node_utils = arm.reload_module(arm.node_utils)
+    arm.utils = arm.reload_module(arm.utils)
 else:
     arm.enable_reload(__name__)
 
@@ -315,6 +317,7 @@ class ArmLogicVariableNodeMixin(ArmLogicTreeNode):
                     items=lst, name_attr='name', wanted_name=self.arm_logic_id, ignore_item=var_item
                 )
                 var_item.type = self.bl_idname
+                var_item.color = arm.utils.get_random_color_rgb()
 
                 target_tree.arm_treevariableslist_index = len(lst) - 1
                 arm.make_state.redraw_ui = True

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -375,6 +375,12 @@ class ArmLogicVariableNodeMixin(ArmLogicTreeNode):
                 row.label(text=line)
                 row.scale_y = 0.4
 
+    def draw_label(self) -> str:
+        if self.arm_logic_id == '':
+            return self.bl_label
+        else:
+            return f'TV: {self.arm_logic_id}'
+
     @staticmethod
     def choose_new_master_node(tree: bpy.types.NodeTree, logic_id: str) -> bool:
         """Choose a new master node from the remaining replica nodes.

--- a/blender/arm/logicnode/array/LN_array.py
+++ b/blender/arm/logicnode/array/LN_array.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class ArrayNode(ArmLogicTreeNode):
+
+class ArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given array as a variable."""
     bl_idname = 'LNArrayNode'
     bl_label = 'Array Dynamic'
@@ -8,23 +9,31 @@ class ArrayNode(ArmLogicTreeNode):
     arm_section = 'variable'
 
     def __init__(self):
-        array_nodes[str(id(self))] = self
+        self.register_id()
 
     def arm_init(self, context):
         self.add_output('ArmNodeSocketArray', 'Array', is_var=True)
         self.add_output('ArmIntSocket', 'Length')
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         row = layout.row(align=True)
 
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         op.socket_type = 'ArmDynamicSocket'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op2.node_index = str(id(self))
+        op2.node_index = self.get_id_str()
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
             return self.bl_label
 
         return f'{self.bl_label}: [{len(self.inputs)}]'
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs.clear()
+        for i in range(len(master_node.inputs)):
+            inp = self.add_input('ArmDynamicSocket', master_node.inputs[i].name)
+            inp.hide = self.arm_logic_id != ''
+            inp.enabled = self.arm_logic_id == ''
+            inp.default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/logicnode/array/LN_array.py
+++ b/blender/arm/logicnode/array/LN_array.py
@@ -26,9 +26,9 @@ class ArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
-            return self.bl_label
+            return super().draw_label()
 
-        return f'{self.bl_label}: [{len(self.inputs)}]'
+        return f'{super().draw_label()} [{len(self.inputs)}]'
 
     def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
         self.inputs.clear()

--- a/blender/arm/logicnode/array/LN_array_boolean.py
+++ b/blender/arm/logicnode/array/LN_array_boolean.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class BooleanArrayNode(ArmLogicTreeNode):
+
+class BooleanArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of boolean elements as a variable."""
     bl_idname = 'LNArrayBooleanNode'
     bl_label = 'Array Boolean'
@@ -9,23 +10,31 @@ class BooleanArrayNode(ArmLogicTreeNode):
 
     def __init__(self):
         super(BooleanArrayNode, self).__init__()
-        array_nodes[str(id(self))] = self
+        self.register_id()
 
     def arm_init(self, context):
         self.add_output('ArmNodeSocketArray', 'Array', is_var=True)
         self.add_output('ArmIntSocket', 'Length')
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         row = layout.row(align=True)
 
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         op.socket_type = 'ArmBoolSocket'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op2.node_index = str(id(self))
+        op2.node_index = self.get_id_str()
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
             return self.bl_label
 
         return f'{self.bl_label}: [{len(self.inputs)}]'
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs.clear()
+        for i in range(len(master_node.inputs)):
+            inp = self.add_input('ArmBoolSocket', master_node.inputs[i].name)
+            inp.hide = self.arm_logic_id != ''
+            inp.enabled = self.arm_logic_id == ''
+            inp.default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/logicnode/array/LN_array_boolean.py
+++ b/blender/arm/logicnode/array/LN_array_boolean.py
@@ -27,9 +27,9 @@ class BooleanArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
-            return self.bl_label
+            return super().draw_label()
 
-        return f'{self.bl_label}: [{len(self.inputs)}]'
+        return f'{super().draw_label()} [{len(self.inputs)}]'
 
     def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
         self.inputs.clear()

--- a/blender/arm/logicnode/array/LN_array_color.py
+++ b/blender/arm/logicnode/array/LN_array_color.py
@@ -27,9 +27,9 @@ class ColorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
-            return self.bl_label
+            return super().draw_label()
 
-        return f'{self.bl_label}: [{len(self.inputs)}]'
+        return f'{super().draw_label()} [{len(self.inputs)}]'
 
     def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
         self.inputs.clear()

--- a/blender/arm/logicnode/array/LN_array_color.py
+++ b/blender/arm/logicnode/array/LN_array_color.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class ColorArrayNode(ArmLogicTreeNode):
+
+class ColorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of color elements as a variable."""
     bl_idname = 'LNArrayColorNode'
     bl_label = 'Array Color'
@@ -9,23 +10,31 @@ class ColorArrayNode(ArmLogicTreeNode):
 
     def __init__(self):
         super(ColorArrayNode, self).__init__()
-        array_nodes[str(id(self))] = self
+        self.register_id()
 
     def arm_init(self, context):
         self.add_output('ArmNodeSocketArray', 'Array', is_var=True)
         self.add_output('ArmIntSocket', 'Length')
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         row = layout.row(align=True)
 
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         op.socket_type = 'ArmColorSocket'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op2.node_index = str(id(self))
+        op2.node_index = self.get_id_str()
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
             return self.bl_label
 
         return f'{self.bl_label}: [{len(self.inputs)}]'
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs.clear()
+        for i in range(len(master_node.inputs)):
+            inp = self.add_input('ArmColorSocket', master_node.inputs[i].name)
+            inp.hide = self.arm_logic_id != ''
+            inp.enabled = self.arm_logic_id == ''
+            inp.default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/logicnode/array/LN_array_float.py
+++ b/blender/arm/logicnode/array/LN_array_float.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class FloatArrayNode(ArmLogicTreeNode):
+
+class FloatArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of float elements as a variable."""
     bl_idname = 'LNArrayFloatNode'
     bl_label = 'Array Float'
@@ -9,23 +10,31 @@ class FloatArrayNode(ArmLogicTreeNode):
 
     def __init__(self):
         super(FloatArrayNode, self).__init__()
-        array_nodes[str(id(self))] = self
+        self.register_id()
 
     def arm_init(self, context):
         self.add_output('ArmNodeSocketArray', 'Array', is_var=True)
         self.add_output('ArmIntSocket', 'Length')
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         row = layout.row(align=True)
 
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         op.socket_type = 'ArmFloatSocket'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op2.node_index = str(id(self))
+        op2.node_index = self.get_id_str()
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
             return self.bl_label
 
         return f'{self.bl_label}: [{len(self.inputs)}]'
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs.clear()
+        for i in range(len(master_node.inputs)):
+            inp = self.add_input('ArmFloatSocket', master_node.inputs[i].name)
+            inp.hide = self.arm_logic_id != ''
+            inp.enabled = self.arm_logic_id == ''
+            inp.default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/logicnode/array/LN_array_float.py
+++ b/blender/arm/logicnode/array/LN_array_float.py
@@ -27,9 +27,9 @@ class FloatArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
-            return self.bl_label
+            return super().draw_label()
 
-        return f'{self.bl_label}: [{len(self.inputs)}]'
+        return f'{super().draw_label()} [{len(self.inputs)}]'
 
     def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
         self.inputs.clear()

--- a/blender/arm/logicnode/array/LN_array_integer.py
+++ b/blender/arm/logicnode/array/LN_array_integer.py
@@ -27,9 +27,9 @@ class IntegerArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
-            return self.bl_label
+            return super().draw_label()
 
-        return f'{self.bl_label}: [{len(self.inputs)}]'
+        return f'{super().draw_label()} [{len(self.inputs)}]'
 
     def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
         self.inputs.clear()

--- a/blender/arm/logicnode/array/LN_array_integer.py
+++ b/blender/arm/logicnode/array/LN_array_integer.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class IntegerArrayNode(ArmLogicTreeNode):
+
+class IntegerArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of integer elements as a variable."""
     bl_idname = 'LNArrayIntegerNode'
     bl_label = 'Array Integer'
@@ -9,23 +10,31 @@ class IntegerArrayNode(ArmLogicTreeNode):
 
     def __init__(self):
         super(IntegerArrayNode, self).__init__()
-        array_nodes[str(id(self))] = self
+        self.register_id()
 
     def arm_init(self, context):
         self.add_output('ArmNodeSocketArray', 'Array')
         self.add_output('ArmIntSocket', 'Length')
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         row = layout.row(align=True)
 
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         op.socket_type = 'ArmIntSocket'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op2.node_index = str(id(self))
+        op2.node_index = self.get_id_str()
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
             return self.bl_label
 
         return f'{self.bl_label}: [{len(self.inputs)}]'
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs.clear()
+        for i in range(len(master_node.inputs)):
+            inp = self.add_input('ArmIntSocket', master_node.inputs[i].name)
+            inp.hide = self.arm_logic_id != ''
+            inp.enabled = self.arm_logic_id == ''
+            inp.default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/logicnode/array/LN_array_object.py
+++ b/blender/arm/logicnode/array/LN_array_object.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class ObjectArrayNode(ArmLogicTreeNode):
+
+class ObjectArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of object elements as a variable."""
     bl_idname = 'LNArrayObjectNode'
     bl_label = 'Array Object'
@@ -9,23 +10,31 @@ class ObjectArrayNode(ArmLogicTreeNode):
 
     def __init__(self):
         super(ObjectArrayNode, self).__init__()
-        array_nodes[str(id(self))] = self
+        self.register_id()
 
     def arm_init(self, context):
         self.add_output('ArmNodeSocketArray', 'Array', is_var=True)
         self.add_output('ArmIntSocket', 'Length')
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         row = layout.row(align=True)
 
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         op.socket_type = 'ArmNodeSocketObject'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op2.node_index = str(id(self))
+        op2.node_index = self.get_id_str()
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
             return self.bl_label
 
         return f'{self.bl_label}: [{len(self.inputs)}]'
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs.clear()
+        for i in range(len(master_node.inputs)):
+            inp = self.add_input('ArmNodeSocketObject', master_node.inputs[i].name)
+            inp.hide = self.arm_logic_id != ''
+            inp.enabled = self.arm_logic_id == ''
+            inp.default_value_raw = master_node.inputs[i].default_value_raw

--- a/blender/arm/logicnode/array/LN_array_object.py
+++ b/blender/arm/logicnode/array/LN_array_object.py
@@ -27,9 +27,9 @@ class ObjectArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
-            return self.bl_label
+            return super().draw_label()
 
-        return f'{self.bl_label}: [{len(self.inputs)}]'
+        return f'{super().draw_label()} [{len(self.inputs)}]'
 
     def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
         self.inputs.clear()

--- a/blender/arm/logicnode/array/LN_array_string.py
+++ b/blender/arm/logicnode/array/LN_array_string.py
@@ -27,9 +27,9 @@ class StringArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
-            return self.bl_label
+            return super().draw_label()
 
-        return f'{self.bl_label}: [{len(self.inputs)}]'
+        return f'{super().draw_label()} [{len(self.inputs)}]'
 
     def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
         self.inputs.clear()

--- a/blender/arm/logicnode/array/LN_array_string.py
+++ b/blender/arm/logicnode/array/LN_array_string.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class StringArrayNode(ArmLogicTreeNode):
+
+class StringArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of string elements as a variable."""
     bl_idname = 'LNArrayStringNode'
     bl_label = 'Array String'
@@ -9,23 +10,31 @@ class StringArrayNode(ArmLogicTreeNode):
 
     def __init__(self):
         super(StringArrayNode, self).__init__()
-        array_nodes[str(id(self))] = self
+        self.register_id()
 
     def arm_init(self, context):
         self.add_output('ArmNodeSocketArray', 'Array', is_var=True)
         self.add_output('ArmIntSocket', 'Length')
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         row = layout.row(align=True)
 
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         op.socket_type = 'ArmStringSocket'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op2.node_index = str(id(self))
+        op2.node_index = self.get_id_str()
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
             return self.bl_label
 
         return f'{self.bl_label}: [{len(self.inputs)}]'
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs.clear()
+        for i in range(len(master_node.inputs)):
+            inp = self.add_input('ArmStringSocket', master_node.inputs[i].name)
+            inp.hide = self.arm_logic_id != ''
+            inp.enabled = self.arm_logic_id == ''
+            inp.default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/logicnode/array/LN_array_vector.py
+++ b/blender/arm/logicnode/array/LN_array_vector.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class VectorArrayNode(ArmLogicTreeNode):
+
+class VectorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of vector elements as a variable."""
     bl_idname = 'LNArrayVectorNode'
     bl_label = 'Array Vector'
@@ -9,23 +10,31 @@ class VectorArrayNode(ArmLogicTreeNode):
 
     def __init__(self):
         super(VectorArrayNode, self).__init__()
-        array_nodes[str(id(self))] = self
+        self.register_id()
 
     def arm_init(self, context):
         self.add_output('ArmNodeSocketArray', 'Array', is_var=True)
         self.add_output('ArmIntSocket', 'Length')
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         row = layout.row(align=True)
 
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         op.socket_type = 'ArmVectorSocket'
         op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op2.node_index = str(id(self))
+        op2.node_index = self.get_id_str()
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
             return self.bl_label
 
         return f'{self.bl_label}: [{len(self.inputs)}]'
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs.clear()
+        for i in range(len(master_node.inputs)):
+            inp = self.add_input('ArmVectorSocket', master_node.inputs[i].name)
+            inp.hide = self.arm_logic_id != ''
+            inp.enabled = self.arm_logic_id == ''
+            inp.default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/logicnode/array/LN_array_vector.py
+++ b/blender/arm/logicnode/array/LN_array_vector.py
@@ -27,9 +27,9 @@ class VectorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
 
     def draw_label(self) -> str:
         if len(self.inputs) == 0:
-            return self.bl_label
+            return super().draw_label()
 
-        return f'{self.bl_label}: [{len(self.inputs)}]'
+        return f'{super().draw_label()} [{len(self.inputs)}]'
 
     def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
         self.inputs.clear()

--- a/blender/arm/logicnode/material/LN_material.py
+++ b/blender/arm/logicnode/material/LN_material.py
@@ -4,7 +4,7 @@ import arm.utils
 from arm.logicnode.arm_nodes import *
 
 
-class MaterialNode(ArmLogicTreeNode):
+class MaterialNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given material as a variable."""
     bl_idname = 'LNMaterialNode'
     bl_label = 'Material'
@@ -23,5 +23,8 @@ class MaterialNode(ArmLogicTreeNode):
     def arm_init(self, context):
         self.add_output('ArmDynamicSocket', 'Material', is_var=True)
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         layout.prop_search(self, 'property0', bpy.data, 'materials', icon='NONE', text='')
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.property0 = master_node.property0

--- a/blender/arm/logicnode/object/LN_object.py
+++ b/blender/arm/logicnode/object/LN_object.py
@@ -15,13 +15,13 @@ class ObjectNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     def draw_label(self) -> str:
         inp_object = self.inputs['Object In']
         if inp_object.is_linked:
-            return self.bl_label
+            return super().draw_label()
 
         obj_name = inp_object.get_default_value()
         if obj_name == '':
             obj_name = '_self'
 
-        return f'{self.bl_label}: {obj_name}'
+        return f'{super().draw_label()}: {obj_name}'
 
     def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
         self.inputs[0].default_value_raw = master_node.inputs[0].default_value_raw

--- a/blender/arm/logicnode/object/LN_object.py
+++ b/blender/arm/logicnode/object/LN_object.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class ObjectNode(ArmLogicTreeNode):
+
+class ObjectNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given object as a variable."""
     bl_idname = 'LNObjectNode'
     bl_label = 'Object'
@@ -21,3 +22,6 @@ class ObjectNode(ArmLogicTreeNode):
             obj_name = '_self'
 
         return f'{self.bl_label}: {obj_name}'
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs[0].default_value_raw = master_node.inputs[0].default_value_raw

--- a/blender/arm/logicnode/replacement.py
+++ b/blender/arm/logicnode/replacement.py
@@ -137,11 +137,11 @@ def replace(tree: bpy.types.NodeTree, node: 'ArmLogicTreeNode'):
     if isinstance(response, arm_nodes.ArmLogicTreeNode):
         newnode = response
         # some misc. properties
-        copy_basic_node_props(from_node=node, to_node=newnode)
+        node_utils.copy_basic_node_props(from_node=node, to_node=newnode)
 
     elif isinstance(response, list):  # a list of nodes:
         for newnode in response:
-            copy_basic_node_props(from_node=node, to_node=newnode)
+            node_utils.copy_basic_node_props(from_node=node, to_node=newnode)
 
     elif isinstance(response, NodeReplacement):
         replacement = response
@@ -156,7 +156,7 @@ def replace(tree: bpy.types.NodeTree, node: 'ArmLogicTreeNode'):
             raise LookupError("The provided NodeReplacement doesn't seem to correspond to the node needing replacement")
 
         # some misc. properties
-        copy_basic_node_props(from_node=node, to_node=newnode)
+        node_utils.copy_basic_node_props(from_node=node, to_node=newnode)
 
         # now, use the `replacement` to hook up the new node correctly
         # start by applying defaults
@@ -279,15 +279,6 @@ def replace_all():
         bpy.ops.arm.show_node_update_errors()
 
 
-def copy_basic_node_props(from_node: bpy.types.Node, to_node: bpy.types.Node):
-    to_node.parent = from_node.parent
-    to_node.location = from_node.location
-    to_node.select = from_node.select
-
-    to_node.arm_logic_id = from_node.arm_logic_id
-    to_node.arm_watch = from_node.arm_watch
-
-
 def node_compat_sdk2108():
     """SDK 21.08 broke compatibility with older nodes as nodes now use
     custom sockets even for Blender's default data types and custom
@@ -310,7 +301,7 @@ def node_compat_sdk2108():
                     continue
 
                 newnode = tree.nodes.new(node.__class__.bl_idname)
-                copy_basic_node_props(from_node=node, to_node=newnode)
+                node_utils.copy_basic_node_props(from_node=node, to_node=newnode)
 
                 # Also copy the node's version number to _not_ prevent actual node
                 # replacement after this step

--- a/blender/arm/logicnode/string/LN_string.py
+++ b/blender/arm/logicnode/string/LN_string.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class StringNode(ArmLogicTreeNode):
+
+class StringNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given string as a variable."""
     bl_idname = 'LNStringNode'
     bl_label = 'String'
@@ -10,3 +11,6 @@ class StringNode(ArmLogicTreeNode):
         self.add_input('ArmStringSocket', 'String In')
 
         self.add_output('ArmStringSocket', 'String Out', is_var=True)
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs[0].default_value_raw = master_node.inputs[0].get_default_value()

--- a/blender/arm/logicnode/trait/LN_trait.py
+++ b/blender/arm/logicnode/trait/LN_trait.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class TraitNode(ArmLogicTreeNode):
+
+class TraitNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given trait as a variable. If the trait was not found or
     was not exported, an error is thrown ([more information](https://github.com/armory3d/armory/wiki/troubleshooting#trait-not-exported)).
     """
@@ -13,5 +14,8 @@ class TraitNode(ArmLogicTreeNode):
     def arm_init(self, context):
         self.add_output('ArmDynamicSocket', 'Trait', is_var=True)
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         layout.prop(self, 'property0')
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.property0 = master_node.property0

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -70,7 +70,6 @@ class ARM_PT_Variables(bpy.types.Panel):
         if len(tree.arm_treevariableslist) > 0:
             selected_item = tree.arm_treevariableslist[tree.arm_treevariableslist_index]
 
-            layout.separator()
             box = layout.box()
             box.label(text="Selected Variable:")
             master_node = arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.get_master_node(tree, selected_item.name)

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -197,11 +197,13 @@ class ARM_OT_TreeVariableVariableAssignToNode(bpy.types.Operator):
         node: arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin = context.active_node
         tree: bpy.types.NodeTree = context.space_data.node_tree
 
+        var_item = tree.arm_treevariableslist[tree.arm_treevariableslist_index]
+
         # Make node local first to ensure the old tree variable (if
         # linked) is notified that the node is no longer linked
-        node.make_local()
+        if node.arm_logic_id != var_item.name:
+            node.make_local()
 
-        var_item = tree.arm_treevariableslist[tree.arm_treevariableslist_index]
         node.arm_logic_id = var_item.name
         node.use_custom_color = True
         node.color = var_item.color

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -35,19 +35,19 @@ class ARM_PT_Variables(bpy.types.Panel):
 
         tree: bpy.types.NodeTree = context.space_data.node_tree
 
-        num_prop_rows = max(len(tree.arm_treevariableslist), 6)
+        node = context.active_node
+        if node is None or node.arm_logic_id == '':
+            layout.operator('arm.variable_promote_node', icon='PLUS')
+        else:
+            layout.operator('arm.variable_node_make_local', icon='TRIA_DOWN_BAR')
+
         row = layout.row(align=True)
         col = row.column(align=True)
 
+        num_prop_rows = max(len(tree.arm_treevariableslist), 6)
         col.template_list('ARM_UL_TreeVarList', '', tree, 'arm_treevariableslist', tree, 'arm_treevariableslist_index', rows=num_prop_rows)
 
-        node = context.active_node
-        if node is not None and node.bl_idname.startswith('LN'):
-            if node.arm_logic_id == '':
-                col.operator('arm.variable_promote_node', icon='PLUS')
-            else:
-                col.operator('arm.variable_node_make_local', icon='TRIA_DOWN_BAR')
-            col.operator('arm.variable_assign_to_node', icon='NODE')
+        col.operator('arm.variable_assign_to_node', icon='NODE')
 
         if len(tree.arm_treevariableslist) > 0:
             selected_item = tree.arm_treevariableslist[tree.arm_treevariableslist_index]
@@ -168,7 +168,7 @@ class ARM_OT_TreeVariableVariableAssignToNode(bpy.types.Operator):
     bl_label = "Assign To Node"
     bl_description = (
             'Assign the selected tree variable to the active variable node. '
-            'The variable node must have the same type as the variable.'
+            'The variable node must have the same type as the variable'
     )
 
     @classmethod
@@ -230,7 +230,7 @@ class ARM_OT_TreeVariableListMoveItem(bpy.types.Operator):
 
 
 class ARM_OT_AddVarGetterNode(bpy.types.Operator):
-    """Add a node to get the value of this variable"""
+    """Add a node to get the value of the selected tree variable"""
     bl_idname = 'arm.add_var_node'
     bl_label = 'Add Getter'
     bl_options = {'GRAB_CURSOR', 'BLOCKING'}
@@ -278,7 +278,7 @@ class ARM_OT_AddVarGetterNode(bpy.types.Operator):
 
 
 class ARM_OT_AddVarSetterNode(bpy.types.Operator):
-    """Add a node to set the value of this variable"""
+    """Add a node to set the value of the selected tree variable"""
     bl_idname = 'arm.add_setvar_node'
     bl_label = 'Add Setter'
     bl_options = {'GRAB_CURSOR', 'BLOCKING'}

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -3,18 +3,18 @@ from bpy.props import *
 
 import arm.log
 import arm.make_state
+import arm.node_utils
 import arm.props_traits_props
 import arm.utils
 import arm.logicnode.arm_nodes
-import arm.logicnode.replacement
 
 if arm.is_reload(__name__):
     arm.log = arm.reload_module(arm.log)
     arm.make_state = arm.reload_module(arm.make_state)
+    arm.node_utils = arm.reload_module(arm.node_utils)
     arm.props_traits_props = arm.reload_module(arm.props_traits_props)
     arm.utils = arm.reload_module(arm.utils)
     arm.logicnode.arm_nodes = arm.reload_module(arm.logicnode.arm_nodes)
-    arm.logicnode.replacement = arm.reload_module(arm.logicnode.replacement)
 else:
     arm.enable_reload(__name__)
 
@@ -453,7 +453,7 @@ def node_compat_sdk2203():
                 for node in tv_nodes[logic_id]:
                     if node.bl_idname != var_type:
                         newnode = tree.nodes.new(var_type)
-                        arm.logicnode.replacement.copy_basic_node_props(from_node=node, to_node=newnode)
+                        arm.node_utils.copy_basic_node_props(from_node=node, to_node=newnode)
 
                         # Connect outputs as good as possible
                         for i in range(min(len(node.outputs), len(newnode.outputs))):

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -197,6 +197,10 @@ class ARM_OT_TreeVariableVariableAssignToNode(bpy.types.Operator):
         node: arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin = context.active_node
         tree: bpy.types.NodeTree = context.space_data.node_tree
 
+        # Make node local first to ensure the old tree variable (if
+        # linked) is notified that the node is no longer linked
+        node.make_local()
+
         var_item = tree.arm_treevariableslist[tree.arm_treevariableslist_index]
         node.arm_logic_id = var_item.name
         node.use_custom_color = True

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -75,8 +75,8 @@ class ARM_PT_Variables(bpy.types.Panel):
             master_node = arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.get_master_node(tree, selected_item.name)
             master_node.draw_content(context, box)
             for inp in master_node.inputs:
-                if hasattr(inp, 'default_value_raw'):
-                    box.prop(inp, 'default_value_raw', text=inp.name)
+                if hasattr(inp, 'draw'):
+                    inp.draw(context, box, master_node, inp.label if inp.label is not None else inp.name)
 
 
 class ARM_OT_TreeVariablePromoteNode(bpy.types.Operator):

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -1,0 +1,503 @@
+import bpy
+from bpy.props import *
+
+import arm.log
+import arm.make_state
+import arm.props_traits_props
+import arm.utils
+import arm.logicnode.arm_nodes
+import arm.logicnode.replacement
+
+if arm.is_reload(__name__):
+    arm.log = arm.reload_module(arm.log)
+    arm.make_state = arm.reload_module(arm.make_state)
+    arm.props_traits_props = arm.reload_module(arm.props_traits_props)
+    arm.utils = arm.reload_module(arm.utils)
+    arm.logicnode.arm_nodes = arm.reload_module(arm.logicnode.arm_nodes)
+    arm.logicnode.replacement = arm.reload_module(arm.logicnode.replacement)
+else:
+    arm.enable_reload(__name__)
+
+
+class ARM_PT_Variables(bpy.types.Panel):
+    bl_label = 'Tree Variables'
+    bl_idname = 'ARM_PT_Variables'
+    bl_space_type = 'NODE_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'Armory'
+
+    @classmethod
+    def poll(cls, context):
+        return context.space_data.tree_type == 'ArmLogicTreeType' and context.space_data.edit_tree
+
+    def draw(self, context):
+        layout = self.layout
+
+        tree: bpy.types.NodeTree = context.space_data.node_tree
+
+        num_prop_rows = max(len(tree.arm_treevariableslist), 6)
+        row = layout.row(align=True)
+        col = row.column(align=True)
+
+        col.template_list('ARM_UL_TreeVarList', '', tree, 'arm_treevariableslist', tree, 'arm_treevariableslist_index', rows=num_prop_rows)
+
+        node = context.active_node
+        if node is not None and node.bl_idname.startswith('LN'):
+            if node.arm_logic_id == '':
+                col.operator('arm.variable_promote_node', icon='PLUS')
+            else:
+                col.operator('arm.variable_node_make_local', icon='TRIA_DOWN_BAR')
+            col.operator('arm.variable_assign_to_node', icon='NODE')
+
+        if len(tree.arm_treevariableslist) > 0:
+            selected_item = tree.arm_treevariableslist[tree.arm_treevariableslist_index]
+
+            col.separator()
+            sub_row = col.row(align=True)
+            sub_row.alignment = 'EXPAND'
+            op = sub_row.operator('arm.add_var_node')
+            op.node_id = selected_item.name
+            op.node_type = selected_item.type
+            op = sub_row.operator('arm.add_setvar_node')
+            op.node_id = selected_item.name
+            op.node_type = selected_item.type
+
+        col = row.column(align=True)
+        col.enabled = len(tree.arm_treevariableslist) > 1
+        col.operator('arm_treevariableslist.move_item', icon='TRIA_UP', text='').direction = 'UP'
+        col.operator('arm_treevariableslist.move_item', icon='TRIA_DOWN', text='').direction = 'DOWN'
+
+        if len(tree.arm_treevariableslist) > 0:
+            selected_item = tree.arm_treevariableslist[tree.arm_treevariableslist_index]
+
+            layout.separator()
+            box = layout.box()
+            box.label(text="Selected Variable:")
+            master_node = arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.get_master_node(tree, selected_item.name)
+            master_node.draw_content(context, box)
+            for inp in master_node.inputs:
+                if hasattr(inp, 'default_value_raw'):
+                    box.prop(inp, 'default_value_raw', text=inp.name)
+
+
+class ARM_OT_TreeVariablePromoteNode(bpy.types.Operator):
+    bl_idname = 'arm.variable_promote_node'
+    bl_label = "New Var From Node"
+    bl_description = 'Create a tree variable from the active node and promote it to a tree variable node'
+
+    var_name: StringProperty(
+        name="Name",
+        description="Name of the new tree variable",
+        default="Untitled"
+    )
+
+    @classmethod
+    def poll(cls, context):
+        tree: bpy.types.NodeTree = context.space_data.node_tree
+        if tree is None:
+            return False
+
+        node = context.active_node
+        if node is None or not node.bl_idname.startswith('LN'):
+            return False
+
+        if not isinstance(node, arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin):
+            return False
+
+        return node.arm_logic_id == ''
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        return wm.invoke_props_dialog(self, width=400)
+
+    def execute(self, context):
+        node: arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin = context.active_node
+        tree: bpy.types.NodeTree = context.space_data.node_tree
+
+        var_type = node.bl_idname
+        var_item = ARM_PG_TreeVarListItem.create_new(tree, self.var_name, var_type)
+
+        node.is_master_node = True
+        node.arm_logic_id = var_item.name
+
+        arm.make_state.redraw_ui = True
+
+        return {'FINISHED'}
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        row.scale_y = 1.3
+        row.activate_init = True
+        row.prop(self, "var_name")
+
+
+class ARM_OT_TreeVariableMakeLocalNode(bpy.types.Operator):
+    bl_idname = 'arm.variable_node_make_local'
+    bl_label = "Make Node Local"
+    bl_description = (
+        'Remove the reference to the tree variable from the active node. '
+        'If the active node is the only node that links to the selected '
+        'tree variable, the tree variable is removed'
+    )
+
+    @classmethod
+    def poll(cls, context):
+        tree: bpy.types.NodeTree = context.space_data.node_tree
+        if tree is None:
+            return False
+
+        node = context.active_node
+        if node is None or not node.bl_idname.startswith('LN'):
+            return False
+
+        if not isinstance(node, arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin):
+            return False
+
+        return node.arm_logic_id != ''
+
+    def execute(self, context):
+        node: arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin = context.active_node
+        node.make_local()
+
+        return {'FINISHED'}
+
+
+class ARM_OT_TreeVariableVariableAssignToNode(bpy.types.Operator):
+    bl_idname = 'arm.variable_assign_to_node'
+    bl_label = "Assign To Node"
+    bl_description = (
+            'Assign the selected tree variable to the active variable node. '
+            'The variable node must have the same type as the variable.'
+    )
+
+    @classmethod
+    def poll(cls, context):
+        tree: bpy.types.NodeTree = context.space_data.node_tree
+        if tree is None or len(tree.arm_treevariableslist) == 0:
+            return False
+
+        node = context.active_node
+        if node is None or not node.bl_idname.startswith('LN'):
+            return False
+
+        if not isinstance(node, arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin):
+            return False
+
+        # Only assign variables to nodes of the correct type
+        if node.bl_idname != tree.arm_treevariableslist[tree.arm_treevariableslist_index].type:
+            return False
+
+        return True
+
+    def execute(self, context):
+        node: arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin = context.active_node
+        tree: bpy.types.NodeTree = context.space_data.node_tree
+        node.arm_logic_id = tree.arm_treevariableslist[tree.arm_treevariableslist_index].name
+
+        return {'FINISHED'}
+
+
+class ARM_OT_TreeVariableListMoveItem(bpy.types.Operator):
+    bl_idname = "arm_treevariableslist.move_item"
+    bl_label = "Move"
+    bl_description = "Move an item in the list"
+
+    direction: EnumProperty(
+        items=(
+            ('UP', 'Up', ""),
+            ('DOWN', 'Down', "")
+        )
+    )
+
+    def execute(self, context):
+        tree: bpy.types.NodeTree = context.space_data.node_tree
+        index = tree.arm_treevariableslist_index
+
+        max_index = len(tree.arm_treevariableslist) - 1
+        new_index = 0
+
+        if self.direction == 'UP':
+            new_index = index - 1
+        elif self.direction == 'DOWN':
+            new_index = index + 1
+        new_index = max(0, min(new_index, max_index))
+
+        tree.arm_treevariableslist.move(index, new_index)
+        tree.arm_treevariableslist_index = new_index
+
+        return{'FINISHED'}
+
+
+class ARM_OT_AddVarGetterNode(bpy.types.Operator):
+    """Add a node to get the value of this variable"""
+    bl_idname = 'arm.add_var_node'
+    bl_label = 'Add Getter'
+    bl_options = {'GRAB_CURSOR', 'BLOCKING'}
+
+    node_id: StringProperty()
+    node_type: StringProperty()
+    nodeRef = None
+
+    @classmethod
+    def poll(cls, context):
+        tree: bpy.types.NodeTree = context.space_data.node_tree
+        return tree is not None and len(tree.arm_treevariableslist) > 0
+
+    def invoke(self, context, event):
+        context.window_manager.modal_handler_add(self)
+        self.execute(context)
+        return {'RUNNING_MODAL'}
+
+    def modal(self, context, event):
+        if event.type == 'MOUSEMOVE':
+            self.nodeRef.location = context.space_data.cursor_location
+        elif event.type == 'LEFTMOUSE':  # Confirm
+            return {'FINISHED'}
+        return {'RUNNING_MODAL'}
+
+    def execute(self, context):
+        node = self.create_getter_node(context, self.node_type, self.node_id)
+
+        global nodeRef
+        self.nodeRef = node
+        return {'FINISHED'}
+
+    @staticmethod
+    def create_getter_node(context, node_type: str, node_id: str) -> arm.logicnode.arm_nodes.ArmLogicTreeNode:
+        nodes = context.space_data.node_tree.nodes
+
+        node = nodes.new(node_type)
+        node.location = context.space_data.cursor_location
+        node.arm_logic_id = node_id
+        node.label = "GET " + node_id
+        node.use_custom_color = True
+        node.color = (0.22, 0.89, 0.5)
+
+        return node
+
+
+class ARM_OT_AddVarSetterNode(bpy.types.Operator):
+    """Add a node to set the value of this variable"""
+    bl_idname = 'arm.add_setvar_node'
+    bl_label = 'Add Setter'
+    bl_options = {'GRAB_CURSOR', 'BLOCKING'}
+
+    node_id: StringProperty()
+    node_type: StringProperty()
+    nodeRef = None
+    setNodeRef = None
+
+    @classmethod
+    def poll(cls, context):
+        tree: bpy.types.NodeTree = context.space_data.node_tree
+        return tree is not None and len(tree.arm_treevariableslist) > 0
+
+    def invoke(self, context, event):
+        context.window_manager.modal_handler_add(self)
+        self.execute(context)
+        return {'RUNNING_MODAL'}
+
+    def modal(self, context, event):
+        if event.type == 'MOUSEMOVE':
+            self.setNodeRef.location = context.space_data.cursor_location
+            self.nodeRef.location[0] = context.space_data.cursor_location[0]+10
+            self.nodeRef.location[1] = context.space_data.cursor_location[1]-10
+        elif event.type == 'LEFTMOUSE':  # Confirm
+            return {'FINISHED'}
+        return {'RUNNING_MODAL'}
+
+    def execute(self, context):
+        nodes = context.space_data.node_tree.nodes
+
+        node = ARM_OT_AddVarGetterNode.create_getter_node(context, self.node_type, self.node_id)
+        node.bl_width_min = 3
+        node.width = 5
+        node.bl_width_min = 100
+
+        setter_node = nodes.new("LNSetVariableNode")
+        setter_node.label = "SET " + self.node_id
+        setter_node.location = context.space_data.cursor_location
+        setter_node.use_custom_color = True
+        setter_node.color = (0.49, 0.2, 1.0)
+        links = context.space_data.node_tree.links
+        links.new(node.outputs[0], setter_node.inputs[1])
+        global nodeRef
+        self.nodeRef = node
+        global setNodeRef
+        self.setNodeRef = setter_node
+        return {'FINISHED'}
+
+
+class ARM_PG_TreeVarListItem(bpy.types.PropertyGroup):
+    def _set_name(self, value: str):
+        old_name = self._get_name()
+
+        tree = bpy.context.space_data.node_tree
+        lst = tree.arm_treevariableslist
+
+        if value == '':
+            # Don't allow empty variable names
+            new_name = old_name
+        else:
+            new_name = arm.utils.unique_str_for_list(items=lst, name_attr='name', wanted_name=value, ignore_item=self)
+
+        self['_name'] = new_name
+
+        for node in tree.nodes:
+            if node.arm_logic_id == old_name:
+                node.arm_logic_id = new_name
+
+    def _get_name(self) -> str:
+        return self.get('_name', 'Untitled')
+
+    name: StringProperty(
+        name="Name",
+        description="The name of this variable",
+        default="Untitled",
+        get=_get_name,
+        set=_set_name
+    )
+
+    type: StringProperty(
+        name="Display Type",
+        description="The displayed type of this property",
+        default="Int"
+    )
+
+    @classmethod
+    def create_new(cls, tree: bpy.types.NodeTree, item_name: str, item_type: str) -> 'ARM_PG_TreeVarListItem':
+        lst = tree.arm_treevariableslist
+
+        var_item: ARM_PG_TreeVarListItem = lst.add()
+        var_item['_name'] = arm.utils.unique_str_for_list(
+            items=lst, name_attr='name', wanted_name=item_name, ignore_item=var_item
+        )
+        var_item.type = item_type
+
+        tree.arm_treevariableslist_index = len(lst) - 1
+        arm.make_state.redraw_ui = True
+
+        return var_item
+
+
+class ARM_UL_TreeVarList(bpy.types.UIList):
+    def draw_item(self, context, layout, data, item: ARM_PG_TreeVarListItem, icon, active_data, active_propname, index):
+        node_type = arm.utils.type_name_to_type(item.type).bl_label
+
+        row = layout.row()
+        row.prop(item, 'name', text='', emboss=False)
+        row.label(text=node_type)
+
+
+def on_update_node_logic_id(node: arm.logicnode.arm_nodes.ArmLogicTreeNode, context):
+    node.on_logic_id_change()
+
+
+def node_compat_sdk2203():
+    """Replace old arm_logic_id system with tree variable system."""
+    for tree in bpy.data.node_groups:
+        if tree.bl_idname == "ArmLogicTreeType":
+            # All tree variable nodes
+            tv_nodes: dict[str, list[arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin]] = {}
+
+            # The type of the tree variable. If two types are found for
+            # a logic ID and one is dynamic, assume it's a getter node.
+            # Otherwise show a warning upon conflict, it was undefined
+            # behaviour before anyway.
+            tv_types: dict[str, str] = {}
+
+            # First pass: find all tree variable nodes and decide the
+            # variable type in case of conflicts
+            node: arm.logicnode.arm_nodes.ArmLogicTreeNode
+            for node in list(tree.nodes):
+                if node.arm_logic_id != '':
+                    if not isinstance(node, arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin):
+                        arm.log.warn(
+                            'While updating the file to the current SDK'
+                            f' version, the node {node.name} in tree'
+                            f' {tree.name} is no variable node but had'
+                            ' a logic ID. The logic ID was reset to'
+                            ' prevent undefined behaviour.'
+                        )
+                        node.arm_logic_id = ''
+                        continue
+
+                    if node.arm_logic_id in tv_nodes:
+                        tv_nodes[node.arm_logic_id].append(node)
+
+                        # Check for getter nodes and type conflicts
+                        cur_type = tv_types[node.arm_logic_id]
+                        if cur_type == 'LNDynamicNode':
+                            tv_types[node.arm_logic_id] = node.bl_idname
+                        elif cur_type != node.bl_idname and node.bl_idname != 'LNDynamicNode':
+                            arm.log.warn(
+                                'Found nodes of different types with the'
+                                ' same logic ID while updating the file'
+                                ' to the current SDK version (undefined'
+                                ' behaviour).\n'
+                                f'\tConflicting types: {cur_type}, {node.bl_idname}\n'
+                                f'\tLogic ID: {node.arm_logic_id}\n'
+                                f'\tNew type for both nodes: {cur_type}'
+                            )
+                    else:
+                        tv_nodes[node.arm_logic_id] = [node]
+                        tv_types[node.arm_logic_id] = node.bl_idname
+
+            # Second pass: add the tree variable and convert all found
+            # tree var nodes to the correct type
+            for logic_id in tv_nodes.keys():
+                var_type = tv_types[logic_id]
+
+                ARM_PG_TreeVarListItem.create_new(tree, logic_id, var_type)
+
+                for node in tv_nodes[logic_id]:
+                    if node.bl_idname != var_type:
+                        newnode = tree.nodes.new(var_type)
+                        arm.logicnode.replacement.copy_basic_node_props(from_node=node, to_node=newnode)
+
+                        # Connect outputs as good as possible
+                        for i in range(min(len(node.outputs), len(newnode.outputs))):
+                            for out in node.outputs:
+                                for link in out.links:
+                                    tree.links.new(newnode.outputs[i], link.to_socket)
+
+                        tree.nodes.remove(node)
+                        node = newnode
+
+                    # Hide sockets
+                    node.on_logic_id_change()
+
+                arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.choose_new_master_node(tree, logic_id)
+
+
+REG_CLASSES = (
+    ARM_PT_Variables,
+    ARM_OT_TreeVariableListMoveItem,
+    ARM_OT_TreeVariableMakeLocalNode,
+    ARM_OT_TreeVariableVariableAssignToNode,
+    ARM_OT_TreeVariablePromoteNode,
+    ARM_OT_AddVarGetterNode,
+    ARM_OT_AddVarSetterNode,
+    ARM_UL_TreeVarList,
+    ARM_PG_TreeVarListItem,
+)
+register_classes, unregister_classes = bpy.utils.register_classes_factory(REG_CLASSES)
+
+
+def register():
+    register_classes()
+
+    bpy.types.Node.arm_logic_id = StringProperty(
+        name="ID",
+        description="Nodes with equal identifier share data",
+        default='',
+        update=on_update_node_logic_id
+    )
+
+    bpy.types.NodeTree.arm_treevariableslist = CollectionProperty(type=ARM_PG_TreeVarListItem)
+    bpy.types.NodeTree.arm_treevariableslist_index = IntProperty(name="Index for arm_variableslist", default=0)
+
+
+def unregister():
+    unregister_classes()

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -207,6 +207,8 @@ class ARM_OT_TreeVariableVariableAssignToNode(bpy.types.Operator):
         node.arm_logic_id = var_item.name
         node.use_custom_color = True
         node.color = var_item.color
+        master_node = arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.get_master_node(tree, node.arm_logic_id)
+        master_node._synchronize_to_replicas(master_node)
 
         return {'FINISHED'}
 

--- a/blender/arm/logicnode/variable/LN_boolean.py
+++ b/blender/arm/logicnode/variable/LN_boolean.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class BooleanNode(ArmLogicTreeNode):
+
+class BooleanNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given boolean as a variable. A boolean value has just two
     states: `true` and `false`."""
     bl_idname = 'LNBooleanNode'
@@ -11,3 +12,6 @@ class BooleanNode(ArmLogicTreeNode):
         self.add_input('ArmBoolSocket', 'Bool In')
 
         self.add_output('ArmBoolSocket', 'Bool Out', is_var=True)
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs[0].default_value_raw = master_node.inputs[0].get_default_value()

--- a/blender/arm/logicnode/variable/LN_color.py
+++ b/blender/arm/logicnode/variable/LN_color.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class ColorNode(ArmLogicTreeNode):
+
+class ColorNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given color as a variable."""
     bl_idname = 'LNColorNode'
     bl_label = 'Color'
@@ -10,3 +11,6 @@ class ColorNode(ArmLogicTreeNode):
         self.add_input('ArmColorSocket', 'Color In', default_value=[1.0, 1.0, 1.0, 1.0])
 
         self.add_output('ArmColorSocket', 'Color Out', is_var=True)
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs[0].default_value_raw = master_node.inputs[0].get_default_value()

--- a/blender/arm/logicnode/variable/LN_dynamic.py
+++ b/blender/arm/logicnode/variable/LN_dynamic.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class DynamicNode(ArmLogicTreeNode):
+
+class DynamicNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given dynamic value (a value with an arbitrary type) as a variable."""
     bl_idname = 'LNDynamicNode'
     bl_label = 'Dynamic'

--- a/blender/arm/logicnode/variable/LN_float.py
+++ b/blender/arm/logicnode/variable/LN_float.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class FloatNode(ArmLogicTreeNode):
+
+class FloatNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given float as a variable. If the set float value has more
     than 3 decimal places, the displayed value in the node will be
     rounded, but when you click on it you can still edit the exact
@@ -12,3 +13,7 @@ class FloatNode(ArmLogicTreeNode):
     def arm_init(self, context):
         self.add_input('ArmFloatSocket', 'Float In')
         self.add_output('ArmFloatSocket', 'Float Out', is_var=True)
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs[0].default_value_raw = master_node.inputs[0].get_default_value()
+

--- a/blender/arm/logicnode/variable/LN_integer.py
+++ b/blender/arm/logicnode/variable/LN_integer.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class IntegerNode(ArmLogicTreeNode):
+
+class IntegerNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given integer (a whole number) as a variable."""
     bl_idname = 'LNIntegerNode'
     bl_label = 'Integer'
@@ -9,3 +10,6 @@ class IntegerNode(ArmLogicTreeNode):
     def arm_init(self, context):
         self.add_input('ArmIntSocket', 'Int In')
         self.add_output('ArmIntSocket', 'Int Out', is_var=True)
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs[0].default_value_raw = master_node.inputs[0].get_default_value()

--- a/blender/arm/logicnode/variable/LN_mask.py
+++ b/blender/arm/logicnode/variable/LN_mask.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class MaskNode(ArmLogicTreeNode):
+
+class MaskNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """TO DO."""
     bl_idname = 'LNMaskNode'
     bl_label = 'Mask'
@@ -12,3 +13,7 @@ class MaskNode(ArmLogicTreeNode):
             self.inputs.new('ArmBoolSocket', label)
 
         self.add_output('ArmIntSocket', 'Mask', is_var=True)
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        for i in range(len(self.inputs)):
+            self.inputs[i].default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/logicnode/variable/LN_rotation.py
+++ b/blender/arm/logicnode/variable/LN_rotation.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class RotationNode(ArmLogicTreeNode):
+
+class RotationNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """A rotation, created from one of its possible mathematical representations"""
     bl_idname = 'LNRotationNode'
     bl_label = 'Rotation'
@@ -11,7 +12,7 @@ class RotationNode(ArmLogicTreeNode):
     def arm_init(self, context):
         self.add_input('ArmVectorSocket', 'Euler Angles / Vector XYZ')
         self.add_input('ArmFloatSocket', 'Angle / W')
-        
+
         self.add_output('ArmRotationSocket', 'Out', is_var=True)
 
     def on_property_update(self, context):
@@ -28,7 +29,7 @@ class RotationNode(ArmLogicTreeNode):
         else:
             raise ValueError('No nodesocket labels for current input mode: check self-consistancy of LN_rotation.py')
 
-    def draw_buttons(self, context, layout):
+    def draw_content(self, context, layout):
         coll = layout.column(align=True)
         coll.prop(self, 'property0')
         if self.property0 in ('EulerAngles','AxisAngle'):
@@ -59,3 +60,11 @@ class RotationNode(ArmLogicTreeNode):
                ('ZYX','ZYX','ZYX')],
         name='', default='XYZ'
     )
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.property0 = master_node.property0
+        self.property1 = master_node.property1
+        self.property2 = master_node.property2
+
+        for i in range(len(self.inputs)):
+            self.inputs[i].default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/logicnode/variable/LN_transform.py
+++ b/blender/arm/logicnode/variable/LN_transform.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class TransformNode(ArmLogicTreeNode):
+
+class TransformNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the location, rotation and scale values as a transform."""
     bl_idname = 'LNTransformNode'
     bl_label = 'Transform'
@@ -12,12 +13,23 @@ class TransformNode(ArmLogicTreeNode):
         self.add_input('ArmVectorSocket', 'Scale', default_value=[1.0, 1.0, 1.0])
         self.add_output('ArmDynamicSocket', 'Transform', is_var=True)
 
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        self.inputs[0].default_value_raw = master_node.inputs[0].get_default_value()
+        self.inputs[2].default_value_raw = master_node.inputs[2].get_default_value()
+
+        self.inputs[1].default_value_mode = master_node.inputs[1].default_value_mode
+        self.inputs[1].default_value_unit = master_node.inputs[1].default_value_unit
+        self.inputs[1].default_value_order = master_node.inputs[1].default_value_order
+        self.inputs[1].default_value_s0 = master_node.inputs[1].default_value_s0
+        self.inputs[1].default_value_s1 = master_node.inputs[1].default_value_s1
+        self.inputs[1].default_value_s2 = master_node.inputs[1].default_value_s2
+        self.inputs[1].default_value_s3 = master_node.inputs[1].default_value_s3
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
         if self.arm_version not in (0, 1):
             raise LookupError()
 
-        
+
         # transition from version 1 to version 2: make rotations their own sockets
         # this transition is a mess, I know.
         newself = self.id_data.nodes.new('LNTransformNode')

--- a/blender/arm/logicnode/variable/LN_vector.py
+++ b/blender/arm/logicnode/variable/LN_vector.py
@@ -1,6 +1,7 @@
 from arm.logicnode.arm_nodes import *
 
-class VectorNode(ArmLogicTreeNode):
+
+class VectorNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given 3D vector as a variable."""
     bl_idname = 'LNVectorNode'
     bl_label = 'Vector'
@@ -12,3 +13,7 @@ class VectorNode(ArmLogicTreeNode):
         self.add_input('ArmFloatSocket', 'Z')
 
         self.add_output('ArmVectorSocket', 'Vector', is_var=True)
+
+    def synchronize_from_master(self, master_node: ArmLogicVariableNodeMixin):
+        for i in range(len(self.inputs)):
+            self.inputs[i].default_value_raw = master_node.inputs[i].get_default_value()

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -203,3 +203,13 @@ def nodetype_to_nodeitem(node_type: Type[bpy.types.Node]) -> NodeItem:
         return NodeItem(node_type.__name__)
 
     return NodeItem(node_type.bl_idname)
+
+
+def copy_basic_node_props(from_node: bpy.types.Node, to_node: bpy.types.Node):
+    """Copy non-node-specific properties to a different node."""
+    to_node.parent = from_node.parent
+    to_node.location = from_node.location
+    to_node.select = from_node.select
+
+    to_node.arm_logic_id = from_node.arm_logic_id
+    to_node.arm_watch = from_node.arm_watch

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -5,6 +5,7 @@ import multiprocessing
 
 import arm.assets as assets
 import arm.logicnode.replacement
+import arm.logicnode.tree_variables
 import arm.make
 import arm.nodes_logic
 import arm.proxy
@@ -13,6 +14,7 @@ import arm.utils
 if arm.is_reload(__name__):
     assets = arm.reload_module(assets)
     arm.logicnode.replacement = arm.reload_module(arm.logicnode.replacement)
+    arm.logicnode.tree_variables = arm.reload_module(arm.logicnode.tree_variables)
     arm.make = arm.reload_module(arm.make)
     arm.nodes_logic = arm.reload_module(arm.nodes_logic)
     arm.proxy = arm.reload_module(arm.proxy)
@@ -486,7 +488,6 @@ def init_properties():
     bpy.types.Material.signature = StringProperty(name="Signature", description="Unique string generated from material nodes", default="")
     bpy.types.Material.arm_cached = BoolProperty(name="Material Cached", description="No need to reexport material data", default=False)
     bpy.types.Node.arm_material_param = BoolProperty(name="Parameter", description="Control this node from script", default=False)
-    bpy.types.Node.arm_logic_id = StringProperty(name="ID", description="Nodes with equal identifier will share data", default='')
     bpy.types.Node.arm_watch = BoolProperty(name="Watch", description="Watch value of this node in debug console", default=False)
     bpy.types.Node.arm_version = IntProperty(name="Node Version", description="The version of an instanced node", default=0)
     # Particles
@@ -525,10 +526,12 @@ def update_armory_world():
                 rp.rp_gi = 'Off'
                 rp.rp_voxelao = True
 
+        # For some breaking changes we need to use a special update
+        # routine first before regularly replacing nodes
         if file_version < (2021, 8):
-            # There were breaking changes in SDK 2021.08, use a special
-            # update routine first before regularly replacing nodes
             arm.logicnode.replacement.node_compat_sdk2108()
+        if file_version < (2022, 3):
+            arm.logicnode.tree_variables.node_compat_sdk2203()
 
         arm.logicnode.replacement.replace_all()
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -620,6 +620,49 @@ def to_hex(val):
 def color_to_int(val):
     return (int(val[3] * 255) << 24) + (int(val[0] * 255) << 16) + (int(val[1] * 255) << 8) + int(val[2] * 255)
 
+
+def unique_str_for_list(items: list, name_attr: str, wanted_name: str, ignore_item: Optional[Any] = None) -> str:
+    """Creates a unique name that no item in the given list already has.
+    The format follows Blender's behaviour when handling duplicate
+    object names.
+
+    @param items The list of items (any type).
+    @param name_attr The attribute of the items that holds the name.
+    @param wanted_name The name that should be preferably returned, if
+        no name collision occurs.
+    @param ignore_item (Optional) Ignore this item in the list when
+        comparing names.
+    """
+    def _has_collision(name: str) -> bool:
+        for item in items:
+            if item == ignore_item:
+                continue
+            if getattr(item, name_attr) == name:
+                return True
+        return False
+
+    # Check this once at the beginning to make sure the user can use
+    # a wanted name like "XY.001" if they want, even if "XY" alone does
+    # not collide
+    if not _has_collision(wanted_name):
+        return wanted_name
+
+    # Get base name without numeric suffix
+    base_name = wanted_name
+    dot_pos = base_name.rfind('.')
+    if dot_pos != -1:
+        if base_name[dot_pos + 1:].isdecimal():
+            base_name = base_name[:dot_pos]
+
+    num_collisions = 0
+    out_name = base_name
+    while _has_collision(out_name):
+        num_collisions += 1
+        out_name = f'{base_name}.{num_collisions:03d}'
+
+    return out_name
+
+
 def safesrc(s):
     s = safestr(s).replace('.', '_').replace('-', '_').replace(' ', '')
     if s[0].isdigit():

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -4,6 +4,7 @@ import json
 import locale
 import os
 import platform
+import random
 import re
 import shlex
 import subprocess
@@ -88,6 +89,11 @@ def convert_image(image, path, file_format='JPEG'):
     ren.image_settings.quality = orig_quality
     ren.image_settings.file_format = orig_file_format
     ren.image_settings.color_mode = orig_color_mode
+
+
+def get_random_color_rgb() -> list[float]:
+    """Return a random RGB color with values in range [0, 1]."""
+    return [random.random(), random.random(), random.random()]
 
 
 def is_livepatch_enabled():


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2434.

What started as an attempt to fix a simple issue became an almost complete rewrite of the logic ID system. Previously it was easily possible to create a few different situations where the correctness of the exported logic tree was completely violated or at least depending on external things such as iteration orders when exporting nodes:
- if multiple variable nodes shared the same values, only one random node was exported, so the initial value was undefined if the nodes had different values.
- it was possible to use the same logic ID for nodes with different types. Because all linked nodes were replaced with the exported node of another type, this could lead to runtime exceptions/type errors in other places of the tree.
- the above also happened with the dynamic getter/setter nodes, which caused the linked issue.

![New Tree Variables panel](https://user-images.githubusercontent.com/17685000/155016107-c6e70620-5f84-4b79-8bbc-05196be0ba89.png)

Now, the logic ID is no longer directly accessible, instead the user has to promote variable nodes to tree variable nodes to let them share data. So if a variable node is linked to a tree variable, it shares its values with all other variable nodes that are linked to the same tree variable. A variable node does not have to be linked to a tree variable, in this case it acts for its own, just as before if the logic ID was unset.

**In one sentence: if the variable node has no logic ID, all stays as it was before. If it has one set, the logic ID acts as a reference for a _tree_ variable.**

Files that are saved before SDK 2022.03 will be automatically upgraded to the new system (assuming that the version number of the SDK in the code will be bumped for the release), apart from the fact that the initial value may be affected by said race conditions.

## Technical explanation of the new system:
 A tree variable stores the type of the variable node to ensure correctness, and it uses one linked node (internally called the "master node") to actually store the variable values. This node is also used to show the variable values in the UI in the side panel, and the master node automatically synchronizes its values with all other nodes that are linked to the same variable (called "replica nodes" in the code). The user doesn't need to know about this concept, it is all done in the background and it even works to copy tree variable nodes between trees, there is always only one master node for each tree var, and for each variable node with a logic ID in the tree there will be a tree variable automatically. If there is no linked node left for a tree variable, the tree variable is removed.

In case this short paragraph is too briefly explained, there is a more detailed explanation in arm_nodes.py :)

## User perspective:
The following operators are relevant for the user:
- **New Var From Node**: creates a new tree variable for the selected variable node. This operator is not visible in the screenshot above, as it shares its position based on the selected node with the next operator, namely...
- ...**Make Node Local**: unlinks the selected variable node from the selected tree variable. If the selected node was the last to link to the tree variable, the tree variable is removed.
- **Assign To Node**: link the selected variable node to the selected tree variable.
- **Add Getter**/**Add Setter**: as before, just that the getter/setter nodes are no longer dynamic but typed the same as the variable.

The tree variables have a color that is automatically synchronized with their linked nodes, and the name of the tree variable is shown in the node's body and header instead of the input sockets and other settings (which are now only editable in the sidebar if the node is linked, because the master node needs to be edited):

![Linked tree variable node](https://user-images.githubusercontent.com/17685000/155018230-7a8166de-d271-4a44-8d2b-d5cb9d829f56.png)

The name of a tree variable can be edited by double clicking on it in the sidebar list.

Thanks a lot to @QuantumCoderQC for the helpful discussions and ideas on Discord!