### PR TITLE
Allow materials to read from a depth texture

### DIFF
--- a/Sources/armory/renderpath/RenderPathCreator.hx
+++ b/Sources/armory/renderpath/RenderPathCreator.hx
@@ -34,23 +34,25 @@ class RenderPathCreator {
 		#end
 
 		#if (rp_renderer == "Forward")
-		RenderPathForward.init(path);
-		path.commands = function() {
-			RenderPathForward.commands();
-			commands();
-		}
+			RenderPathForward.init(path);
+			path.commands = function() {
+				RenderPathForward.commands();
+				commands();
+			}
+			path.setupDepthTexture = RenderPathForward.setupDepthTexture;
 		#elseif (rp_renderer == "Deferred")
-		RenderPathDeferred.init(path);
-		path.commands = function() {
-			RenderPathDeferred.commands();
-			commands();
-		}
+			RenderPathDeferred.init(path);
+			path.commands = function() {
+				RenderPathDeferred.commands();
+				commands();
+			}
+			path.setupDepthTexture = RenderPathDeferred.setupDepthTexture;
 		#elseif (rp_renderer == "Raytracer")
-		RenderPathRaytracer.init(path);
-		path.commands = function() {
-			RenderPathRaytracer.commands();
-			commands();
-		}
+			RenderPathRaytracer.init(path);
+			path.commands = function() {
+				RenderPathRaytracer.commands();
+				commands();
+			}
 		#end
 		return path;
 	}

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2008,6 +2008,7 @@ Make sure the mesh only has tris/quads.""")
         transluc_used = False
         overlays_used = False
         blending_used = False
+        depthtex_used = False
         decals_used = False
         sss_used = False
 
@@ -2063,8 +2064,11 @@ Make sure the mesh only has tris/quads.""")
                 transluc_used = True
             if 'overlay' in rpasses:
                 overlays_used = True
-            if 'mesh' in rpasses and material.arm_blending:
-                blending_used = True
+            if 'mesh' in rpasses:
+                if material.arm_blending:
+                    blending_used = True
+                if material.arm_depth_read:
+                    depthtex_used = True
             if 'decal' in rpasses:
                 decals_used = True
 
@@ -2114,6 +2118,9 @@ Make sure the mesh only has tris/quads.""")
             rebuild_rp = True
         if rpdat.rp_blending_state == 'Auto' and rpdat.rp_blending != blending_used:
             rpdat.rp_blending = blending_used
+            rebuild_rp = True
+        if rpdat.rp_depth_texture_state == 'Auto' and rpdat.rp_depth_texture != depthtex_used:
+            rpdat.rp_depth_texture = depthtex_used
             rebuild_rp = True
         if rpdat.rp_decals_state == 'Auto' and rpdat.rp_decals != decals_used:
             rpdat.rp_decals = decals_used

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -346,6 +346,10 @@ def build():
     if rpdat.rp_blending:
         assets.add_khafile_def('rp_blending')
 
+    if rpdat.rp_depth_texture:
+        assets.add_khafile_def('rp_depth_texture')
+        assets.add_shader_pass('copy_pass')
+
     if rpdat.rp_sss:
         assets.add_khafile_def('rp_sss')
         wrd.world_defs += '_SSS'

--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -70,6 +70,7 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
             'name': rp,
             'bind_constants': [] + bind_constants[rp],
             'bind_textures': [] + bind_textures[rp],
+            'depth_read': material.arm_depth_read,
         }
         mat_data['contexts'].append(c)
 

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -40,7 +40,7 @@ def make(context_id, rpasses):
     # Blend context
     mat = mat_state.material
     blend = mat.arm_blending
-    particle = mat_state.material.arm_particle_flag
+    particle = mat.arm_particle_flag
     dprepass = rid == 'Forward' and rpdat.rp_depthprepass
     if blend:
         con['name'] = 'blend'
@@ -54,7 +54,9 @@ def make(context_id, rpasses):
         con['compare_mode'] = 'less'
     elif particle:
         pass
-    elif dprepass: # Depth prepass was performed
+    # Depth prepass was performed, exclude mat with depth read that
+    # isn't part of depth prepass
+    elif dprepass and not (rpdat.rp_depth_texture and mat.arm_depth_read):
         con['depth_write'] = False
         con['compare_mode'] = 'equal'
 

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -360,6 +360,7 @@ def init_properties():
     bpy.types.World.arm_nishita_density = FloatVectorProperty(name="Nishita Density", size=3, default=[1, 1, 1])
     bpy.types.Material.arm_cast_shadow = BoolProperty(name="Cast Shadow", default=True)
     bpy.types.Material.arm_receive_shadow = BoolProperty(name="Receive Shadow", description="Requires forward render path", default=True)
+    bpy.types.Material.arm_depth_read = BoolProperty(name="Read Depth", description="Allow this material to read from a depth texture which is copied from the depth buffer. The meshes using this material will be drawn after all meshes that don't read from the depth texture", default=False)
     bpy.types.Material.arm_overlay = BoolProperty(name="Overlay", default=False)
     bpy.types.Material.arm_decal = BoolProperty(name="Decal", default=False)
     bpy.types.Material.arm_two_sided = BoolProperty(name="Two-Sided", description="Flip normal when drawing back-face", default=False)

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -190,7 +190,7 @@ def update_preset(self, context):
     update_renderpath(self, context)
 
 def update_renderpath(self, context):
-    if assets.invalidate_enabled == False:
+    if not assets.invalidate_enabled:
         return
     assets.invalidate_shader_cache(self, context)
     bpy.data.worlds['Arm'].arm_recompile = True
@@ -238,6 +238,17 @@ def update_blending_state(self, context):
     else: # Auto - updates rp at build time if blending mat is used
         return
     update_renderpath(self, context)
+
+
+def update_depth_texture_state(self, context):
+    if self.rp_depth_texture_state == 'On':
+        self.rp_depth_texture = True
+    elif self.rp_depth_texture_state == 'Off':
+        self.rp_depth_texture = False
+    else: # Auto - updates rp at build time if depth texture mat is used
+        return
+    update_renderpath(self, context)
+
 
 def update_sss_state(self, context):
     if self.rp_sss_state == 'On':
@@ -405,6 +416,12 @@ class ArmRPListItem(bpy.types.PropertyGroup):
                ('Distance', 'Distance', 'Distance'),
                ('Shader', 'Shader', 'Shader')],
         name='Draw Order', description='Sort objects', default='Auto', update=assets.invalidate_compiled_data)
+    rp_depth_texture: BoolProperty(name="Depth Texture", description="Current render-path state", default=False)
+    rp_depth_texture_state: EnumProperty(
+        items=[('On', 'On', 'On'),
+               ('Off', 'Off', 'Off'),
+               ('Auto', 'Auto', 'Auto')],
+        name='Depth Texture', description='Whether materials can read from a depth texture', default='Auto', update=update_depth_texture_state)
     rp_stereo: BoolProperty(name="VR", description="Stereo rendering", default=False, update=update_renderpath)
     rp_water: BoolProperty(name="Water", description="Enable water surface pass", default=False, update=update_renderpath)
     rp_pp: BoolProperty(name="Realtime postprocess", description="Realtime postprocess", default=False, update=update_renderpath)

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -57,6 +57,7 @@ def update_preset(self, context):
         rpdat.rp_decals_state = 'Auto'
         rpdat.rp_sss_state = 'Auto'
         rpdat.rp_blending_state = 'Auto'
+        rpdat.rp_depth_texture_state = 'Auto'
         rpdat.rp_draw_order = 'Auto'
         rpdat.rp_hdr = True
         rpdat.rp_background = 'World'
@@ -92,6 +93,7 @@ def update_preset(self, context):
         rpdat.rp_decals_state = 'Off'
         rpdat.rp_sss_state = 'Off'
         rpdat.rp_blending_state = 'Off'
+        rpdat.rp_depth_texture_state = 'Auto'
         rpdat.rp_draw_order = 'Auto'
         rpdat.rp_hdr = False
         rpdat.rp_background = 'Clear'
@@ -125,6 +127,7 @@ def update_preset(self, context):
         rpdat.rp_decals_state = 'Auto'
         rpdat.rp_sss_state = 'Auto'
         rpdat.rp_blending_state = 'Auto'
+        rpdat.rp_depth_texture_state = 'Auto'
         rpdat.rp_draw_order = 'Auto'
         rpdat.rp_hdr = True
         rpdat.rp_background = 'World'
@@ -165,6 +168,7 @@ def update_preset(self, context):
         rpdat.rp_decals_state = 'Off'
         rpdat.rp_sss_state = 'Off'
         rpdat.rp_blending_state = 'Off'
+        rpdat.rp_depth_texture_state = 'Off'
         rpdat.rp_draw_order = 'Auto'
         rpdat.rp_hdr = False
         rpdat.rp_background = 'Clear'

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -505,6 +505,7 @@ class ARM_PT_MaterialPropsPanel(bpy.types.Panel):
         columnb.enabled = not mat.arm_two_sided
         columnb.prop(mat, 'arm_cull_mode')
         layout.prop(mat, 'arm_material_id')
+        layout.prop(mat, 'arm_depth_read')
         layout.prop(mat, 'arm_overlay')
         layout.prop(mat, 'arm_decal')
         layout.prop(mat, 'arm_discard')
@@ -1323,6 +1324,7 @@ class ARM_PT_RenderPathRendererPanel(bpy.types.Panel):
         layout.prop(rpdat, 'rp_overlays_state')
         layout.prop(rpdat, 'rp_decals_state')
         layout.prop(rpdat, 'rp_blending_state')
+        layout.prop(rpdat, 'rp_depth_texture_state')
         layout.prop(rpdat, 'rp_draw_order')
         layout.prop(rpdat, 'arm_samples_per_pixel')
         layout.prop(rpdat, 'arm_texture_filter')


### PR DESCRIPTION
Requries https://github.com/armory3d/iron/pull/160.

This PR implements what was discussed in https://github.com/armory3d/armory/pull/1817. Materials now can specify that they want to read from the depth buffer. In this case, meshes with those materials are drawn last and before they are drawn, the depth buffer is copied to a dedicated depth texture that can then be sampled from a shader uniform called `depthtex`.

![Material UI](https://user-images.githubusercontent.com/17685000/161437565-f9f00e61-ad36-4990-85e9-6856d7937b86.png)

![depthtex](https://user-images.githubusercontent.com/17685000/161437419-15459c24-f84c-4225-9a79-eb44a53af26e.gif)

It works on deferred and forward (Depth prepass on/off), with shadows and transparency, SSR and mesh batching. The only limitation I know is that on forward RP this doesn't work when the compositor is turned off because then the `rp_render_to_texture` define is undefined and `lbuffer0` does not exist. I'm not sure whether this define should only be set for the compositor (as it also creates some other render targets for example) or whether it can be enabled for this feature as well. In general it's difficult to see what rendertargets and defines are used for what purpose, so please let me know if I should change something. Btw, what does the `l` in `lbuffer0` stand for?

Tested on:
- Krom on Windows
- html5
- Hl/C on both OpenGL and D3D11 on Windows

The entire depth texture feature can be toggled on or off in the renderpath settings:
![depthtex_menu](https://user-images.githubusercontent.com/17685000/161437429-115ecdac-de9c-47f1-a95e-33f9067ed0cc.png)

My next goal is to implement the possibility to allow defining samplers/texture units in custom materials via the UI (because they are defined in the mat data .json and not in the shader .json that the user can provide; also Khamake needs to know about the textures). Then it would be possible for example to create an underwater caustics volume together with the depth read feature.