### PR TITLE
Fix polling of tree variable operators outside of logic trees

### DIFF
--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -860,6 +860,11 @@ def deprecated(*alternatives: str, message=""):
     return wrapper
 
 
+def is_logic_node_context(context: bpy.context) -> bool:
+    """Return whether the given bpy context is inside a logic node editor."""
+    return context.space_data.type == 'NODE_EDITOR' and context.space_data.tree_type == 'ArmLogicTreeType'
+
+
 def reset_globals():
     global nodes
     global category_items

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -92,6 +92,8 @@ class ARM_OT_TreeVariablePromoteNode(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
+        if not arm.logicnode.arm_nodes.is_logic_node_context(context):
+            return False
         tree: bpy.types.NodeTree = context.space_data.node_tree
         if tree is None:
             return False
@@ -144,6 +146,8 @@ class ARM_OT_TreeVariableMakeLocalNode(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
+        if not arm.logicnode.arm_nodes.is_logic_node_context(context):
+            return False
         tree: bpy.types.NodeTree = context.space_data.node_tree
         if tree is None:
             return False
@@ -176,6 +180,8 @@ class ARM_OT_TreeVariableVariableAssignToNode(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
+        if not arm.logicnode.arm_nodes.is_logic_node_context(context):
+            return False
         tree: bpy.types.NodeTree = context.space_data.node_tree
         if tree is None or len(tree.arm_treevariableslist) == 0:
             return False
@@ -256,6 +262,8 @@ class ARM_OT_AddVarGetterNode(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
+        if not arm.logicnode.arm_nodes.is_logic_node_context(context):
+            return False
         tree: bpy.types.NodeTree = context.space_data.node_tree
         return tree is not None and len(tree.arm_treevariableslist) > 0
 
@@ -302,6 +310,8 @@ class ARM_OT_AddVarSetterNode(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
+        if not arm.logicnode.arm_nodes.is_logic_node_context(context):
+            return False
         tree: bpy.types.NodeTree = context.space_data.node_tree
         return tree is not None and len(tree.arm_treevariableslist) > 0
 

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -223,6 +223,7 @@ class ARM_OT_TreeVariableListMoveItem(bpy.types.Operator):
     bl_idname = 'arm_treevariableslist.move_item'
     bl_label = 'Move'
     bl_description = 'Move an item in the list'
+    bl_options = {'UNDO', 'INTERNAL'}
 
     direction: EnumProperty(
         items=(


### PR DESCRIPTION
Fixed an exception that could occur when using the operator search (F3) outside the logic node editor.