### PR TITLE
Fix and improve loading of libraries

### DIFF
--- a/blender/arm/api.py
+++ b/blender/arm/api.py
@@ -37,3 +37,7 @@ def add_driver(driver_name: str,
         'draw_props': draw_props,
         'draw_mat_props': draw_mat_props
     }
+
+
+def remove_drivers():
+    drivers.clear()

--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -168,7 +168,7 @@ def on_load_post(context):
 
     wrd = bpy.data.worlds['Arm']
     wrd.arm_recompile = True
-    arm.api.drivers = dict()
+    arm.api.remove_drivers()
 
     load_py_libraries()
 
@@ -226,7 +226,7 @@ def unload_py_libraries():
 
 def reload_blend_data():
     armory_pbr = bpy.data.node_groups.get('Armory PBR')
-    if armory_pbr == None:
+    if armory_pbr is None:
         load_library('Armory PBR')
 
 


### PR DESCRIPTION
Fixes an issue described in https://forums.armory3d.org/t/celshade-option-only-appears-after-opening-forest-example-with-right-click-how-to-set-manually-for-other-blends/4891.

Libraries weren't reloaded when changing files from within the same project, but registered render path drivers are removed each time a file is changed. Now libraries are reloaded each time a file is opened or the addon is reloaded, which also gives libraries the possibility to re-initialize themselves for a new file. Also, libraries can now have an optional `unregister` function that will be called before a new file is loaded or when the addon is unregistered, giving libraries the possibility to properly clean up.

Furthermore libraries are no longer loaded twice when a blend file is opened from the file explorer and there is a little debug message in the console that shows which libraries get (un-)loaded.