### PR TITLE
Better shader node tree warnings

### DIFF
--- a/blender/arm/make_world.py
+++ b/blender/arm/make_world.py
@@ -163,7 +163,7 @@ def build_node_tree(world: bpy.types.World, frag: Shader, vert: Shader, con: Sha
         frag.write('fragColor.rgb = backgroundCol;')
         return
 
-    parser_state = ParserState(ParserContext.WORLD, world)
+    parser_state = ParserState(ParserContext.WORLD, world.name, world)
     parser_state.con = con
     parser_state.curshader = frag
     parser_state.frag = frag

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -58,7 +58,7 @@ def parse(nodes, con: ShaderContext,
           parse_surface=True, parse_opacity=True, parse_displacement=True, basecol_only=False):
     global state
 
-    state = ParserState(ParserContext.OBJECT)
+    state = ParserState(ParserContext.OBJECT, mat_state.material.name)
 
     state.parse_surface = parse_surface
     state.parse_opacity = parse_opacity
@@ -231,7 +231,7 @@ def parse_shader(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> Tuple[st
             if state.parse_surface:
                 # Normal
                 if node.inputs[5].is_linked and node.inputs[5].links[0].from_node.type == 'NORMAL_MAP':
-                    log.warn(mat_name() + ' - Do not use Normal Map node with Armory PBR, connect Image Texture directly')
+                    log.warn(tree_name() + ' - Do not use Normal Map node with Armory PBR, connect Image Texture directly')
                 parse_normal_map_color_input(node.inputs[5])
                 # Base color
                 state.out_basecol = parse_vector_input(node.inputs[0])
@@ -258,8 +258,7 @@ def parse_shader(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> Tuple[st
             return node.parse(state.frag, state.vert)
 
     else:
-        # TODO: Print node tree name (save in ParserState)
-        log.warn(f'Material node type {node.type} not supported')
+        log.warn(f'Node tree "{tree_name()}": material node type {node.type} not supported')
 
     return state.get_outs()
 
@@ -366,7 +365,7 @@ def parse_vector(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> str:
         if node.bl_idname == 'ArmShaderDataNode':
             return node.parse(state.frag, state.vert)
 
-    log.warn(f'Material node type {node.type} not supported')
+    log.warn(f'Node tree "{tree_name()}": material node type {node.type} not supported')
     return "vec3(0, 0, 0)"
 
 
@@ -476,7 +475,7 @@ def parse_value(node, socket):
         if node.bl_idname == 'ArmShaderDataNode':
             return node.parse(state.frag, state.vert)
 
-    log.warn(f'Material node type {node.type} not supported')
+    log.warn(f'Node tree "{tree_name()}": material node type {node.type} not supported')
     return '0.0'
 
 
@@ -910,8 +909,8 @@ def assets_add(path):
 def assets_add_embedded_data(path):
     arm.assets.add_embedded_data(path)
 
-def mat_name():
-    return mat_state.material.name
+def tree_name() -> str:
+    return state.tree_name
 
 def mat_batch():
     return mat_state.batch

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -23,8 +23,9 @@ else:
 
 class ParserState:
     """Dataclass to keep track of the current state while parsing a shader tree."""
-    def __init__(self, context: ParserContext, world: Optional[bpy.types.World] = None):
+    def __init__(self, context: ParserContext, tree_name: str, world: Optional[bpy.types.World] = None):
         self.context = context
+        self.tree_name = tree_name
 
         # The current world, if parsing a world node tree
         self.world = world


### PR DESCRIPTION
Closes https://github.com/armory3d/armory/issues/2490.

Now the socket parsing functions are only called if the link's socket types are supported, otherwise a warning is printed and a default value is used. This prevents either "unsupported node" warnings as in the linked issue or in some cases even glsl errors.