### PR TITLE
Support for texture bindings for custom (json) materials

### DIFF
--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -127,7 +127,7 @@ def parse_tex_image(node: bpy.types.ShaderNodeTexImage, out_socket: bpy.types.No
                 return f'{c.store_var_name(node)}.a'
 
         tex_name = c.node_name(node.name)
-        tex = c.make_texture(node, tex_name)
+        tex = c.make_texture_from_image_node(node, tex_name)
         tex_link = None
         tex_default_file = None
         is_arm_mat_param = None


### PR DESCRIPTION
Custom materials can now sample from textures that have been loaded in Blender ("mesh" context only for now). If the user has selected a custom material, the following panel appears:

![bind_textures_UI](https://user-images.githubusercontent.com/17685000/163731425-59eecb30-5d55-4053-bd6e-03d980e722d2.png)

The selected images then get an entry in the scene's material data for binding them to a texture unit, but the user still has to add the actual texture unit in the material's .json file. Apart from checking whether the uniform name is not empty and there is an image selected, there are for now no additional checks if the uniform name is actually allowed.