### PR TITLE
key Interpolation Node

### DIFF
--- a/Sources/armory/logicnode/KeyInterpolateNode.hx
+++ b/Sources/armory/logicnode/KeyInterpolateNode.hx
@@ -1,0 +1,32 @@
+package armory.logicnode;
+
+import kha.FastFloat;
+
+class KeyInterpolateNode extends LogicNode {
+
+	var value: FastFloat = 0.0;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+		tree.notifyOnInit(init);
+		tree.notifyOnUpdate(update);
+	}
+
+	function init() {
+		value = clamp(inputs[1].get());
+	}
+
+	function update() {
+		final sign = inputs[0].get() ? 1.0 : -1.0;
+		final rate = inputs[2].get();
+		value = clamp(value + rate * sign);
+	}
+
+	override function get(from: Int): FastFloat {
+		return value;
+	}
+
+	inline function clamp(value: FastFloat): FastFloat {
+		return value < 0.0 ? 0.0 : value > 1.0 ? 1.0 : value;
+	}
+}

--- a/blender/arm/logicnode/math/LN_key_interpolate.py
+++ b/blender/arm/logicnode/math/LN_key_interpolate.py
@@ -1,0 +1,18 @@
+from arm.logicnode.arm_nodes import *
+
+class KeyInterpolateNode(ArmLogicTreeNode):
+    """Linearly interpolate to 1.0 if input is true and interpolate to 0.0 if input is false.
+    @input Key State: Interpolate to 1.0 if true and 0.0 if false.
+    @input Init: Initial value in the range 0.0 to 1.0.
+    @input Rate: Rate of interpolation.
+    """
+    bl_idname = 'LNKeyInterpolateNode'
+    bl_label = 'Key Interpolate Node'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmBoolSocket', 'Key State')
+        self.add_input('ArmFloatSocket', 'Init', default_value=0.0)
+        self.add_input('ArmFloatSocket', 'Rate')
+
+        self.add_output('ArmFloatSocket', 'Result')


### PR DESCRIPTION
This node allows to linearly interpolate between `0` and `1` based on a condition, For example keyboard/ mouse key down. It can be used to smooth character movement/translations that are activated on key down.

![image](https://user-images.githubusercontent.com/55564981/162381553-320a9c0a-cdd7-4ad5-8c05-c79ac0af8e44.png)