### PR TITLE
Improve output socket handling of the Value Changed node

### DIFF
--- a/Sources/armory/logicnode/ValueChangedNode.hx
+++ b/Sources/armory/logicnode/ValueChangedNode.hx
@@ -2,24 +2,36 @@ package armory.logicnode;
 
 class ValueChangedNode extends LogicNode {
 
-	var initial: Dynamic;
-	var value: Dynamic;
+	var initialized = false;
+	var initialValue: Dynamic;
+	var lastValue: Dynamic;
 
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 	override function run(from: Int) {
-		if (initial == null) {
-			initial = inputs[1].get();
-			value = initial;
+		var currentValue = inputs[1].get();
+
+		if (!initialized) {
+			initialValue = currentValue;
+			lastValue = initialValue;
+			initialized = true;
+			runOutput(0);
+			runOutput(2);
+			return;
 		}
 
-		else if (value != inputs[1].get()) {
-			value = inputs[1].get();
-			value != initial ? runOutput(0) : runOutput(1);
+		if (currentValue == lastValue) {
+			runOutput(1);
+		}
+		else {
+			lastValue = currentValue;
+			runOutput(0);
 		}
 
+		if (currentValue == initialValue) {
+			runOutput(2);
+		}
 	}
-
 }

--- a/blender/arm/logicnode/logic/LN_value_changed.py
+++ b/blender/arm/logicnode/logic/LN_value_changed.py
@@ -1,10 +1,24 @@
 from arm.logicnode.arm_nodes import *
 
+
 class ValueChangedNode(ArmLogicTreeNode):
-    """Sends a signal to `Changed` output whether the connected value is changed and a signal to `Unchanged` if the connected value returns to initial. Does not works with `null` value."""
+    """Upon activation through the `In` input, this node checks whether
+    the given value is different than the value from the last execution
+    of this node.
+
+    @output Changed: Activates if the value has changed compared to the
+        last time the node was executed or if the node is executed for
+        the first time and there is no value for comparison yet.
+    @output Unchanged: Activates if the value is the same as it was when
+        the node was executed the last time.
+    @output Is Initial: Activates if the value is equal to the value at
+        the first time the node was executed or if the node is executed
+        for the first time. This output works independently of the
+        `Changed` or `Unchanged` outputs.
+    """
     bl_idname = 'LNValueChangedNode'
     bl_label = 'Value Changed'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
@@ -12,3 +26,13 @@ class ValueChangedNode(ArmLogicTreeNode):
 
         self.add_output('ArmNodeSocketAction', 'Changed')
         self.add_output('ArmNodeSocketAction', 'Unchanged')
+        self.add_output('ArmNodeSocketAction', 'Is Initial')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement(
+            'LNValueChangedNode', self.arm_version, 'LNValueChangedNode', 2,
+            in_socket_mapping={0: 0, 1: 1}, out_socket_mapping={0: 0, 1: 2}
+        )


### PR DESCRIPTION
Previously the "Unchanged" output of the Value Changed node was not activated if the value was unchanged _compared to the last value_, but only if it was different to the _initial value_ from the first execution of the node. The "Changed" output however compared the last value.

This led to some confusion, so there is now a new output "Is Initial" for the old functionality, and "Unchanged" now checks against the last value as well. It's also possible now to use `null` as a value without always triggering the initialization of the node.