### PR TITLE
Use port from prefs for html5 player path

### DIFF
--- a/blender/arm/lib/server.py
+++ b/blender/arm/lib/server.py
@@ -1,4 +1,3 @@
-import arm.utils
 import atexit
 import http.server
 import socketserver
@@ -6,10 +5,7 @@ import subprocess
 
 haxe_server = None
 
-def run_tcp():
-	prefs = arm.utils.get_arm_preferences()
-	port = prefs.html5_server_port
-	do_log = prefs.html5_server_log
+def run_tcp(port:int, do_log:bool):
 	class HTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 		def log_message(self,format,*args):
 			if do_log: print(format % args)

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -547,10 +547,10 @@ def build_success():
         if wrd.arm_runtime == 'Browser':
             # Start server
             os.chdir(arm.utils.get_fp())
-            t = threading.Thread(name='localserver', target=arm.lib.server.run_tcp)
-            t.daemon = True
+            prefs = arm.utils.get_arm_preferences()
+            t = threading.Thread(name='localserver', target=arm.lib.server.run_tcp, args=(prefs.html5_server_port, prefs.html5_server_log), daemon=True)
             t.start()
-            html5_app_path = 'http://localhost:8040/' + arm.utils.build_dir() + '/debug/html5'
+            html5_app_path = 'http://localhost:{}/{}/debug/html5'.format(prefs.html5_server_port, arm.utils.build_dir())
             webbrowser.open(html5_app_path)
         elif wrd.arm_runtime == 'Krom':
             if wrd.arm_live_patch:


### PR DESCRIPTION
Use web server port number specified in preferences, not hard coded.
Also removes dependency of arm.lib.server outside its' package.
