### PR TITLE
Fix updating rotation sockets during live patch session

### DIFF
--- a/Sources/armory/trait/internal/Bridge.hx
+++ b/Sources/armory/trait/internal/Bridge.hx
@@ -12,6 +12,7 @@ class Bridge {
 	public static var Object = iron.object.Object;
 	public static var Data = iron.data.Data;
 	public static var Vec4 = iron.math.Vec4;
+	public static var Quat = iron.math.Quat;
 	public static function log(s: String) { trace(s); };
 }
 

--- a/blender/arm/live_patch.py
+++ b/blender/arm/live_patch.py
@@ -230,6 +230,8 @@ def send_event(event_id: str, opt_data: Any = None):
                 value = f'new iron.Vec4({arm.node_utils.haxe_format_socket_val(value, array_outer_brackets=False)}, 1.0)'
             elif inp_type == 'RGBA':
                 value = f'new iron.Vec4({arm.node_utils.haxe_format_socket_val(value, array_outer_brackets=False)})'
+            elif inp_type == 'ROTATION':
+                value = f'new iron.Quat({arm.node_utils.haxe_format_socket_val(value, array_outer_brackets=False)})'
             elif inp_type == 'OBJECT':
                 value = f'iron.Scene.active.getChild("{value}")' if value != '' else 'null'
             else:


### PR DESCRIPTION
I'm not quite sure why it worked before in some cases (js...), but setting quaternion values as simple float arrays sometimes led to NaN values which then caused havoc later.

Thanks @rpaladin for the report!