### PR TITLE
Full support for arbitrary spotlight scales

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -475,8 +475,8 @@ void main() {
 			#endif
 			#ifdef _Spot
 			, lightsArray[li * 3 + 2].y != 0.0
-			, lightsArray[li * 3 + 2].y // cutoff
-			, lightsArraySpot[li * 2].w // exponent
+			, lightsArray[li * 3 + 2].y // spot size (cutoff)
+			, lightsArraySpot[li * 2].w // spot blend (exponent)
 			, lightsArraySpot[li * 2].xyz // spotDir
 			, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w) // scale
 			, lightsArraySpot[li * 2 + 1].xyz // right

--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -98,7 +98,7 @@ uniform vec3 eyeLook;
 #ifdef _Clusters
 uniform vec4 lightsArray[maxLights * 3];
 	#ifdef _Spot
-	uniform vec4 lightsArraySpot[maxLights];
+	uniform vec4 lightsArraySpot[maxLights * 2];
 	#endif
 uniform sampler2D clustersData;
 uniform vec2 cameraPlane;
@@ -170,7 +170,8 @@ uniform vec3 pointCol;
 	#endif
 	#ifdef _Spot
 	uniform vec3 spotDir;
-	uniform vec2 spotData;
+	uniform vec3 spotRight;
+	uniform vec4 spotData;
 	#endif
 #endif
 
@@ -418,7 +419,7 @@ void main() {
 			, 0, pointBias, true
 		#endif
 		#ifdef _Spot
-		, true, spotData.x, spotData.y, spotDir
+		, true, spotData.x, spotData.y, spotDir, spotData.zw, spotRight
 		#endif
 		#ifdef _VoxelAOvar
 		#ifdef _VoxelShadow
@@ -475,8 +476,10 @@ void main() {
 			#ifdef _Spot
 			, lightsArray[li * 3 + 2].y != 0.0
 			, lightsArray[li * 3 + 2].y // cutoff
-			, lightsArraySpot[li].w // cutoff - exponent
-			, lightsArraySpot[li].xyz // spotDir
+			, lightsArraySpot[li * 2].w // exponent
+			, lightsArraySpot[li * 2].xyz // spotDir
+			, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w) // scale
+			, lightsArraySpot[li * 2 + 1].xyz // right
 			#endif
 			#ifdef _MicroShadowing
 			, occspec.x

--- a/Shaders/deferred_light/deferred_light.json
+++ b/Shaders/deferred_light/deferred_light.json
@@ -199,6 +199,11 @@
 					"ifdef": ["_SinglePoint", "_Spot"]
 				},
 				{
+					"name": "spotRight",
+					"link": "_spotRight",
+					"ifdef": ["_SinglePoint", "_Spot"]
+				},
+				{
 					"name": "LWVPSpotArray",
 					"link": "_biasLightWorldViewProjectionMatrixSpotArray",
 					"ifdef": ["_Clusters", "_ShadowMap", "_Spot"]

--- a/Shaders/deferred_light_mobile/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_mobile/deferred_light.frag.glsl
@@ -271,8 +271,8 @@ void main() {
 			#endif
 			#ifdef _Spot
 			, lightsArray[li * 3 + 2].y != 0.0
-			, lightsArray[li * 3 + 2].y // cutoff
-			, lightsArraySpot[li].w // exponent
+			, lightsArray[li * 3 + 2].y // spot size (cutoff)
+			, lightsArraySpot[li].w // spot blend (exponent)
 			, lightsArraySpot[li].xyz // spotDir
 			, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w) // scale
 			, lightsArraySpot[li * 2 + 1].xyz // right

--- a/Shaders/deferred_light_mobile/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_mobile/deferred_light.frag.glsl
@@ -39,7 +39,7 @@ uniform vec3 eyeLook;
 #ifdef _Clusters
 uniform vec4 lightsArray[maxLights * 3];
 	#ifdef _Spot
-	uniform vec4 lightsArraySpot[maxLights];
+	uniform vec4 lightsArraySpot[maxLights * 2];
 	#endif
 uniform sampler2D clustersData;
 uniform vec2 cameraPlane;
@@ -109,7 +109,8 @@ uniform vec3 pointCol;
 uniform float pointBias;
 	#ifdef _Spot
 	uniform vec3 spotDir;
-	uniform vec2 spotData;
+	uniform vec3 spotRight;
+	uniform vec4 spotData;
 	#endif
 #endif
 
@@ -232,7 +233,7 @@ void main() {
 			, 0, pointBias, true
 		#endif
 		#ifdef _Spot
-		, true, spotData.x, spotData.y, spotDir
+		, true, spotData.x, spotData.y, spotDir, spotData.zw, spotRight  // TODO: Test!
 		#endif
 	);
 #endif
@@ -271,8 +272,10 @@ void main() {
 			#ifdef _Spot
 			, lightsArray[li * 3 + 2].y != 0.0
 			, lightsArray[li * 3 + 2].y // cutoff
-			, lightsArraySpot[li].w // cutoff - exponent
+			, lightsArraySpot[li].w // exponent
 			, lightsArraySpot[li].xyz // spotDir
+			, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w) // scale
+			, lightsArraySpot[li * 2 + 1].xyz // right
 			#endif
 		);
 	}

--- a/Shaders/deferred_light_mobile/deferred_light_mobile.json
+++ b/Shaders/deferred_light_mobile/deferred_light_mobile.json
@@ -143,6 +143,11 @@
 					"ifdef": ["_SinglePoint", "_Spot"]
 				},
 				{
+					"name": "spotRight",
+					"link": "_spotRight",
+					"ifdef": ["_SinglePoint", "_Spot"]
+				},
+				{
 					"name": "LWVPSpotArray",
 					"link": "_biasLightWorldViewProjectionMatrixSpotArray",
 					"ifdef": ["_Clusters", "_ShadowMap", "_Spot"]

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -87,7 +87,7 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 		, int index, float bias, bool receiveShadow
 	#endif
 	#ifdef _Spot
-		, bool isSpot, float spotA, float spotB, vec3 spotDir, vec2 scale, vec3 right
+		, bool isSpot, float spotSize, float spotBlend, vec3 spotDir, vec2 scale, vec3 right
 	#endif
 	#ifdef _VoxelAOvar
 	#ifdef _VoxelShadow
@@ -174,7 +174,7 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 
 	#ifdef _Spot
 	if (isSpot) {
-		direct *= spotlightMask(l, spotDir, right, scale, spotA, spotB);
+		direct *= spotlightMask(l, spotDir, right, scale, spotSize, spotBlend);
 
 		#ifdef _ShadowMap
 			if (receiveShadow) {

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -19,6 +19,9 @@
 #ifdef _SSRS
 #include "std/ssrs.glsl"
 #endif
+#ifdef _Spot
+#include "std/light_common.glsl"
+#endif
 
 #ifdef _ShadowMap
 	#ifdef _SinglePoint
@@ -84,7 +87,7 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 		, int index, float bias, bool receiveShadow
 	#endif
 	#ifdef _Spot
-		, bool isSpot, float spotA, float spotB, vec3 spotDir
+		, bool isSpot, float spotA, float spotB, vec3 spotDir, vec2 scale, vec3 right
 	#endif
 	#ifdef _VoxelAOvar
 	#ifdef _VoxelShadow
@@ -171,11 +174,8 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 
 	#ifdef _Spot
 	if (isSpot) {
-		float spotEffect = dot(spotDir, l); // lightDir
-		// x - cutoff, y - cutoff - exponent
-		if (spotEffect < spotA) {
-			direct *= smoothstep(spotB, spotA, spotEffect);
-		}
+		direct *= spotlightMask(l, spotDir, right, scale, spotA, spotB);
+
 		#ifdef _ShadowMap
 			if (receiveShadow) {
 				#ifdef _SinglePoint

--- a/Shaders/std/light_common.glsl
+++ b/Shaders/std/light_common.glsl
@@ -1,0 +1,31 @@
+#ifndef _LIGHT_COMMON_GLSL_
+#define _LIGHT_COMMON_GLSL_
+
+#ifdef _Spot
+float spotlightMask(const vec3 dir, const vec3 spotDir, const vec3 right, const vec2 scale, const float spotSize, const float spotBlend) {
+	// Project the fragment's light dir to the z axis in the light's local space
+	float localZ = dot(spotDir, dir);
+
+	if (localZ < 0) {
+		return 0.0; // Discard opposite cone
+	}
+
+	vec3 up = cross(spotDir, right);
+
+	// Scale the incoming light direction to treat the spotlight's ellipse as if
+	// it was 1 unit away from the light source, this way the smoothstep below
+	// works independently of the distance
+	vec3 scaledDir = dir.xyz / localZ;
+
+	// Project to right and up vectors to apply axis scale
+	float localX = dot(scaledDir, right) / scale.x;
+	float localY = dot(scaledDir, up) / scale.y;
+
+	// Inverse of length of vector from ellipse to light (scaledDir.z == 1.0)
+	float ellipse = inversesqrt(localX * localX + localY * localY + 1.0);
+
+	return smoothstep(0.0, 1.0, (ellipse - spotSize) / spotBlend);
+}
+#endif // _Spot
+
+#endif // _LIGHT_COMMON_GLSL_

--- a/Shaders/std/light_mobile.glsl
+++ b/Shaders/std/light_mobile.glsl
@@ -51,7 +51,7 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 		, int index, float bias, bool receiveShadow
 	#endif
 	#ifdef _Spot
-		, bool isSpot, float spotA, float spotB, vec3 spotDir, vec2 scale, vec3 right
+		, bool isSpot, float spotSize, float spotBlend, vec3 spotDir, vec2 scale, vec3 right
 	#endif
 	) {
 	vec3 ld = lp - p;
@@ -69,7 +69,7 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 
 	#ifdef _Spot
 	if (isSpot) {
-		direct *= spotlightMask(l, spotDir, right, scale, spotA, spotB);
+		direct *= spotlightMask(l, spotDir, right, scale, spotSize, spotBlend);
 
 		#ifdef _ShadowMap
 			if (receiveShadow) {

--- a/Shaders/std/light_mobile.glsl
+++ b/Shaders/std/light_mobile.glsl
@@ -6,6 +6,9 @@
 #ifdef _ShadowMap
 #include "std/shadows.glsl"
 #endif
+#ifdef _Spot
+#include "std/light_common.glsl"
+#endif
 
 #ifdef _ShadowMap
 	#ifdef _SinglePoint
@@ -48,7 +51,7 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 		, int index, float bias, bool receiveShadow
 	#endif
 	#ifdef _Spot
-		, bool isSpot, float spotA, float spotB, vec3 spotDir
+		, bool isSpot, float spotA, float spotB, vec3 spotDir, vec2 scale, vec3 right
 	#endif
 	) {
 	vec3 ld = lp - p;
@@ -66,11 +69,8 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 
 	#ifdef _Spot
 	if (isSpot) {
-		float spotEffect = dot(spotDir, l); // lightDir
-		// x - cutoff, y - cutoff - exponent
-		if (spotEffect < spotA) {
-			direct *= smoothstep(spotB, spotA, spotEffect);
-		}
+		direct *= spotlightMask(l, spotDir, right, scale, spotA, spotB);
+
 		#ifdef _ShadowMap
 			if (receiveShadow) {
 				#ifdef _SinglePoint

--- a/Shaders/volumetric_light/volumetric_light.json
+++ b/Shaders/volumetric_light/volumetric_light.json
@@ -108,6 +108,11 @@
 					"ifdef": ["_SinglePoint", "_Spot"]
 				},
 				{
+					"name": "spotRight",
+					"link": "_spotRight",
+					"ifdef": ["_SinglePoint", "_Spot"]
+				},
+				{
 					"name": "LWVPSpotArray",
 					"link": "_biasLightWorldViewProjectionMatrixSpotArray",
 					"ifdef": ["_Clusters", "_ShadowMap", "_Spot"]

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -66,8 +66,8 @@ def write(vert, frag):
         frag.write('\t, li, lightsArray[li * 3 + 2].x, lightsArray[li * 3 + 2].z != 0.0') # bias
     if '_Spot' in wrd.world_defs:
         frag.write('\t, lightsArray[li * 3 + 2].y != 0.0')
-        frag.write('\t, lightsArray[li * 3 + 2].y') # cutoff
-        frag.write('\t, lightsArraySpot[li].w') # exponent
+        frag.write('\t, lightsArray[li * 3 + 2].y') # spot size (cutoff)
+        frag.write('\t, lightsArraySpot[li].w') # spot blend (exponent)
         frag.write('\t, lightsArraySpot[li].xyz') # spotDir
         frag.write('\t, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w)') # scale
         frag.write('\t, lightsArraySpot[li * 2 + 1].xyz') # right

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -34,7 +34,7 @@ def write(vert, frag):
     frag.write('#endif')
 
     if '_Spot' in wrd.world_defs:
-        frag.add_uniform('vec4 lightsArraySpot[maxLights]', link='_lightsArraySpot')
+        frag.add_uniform('vec4 lightsArraySpot[maxLights * 2]', link='_lightsArraySpot')
         frag.write('int numSpots = int(texelFetch(clustersData, ivec2(clusterI, 1 + maxLightsCluster), 0).r * 255);')
         frag.write('int numPoints = numLights - numSpots;')
         if is_shadows:
@@ -67,8 +67,10 @@ def write(vert, frag):
     if '_Spot' in wrd.world_defs:
         frag.write('\t, lightsArray[li * 3 + 2].y != 0.0')
         frag.write('\t, lightsArray[li * 3 + 2].y') # cutoff
-        frag.write('\t, lightsArraySpot[li].w') # cutoff - exponent
+        frag.write('\t, lightsArraySpot[li].w') # exponent
         frag.write('\t, lightsArraySpot[li].xyz') # spotDir
+        frag.write('\t, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w)') # scale
+        frag.write('\t, lightsArraySpot[li * 2 + 1].xyz') # right
     if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:
         frag.write('  , voxels, voxpos')
     frag.write(');')

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -384,7 +384,8 @@ def make_forward_mobile(con_mesh):
         frag.add_uniform('vec3 pointCol', '_pointColor')
         if '_Spot' in wrd.world_defs:
             frag.add_uniform('vec3 spotDir', link='_spotDirection')
-            frag.add_uniform('vec2 spotData', link='_spotData')
+            frag.add_uniform('vec3 spotRight', link='_spotRight')
+            frag.add_uniform('vec4 spotData', link='_spotData')
         frag.write('float visibility = 1.0;')
         frag.write('vec3 ld = pointPos - wposition;')
         frag.write('vec3 l = normalize(ld);')
@@ -693,7 +694,8 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
         frag.add_uniform('vec3 pointCol', link='_pointColor')
         if '_Spot' in wrd.world_defs:
             frag.add_uniform('vec3 spotDir', link='_spotDirection')
-            frag.add_uniform('vec2 spotData', link='_spotData')
+            frag.add_uniform('vec3 spotRight', link='_spotRight')
+            frag.add_uniform('vec4 spotData', link='_spotData')
         if is_shadows:
             frag.add_uniform('bool receiveShadow')
             frag.add_uniform('float pointBias', link='_pointShadowsBias')
@@ -709,7 +711,7 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
         if is_shadows:
             frag.write('  , 0, pointBias, receiveShadow')
         if '_Spot' in wrd.world_defs:
-            frag.write('  , true, spotData.x, spotData.y, spotDir')
+            frag.write('  , true, spotData.x, spotData.y, spotDir, spotData.zw, spotRight')
         if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:
             frag.write('  , voxels, voxpos')
         frag.write(');')


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2145 and requires https://github.com/armory3d/iron/pull/155.

Previously the code expected spotlights to be scaled to 1,1,1 and if this wasn't the case, it could happen that spot lights weren't rendered (because each fragment was treated as being outside of the light cone).

Now Armory supports arbitrary spotlight scales, so it is now possible for example to create an elliptic spotlight by scaling it on one axis. The output shape is exactly the same as in Eevee. Unfortunately we need slightly more data on the GPU now (up to 4 more floats per spotlight depending on the shader), but I think that's acceptable.

I put the spotlight glsl code in a new module because it is also used in mobile deferred where including light.glsl would lead to a redefinition of uniforms.