### PR TITLE
Fix node tree caching

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -114,10 +114,7 @@ def always() -> float:
             if area.type in ('NODE_EDITOR', 'PROPERTIES', 'VIEW_3D'):
                 area.tag_redraw()
         state.redraw_ui = False
-    # TODO: depsgraph.updates only triggers material trees
-    space = arm.utils.logic_editor_space(context_screen)
-    if space is not None:
-        space.node_tree.arm_cached = False
+
     return 0.5
 
 


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2219.

Since https://github.com/armory3d/armory/commit/7a1acb6228ecbb76013e57973c50d70270182275 there was a workaround in place to ensure that the cache of logic trees gets cleared very frequently because the depsgraph updates don't reflect all updates to logic trees. But because the `always()` callback only runs twice a second, it could happen that changes made to a tree weren't reflected in the build if the user starts the build before the `always()` callback was run. Now that we have dedicated tree update callbacks for live patching, we can use them to clear the cache on each change made to the node tree and get rid of the old workaround.

Note that the current approach is still a bit over-conservative (less than before though), for example the cache is also cleared when you start dragging a connection from a socket but cancel the operation before reaching the target socket. So there is still some potential for improvement in the future.