### PR TITLE
Various export fixes for subsurface scattering

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2009,7 +2009,7 @@ Make sure the mesh only has tris/quads.""")
         overlays_used = False
         blending_used = False
         decals_used = False
-        # sss_used = False
+        sss_used = False
 
         for material in self.material_array:
             # If the material is unlinked, material becomes None
@@ -2044,7 +2044,8 @@ Make sure the mesh only has tris/quads.""")
 
             mat_users = self.material_to_object_dict
             mat_armusers = self.material_to_arm_object_dict
-            sd, rpasses = make_material.parse(material, o, mat_users, mat_armusers)
+            sd, rpasses, needs_sss = make_material.parse(material, o, mat_users, mat_armusers)
+            sss_used |= needs_sss
 
             # Attach MovieTexture
             for con in o['contexts']:
@@ -2102,7 +2103,7 @@ Make sure the mesh only has tris/quads.""")
             self.output['material_datas'].append(o)
             material.arm_cached = True
 
-        # Auto-enable render-path featues
+        # Auto-enable render-path features
         rebuild_rp = False
         rpdat = arm.utils.get_rp()
         if rpdat.rp_translucency_state == 'Auto' and rpdat.rp_translucency != transluc_used:
@@ -2117,9 +2118,9 @@ Make sure the mesh only has tris/quads.""")
         if rpdat.rp_decals_state == 'Auto' and rpdat.rp_decals != decals_used:
             rpdat.rp_decals = decals_used
             rebuild_rp = True
-        # if rpdat.rp_sss_state == 'Auto' and rpdat.rp_sss != sss_used:
-            # rpdat.rp_sss = sss_used
-            # rebuild_rp = True
+        if rpdat.rp_sss_state == 'Auto' and rpdat.rp_sss != sss_used:
+            rpdat.rp_sss = sss_used
+            rebuild_rp = True
         if rebuild_rp:
             make_renderpath.build()
 

--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -34,6 +34,11 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
 
+    needs_sss = material_needs_sss(material)
+    if needs_sss and rpdat.rp_sss_state != 'Off' and '_SSS' not in wrd.world_defs:
+        # Must be set before calling make_shader.build()
+        wrd.world_defs += '_SSS'
+
     # No batch - shader data per material
     if material.arm_custom_material != '':
         rpasses = ['mesh']
@@ -79,7 +84,7 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
 
             elif rpdat.rp_sss_state != 'Off':
                 const = {'name': 'materialID'}
-                if material_needs_sss(material):
+                if needs_sss:
                     const['int'] = 2
                     sss_used = True
                 else:

--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -30,7 +30,7 @@ def glsl_value(val):
         return val
 
 
-def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]], mat_armusers):
+def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]], mat_armusers) -> tuple:
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
 
@@ -57,6 +57,8 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
         rpasses, shader_data, shader_data_name, bind_constants, bind_textures = mat_batch.get(material)
         sd = shader_data.sd
 
+    sss_used = False
+
     # Material
     for rp in rpasses:
         c = {
@@ -75,7 +77,7 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
                 if material.arm_material_id == 2:
                     wrd.world_defs += '_Hair'
 
-            elif rpdat.rp_sss_state == 'On':
+            elif rpdat.rp_sss_state != 'Off':
                 sss = False
                 sss_node = arm.node_utils.get_node_by_type(material.node_tree, 'SUBSURFACE_SCATTERING')
                 if sss_node is not None and sss_node.outputs[0].is_linked: # Check linked node
@@ -90,6 +92,7 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
                 const = {'name': 'materialID'}
                 if sss:
                     const['int'] = 2
+                    sss_used = True
                 else:
                     const['int'] = 0
                 c['bind_constants'].append(const)
@@ -125,4 +128,4 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
         ext = '' if wrd.arm_minimize and material.arm_custom_material == "" else '.json'
         mat_data['shader'] = shader_data_name + ext + '/' + shader_data_name
 
-    return sd, rpasses
+    return sd, rpasses, sss_used

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -35,15 +35,30 @@ def find_link(node_group, to_node, inp):
         if link.to_node == to_node and link.to_socket == inp:
             return link
 
-def get_node_by_type(node_group, ntype):
+
+def get_node_by_type(node_group: bpy.types.NodeTree, ntype: str) -> bpy.types.Node:
     for node in node_group.nodes:
         if node.type == ntype:
             return node
 
-def get_node_armorypbr(node_group):
+
+def iter_nodes_by_type(node_group: bpy.types.NodeTree, ntype: str) -> Generator[bpy.types.Node, None, None]:
+    for node in node_group.nodes:
+        if node.type == ntype:
+            yield node
+
+
+def get_node_armorypbr(node_group: bpy.types.NodeTree) -> bpy.types.Node:
     for node in node_group.nodes:
         if node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR'):
             return node
+
+
+def iter_nodes_armorypbr(node_group: bpy.types.NodeTree) -> Generator[bpy.types.Node, None, None]:
+    for node in node_group.nodes:
+        if node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR'):
+            yield node
+
 
 def get_input_node(node_group, to_node, input_index):
     for link in node_group.links:

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -712,10 +712,8 @@ const float voxelgiOffset = """ + str(round(rpdat.arm_voxelgi_offset * 100) / 10
 const float voxelgiAperture = """ + str(round(rpdat.arm_voxelgi_aperture * 100) / 100) + """;
 """)
 
-        if rpdat.rp_sss_state == 'On':
-            f.write(
-"""const float sssWidth = """ + str(rpdat.arm_sss_width / 10.0) + """;
-""")
+        if rpdat.rp_sss:
+            f.write(f"const float sssWidth = {rpdat.arm_sss_width / 10.0};\n")
 
         # Skinning
         if rpdat.arm_skin == 'On':


### PR DESCRIPTION
- The "Auto" option for SSS could lead to a missing `sssWidth` variable in the shader which is one of the issue mentioned here: https://github.com/armory3d/armory/issues/2136
- If multiple SSS nodes were present in a material but the first to be parsed was not used, the shader didn't use SSS. It's still far away from Blender's subsurface scattering, but it's a bit more reliable now.
- When compiling with SSS disabled and then setting it to "Auto" without clearing the cache, it could happen that the generated materials didn't activate SSS because the `_SSS` flag wasn't set. I'm not completely happy with the solution, but I'm not yet confident enough with the material exporter code to be able to refactor the code in a way that prevents the dependency/order issues that can happen. It might be a good idea to first check all the requirements of a material, store them temporary with the material and only then create the shaders.

@luboslenco Do you remember why the material ID is handled via a uniform whose value is defined during export (see [this](https://github.com/armory3d/armory/blob/8e91e5e84c15ed4d9ddc16f85a2bb00178ba0f91/blender/arm/material/make_mesh.py#L243-L251) and [this](https://github.com/armory3d/armory/blob/8e91e5e84c15ed4d9ddc16f85a2bb00178ba0f91/blender/arm/material/make.py#L90-L95))? Is it for context variants or to be able to merge similar shaders for less context switches?