### PR TITLE
Follow reroutes for group nodes and update call group node upon changes

### DIFF
--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -122,6 +122,11 @@ class ArmLogicTreeNode(bpy.types.Node):
             self.on_socket_state_change()
             last_node_state[self_id] = current_state
 
+        # Notify sockets
+        for socket in itertools.chain(self.inputs, self.outputs):
+            if isinstance(socket, ArmCustomSocket):
+                socket.on_node_update()
+
     def free(self):
         """Called before the node is deleted."""
         arm.live_patch.send_event('ln_delete', self)

--- a/blender/arm/logicnode/miscellaneous/LN_call_group.py
+++ b/blender/arm/logicnode/miscellaneous/LN_call_group.py
@@ -17,15 +17,17 @@ class CallGroupNode(ArmLogicTreeNode):
 
     def update_inputs(self, node, context):
         for output in node.outputs:
-            if output.is_linked:
-                self.add_input(output.links[0].to_socket.bl_idname, output.links[0].to_socket.name)
+            _, c_socket = arm.node_utils.output_get_connected_node(output)
+            if c_socket is not None:
+                self.add_input(c_socket.bl_idname, c_socket.name)
             else:
                 self.add_input('ArmAnySocket', '')
 
     def update_outputs(self, node, context):
         for input in node.inputs:
-            if input.is_linked:
-                self.add_output(input.links[0].from_socket.bl_idname, input.links[0].from_socket.name)
+            _, c_socket = arm.node_utils.input_get_connected_node(input)
+            if c_socket is not None:
+                self.add_output(c_socket.bl_idname, c_socket.name)
             else:
                 self.add_output('ArmAnySocket', '')
 
@@ -51,3 +53,14 @@ class CallGroupNode(ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop_search(self, 'property0_', bpy.data, 'node_groups', icon='NONE', text='')
+
+    @classmethod
+    def update_all(cls):
+        """Called by group input and group output nodes when all call
+        node inputs should update their sockets.
+        """
+        for tree in bpy.data.node_groups:
+            if tree.bl_idname == "ArmLogicTreeType":
+                for node in tree.nodes:
+                    if isinstance(node, cls):
+                        node.update_sockets(bpy.context)

--- a/blender/arm/logicnode/miscellaneous/LN_call_group.py
+++ b/blender/arm/logicnode/miscellaneous/LN_call_group.py
@@ -24,30 +24,30 @@ class CallGroupNode(ArmLogicTreeNode):
                 self.add_input('ArmAnySocket', '')
 
     def update_outputs(self, node, context):
-        for input in node.inputs:
-            _, c_socket = arm.node_utils.input_get_connected_node(input)
+        for inp in node.inputs:
+            _, c_socket = arm.node_utils.input_get_connected_node(inp)
             if c_socket is not None:
                 self.add_output(c_socket.bl_idname, c_socket.name)
             else:
                 self.add_output('ArmAnySocket', '')
 
     def update_sockets(self, context):
-        for input in self.inputs:
-            self.inputs.remove(input)
+        for inp in self.inputs:
+            self.inputs.remove(inp)
         for output in self.outputs:
             self.outputs.remove(output)
         if self.property0_ is not None:
             for node in self.property0_.nodes:
-                if (node.bl_idname == 'LNGroupInputsNode'):
+                if node.bl_idname == 'LNGroupInputsNode':
                     self.update_inputs(node, context)
                     break
             for node in self.property0_.nodes:
-                if (node.bl_idname == 'LNGroupOutputsNode'):
+                if node.bl_idname == 'LNGroupOutputsNode':
                     self.update_outputs(node, context)
                     break
 
     property0_: HaxePointerProperty('property0', name='Group', type=bpy.types.NodeTree, update=update_sockets)
-    
+
     def arm_init(self, context):
         pass
 

--- a/blender/arm/logicnode/miscellaneous/LN_group_input.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_input.py
@@ -3,10 +3,11 @@ import bpy
 import arm
 import arm.utils
 from arm.logicnode.arm_nodes import *
+import arm.logicnode.miscellaneous.LN_call_group as LN_call_group
 
 
 class GroupInputsNode(ArmLogicTreeNode):
-    """Input for a given a node tree."""
+    """Input for a node group."""
     bl_idname = 'LNGroupInputsNode'
     bl_label = 'Group Input Node'
     arm_section = 'group'
@@ -36,6 +37,10 @@ class GroupInputsNode(ArmLogicTreeNode):
         if nodeCount > 1:
             arm.log.warn("Only one group input node per node tree is allowed")
             tree.nodes.remove(self)
+
+    def update(self):
+        super().update()
+        LN_call_group.CallGroupNode.update_all()
 
     def arm_init(self, context):
         self.add_output('ArmAnySocket', '')

--- a/blender/arm/logicnode/miscellaneous/LN_group_input.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_input.py
@@ -1,6 +1,5 @@
 import bpy
 
-import arm
 import arm.utils
 from arm.logicnode.arm_nodes import *
 import arm.logicnode.miscellaneous.LN_call_group as LN_call_group
@@ -15,26 +14,26 @@ class GroupInputsNode(ArmLogicTreeNode):
 
     def __init__(self):
         array_nodes[str(id(self))] = self
-    
+
     def init(self, context):
         tree = bpy.context.space_data.edit_tree
-        nodeCount = 0
+        node_count = 0
         for node in tree.nodes:
             if node.bl_idname == 'LNGroupInputsNode':
-                nodeCount += 1
-        if nodeCount > 1:
+                node_count += 1
+        if node_count > 1:
             arm.log.warn("Only one group input node per node tree is allowed")
             tree.nodes.remove(self)
         else:
             self.arm_init(context)
-    
+
     def copy(self, node):
         tree = bpy.context.space_data.edit_tree
-        nodeCount = 0
+        node_count = 0
         for node in tree.nodes:
             if node.bl_idname == 'LNGroupInputsNode':
-                nodeCount += 1
-        if nodeCount > 1:
+                node_count += 1
+        if node_count > 1:
             arm.log.warn("Only one group input node per node tree is allowed")
             tree.nodes.remove(self)
 
@@ -44,7 +43,7 @@ class GroupInputsNode(ArmLogicTreeNode):
 
     def arm_init(self, context):
         self.add_output('ArmAnySocket', '')
-    
+
     def draw_buttons(self, context, layout):
         row = layout.row(align=True)
 

--- a/blender/arm/logicnode/miscellaneous/LN_group_output.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_output.py
@@ -17,23 +17,23 @@ class GroupOutputsNode(ArmLogicTreeNode):
 
     def init(self, context):
         tree = bpy.context.space_data.edit_tree
-        nodeCount = 0
+        node_count = 0
         for node in tree.nodes:
             if node.bl_idname == 'LNGroupOutputsNode':
-                nodeCount += 1
-        if nodeCount > 1:
+                node_count += 1
+        if node_count > 1:
             arm.log.warn("Only one group output node per node tree is allowed")
             tree.nodes.remove(self)
         else:
             self.arm_init(context)
-    
+
     def copy(self, node):
         tree = bpy.context.space_data.edit_tree
-        nodeCount = 0
+        node_count = 0
         for node in tree.nodes:
             if node.bl_idname == 'LNGroupOutputsNode':
-                nodeCount += 1
-        if nodeCount > 1:
+                node_count += 1
+        if node_count > 1:
             arm.log.warn("Only one group output node per node tree is allowed")
             tree.nodes.remove(self)
 
@@ -43,13 +43,13 @@ class GroupOutputsNode(ArmLogicTreeNode):
 
     def arm_init(self, context):
         self.add_input('ArmAnySocket', '')
-    
+
     def draw_buttons(self, context, layout):
         row = layout.row(align=True)
 
         op = row.operator('arm.node_add_input', text='New', icon='PLUS', emboss=True)
         op.node_index = str(id(self))
         op.socket_type = 'ArmAnySocket'
-        if(len(self.inputs) > 1):
+        if len(self.inputs) > 1:
             op2 = row.operator('arm.node_remove_input', text='', icon='X', emboss=True)
             op2.node_index = str(id(self))

--- a/blender/arm/logicnode/miscellaneous/LN_group_output.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_output.py
@@ -2,10 +2,11 @@ import bpy
 
 import arm.utils
 from arm.logicnode.arm_nodes import *
+import arm.logicnode.miscellaneous.LN_call_group as LN_call_group
 
 
 class GroupOutputsNode(ArmLogicTreeNode):
-    """Output for a given a node tree."""
+    """Output for a node group."""
     bl_idname = 'LNGroupOutputsNode'
     bl_label = 'Group Output Node'
     arm_section = 'group'
@@ -35,6 +36,10 @@ class GroupOutputsNode(ArmLogicTreeNode):
         if nodeCount > 1:
             arm.log.warn("Only one group output node per node tree is allowed")
             tree.nodes.remove(self)
+
+    def update(self):
+        super().update()
+        LN_call_group.CallGroupNode.update_all()
 
     def arm_init(self, context):
         self.add_input('ArmAnySocket', '')

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -99,21 +99,6 @@ def output_get_connected_node(output_socket: bpy.types.NodeSocket) -> tuple[Opti
     return to_node, link.to_socket
 
 
-def get_input_node(node_group, to_node, input_index):
-    for link in node_group.links:
-        if link.to_node == to_node and link.to_socket == to_node.inputs[input_index]:
-            if link.from_node.bl_idname == 'NodeReroute': # Step through reroutes
-                return find_node_by_link(node_group, link.from_node, link.from_node.inputs[0])
-            return link.from_node
-
-def get_output_node(node_group, from_node, output_index):
-    for link in node_group.links:
-        if link.from_node == from_node and link.from_socket == from_node.outputs[output_index]:
-            if link.to_node.bl_idname == 'NodeReroute': # Step through reroutes
-                return find_node_by_link_from(node_group, link.to_node, link.to_node.inputs[0])
-            return link.to_node
-
-
 def get_socket_index(sockets: Union[NodeInputs, NodeOutputs], socket: NodeSocket) -> int:
     """Find the socket index in the given node input or output
     collection, return -1 if not found.

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -68,7 +68,9 @@ def input_get_connected_node(input_socket: bpy.types.NodeSocket) -> tuple[Option
     connection route ends without a connected node, `(None, None)` is
     returned.
     """
-    if not input_socket.is_linked:
+    # If this method is called while a socket is being unconnected, it
+    # can happen that is_linked is true but there are no links
+    if not input_socket.is_linked or len(input_socket.links) == 0:
         return None, None
 
     link: bpy.types.NodeLink = input_socket.links[0]
@@ -87,7 +89,7 @@ def output_get_connected_node(output_socket: bpy.types.NodeSocket) -> tuple[Opti
     connection route ends without a connected node, `(None, None)` is
     returned.
     """
-    if not output_socket.is_linked:
+    if not output_socket.is_linked or len(output_socket.links) == 0:
         return None, None
 
     link: bpy.types.NodeLink = output_socket.links[0]

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -1,5 +1,5 @@
 import collections.abc
-from typing import Any, Generator, Type, Union
+from typing import Any, Generator, Optional, Type, Union
 
 import bpy
 import mathutils
@@ -24,6 +24,7 @@ def find_node_by_link(node_group, to_node, inp):
             if link.from_node.bl_idname == 'NodeReroute': # Step through reroutes
                 return find_node_by_link(node_group, link.from_node, link.from_node.inputs[0])
             return link.from_node
+
 
 def find_node_by_link_from(node_group, from_node, outp):
     for link in node_group.links:
@@ -58,6 +59,44 @@ def iter_nodes_armorypbr(node_group: bpy.types.NodeTree) -> Generator[bpy.types.
     for node in node_group.nodes:
         if node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR'):
             yield node
+
+
+def input_get_connected_node(input_socket: bpy.types.NodeSocket) -> tuple[Optional[bpy.types.Node], Optional[bpy.types.NodeSocket]]:
+    """Get the node and the output socket of that node that is connected
+    to the given input, while following reroutes. If the input has
+    multiple incoming connections, the first one is followed. If the
+    connection route ends without a connected node, `(None, None)` is
+    returned.
+    """
+    if not input_socket.is_linked:
+        return None, None
+
+    link: bpy.types.NodeLink = input_socket.links[0]
+    from_node = link.from_node
+
+    if from_node.type == 'REROUTE':
+        return input_get_connected_node(from_node.inputs[0])
+
+    return from_node, link.from_socket
+
+
+def output_get_connected_node(output_socket: bpy.types.NodeSocket) -> tuple[Optional[bpy.types.Node], Optional[bpy.types.NodeSocket]]:
+    """Get the node and the input socket of that node that is connected
+    to the given output, while following reroutes. If the output has
+    multiple outgoing connections, the first one is followed. If the
+    connection route ends without a connected node, `(None, None)` is
+    returned.
+    """
+    if not output_socket.is_linked:
+        return None, None
+
+    link: bpy.types.NodeLink = output_socket.links[0]
+    to_node = link.to_node
+
+    if to_node.type == 'REROUTE':
+        return output_get_connected_node(to_node.outputs[0])
+
+    return to_node, link.to_socket
 
 
 def get_input_node(node_group, to_node, input_index):


### PR DESCRIPTION
I guess it's explained best with some gifs:

- ArmAnySocket sockets now follow reroutes and correctly display the name and color of the actually connected socket:
![](https://user-images.githubusercontent.com/17685000/157539669-4d224a84-7969-456f-8ee2-c69e760949f7.gif)

- CallNodeGroup nodes are now updated when a node group changes its inputs or outputs (also following reroutes now):
![](https://user-images.githubusercontent.com/17685000/157539869-197123a5-dfba-4e52-9691-0f6448ce2862.gif)

