### PR TITLE
Fix redefinition in volumetric light shader when using both sun and single spot light

### DIFF
--- a/Shaders/volumetric_light/volumetric_light.frag.glsl
+++ b/Shaders/volumetric_light/volumetric_light.frag.glsl
@@ -100,12 +100,13 @@ void rayStep(inout vec3 curPos, inout float curOpticalDepth, inout float scatter
 	curOpticalDepth *= exp(-tExt * stepLenWorld * density);
 
 	float visibility = 0.0;
+	vec4 lPos;
 
 #ifdef _Sun
 	#ifdef _CSM
 	mat4 LWVP = mat4(casData[4], casData[4 + 1], casData[4 + 2], casData[4 + 3]);
 	#endif
-	vec4 lPos = LWVP * vec4(curPos, 1.0);
+	lPos = LWVP * vec4(curPos, 1.0);
 	lPos.xyz /= lPos.w;
 	visibility = texture(
 		#ifdef _ShadowMapAtlas
@@ -122,7 +123,7 @@ void rayStep(inout vec3 curPos, inout float curOpticalDepth, inout float scatter
 
 #ifdef _SinglePoint
 	#ifdef _Spot
-	vec4 lPos = LWVPSpot[0] * vec4(curPos, 1.0);
+	lPos = LWVPSpot[0] * vec4(curPos, 1.0);
 	visibility = shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, pointBias);
 	visibility *= spotlightMask(normalize(pointPos - curPos), spotDir, spotRight, spotData.zw, spotData.x, spotData.y);
 	#else


### PR DESCRIPTION
Fixes the first error mentioned in https://github.com/armory3d/armory/issues/1480, the other two errors seem to have been fixed already by https://github.com/armory3d/armory/pull/1945. I'm assuming the shader compiler is clever enough to remove unused variables in case neither `_Sun` nor `_SinglePoint` are defined :)

---

@luboslenco out of interest (because I'm trying to fix another lighting issue), what is the reason for supporting `ifdef` and `ifndef` for links in the accompanying .json files for shaders when the links are only resolved when the uniform is used in the shaders anyway (see [blender/arm/lib/make_datas.py](https://github.com/armory3d/armory/blob/fe19efe56a3831df43a9392d9c301c6ef8dc60ae/blender/arm/lib/make_datas.py#L82))? It looks like the links are checked twice this way, but I probably miss something important here.

The issue itself is more or less unrelated to this, some uniforms aren't correctly linked because I guess [this syntax](https://github.com/armory3d/armory/blob/fe19efe56a3831df43a9392d9c301c6ef8dc60ae/Shaders/deferred_light/deferred_light.json#L216-L239) for linking individual array elements isn't supposed to work at all. I have no idea how to fix this yet, I'll probably split the array into individual uniforms which is how it was before the shadow atlas PR.