### PR TITLE
Remove unused code that substantially slowed down texture export

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -852,9 +852,6 @@ def make_texture(image_node: bpy.types.ShaderNodeTexImage, tex_name: str, matnam
     elif texfilter == 'Point':
         interpolation = 'Closest'
 
-    # TODO: Blender seems to load full images on size request, cache size instead
-    powimage = is_pow(image.size[0]) and is_pow(image.size[1])
-
     if interpolation == 'Cubic': # Mipmap linear
         tex['mipmap_filter'] = 'linear'
         tex['generate_mipmaps'] = True


### PR DESCRIPTION
There was some leftover code in the texture export that, according to a comment, led to Blender loading the textures into memory even though its no longer used. After removing the code, I got from 2.6s to 0.2s overall spent in `make_texture()` in a file with 15 textures on my machine.