### PR TITLE
Align RGB to grayscale luminance with Blender

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -709,7 +709,9 @@ def cast_value(val: str, from_type: str, to_type: str) -> str:
 
 
 def rgb_to_bw(res_var: vec3str) -> floatstr:
-    return f'((({res_var}.r * 0.3 + {res_var}.g * 0.59 + {res_var}.b * 0.11) / 3.0) * 2.5)'
+    # Blender uses the default OpenColorIO luma coefficients which
+    # originally come from the Rec. 709 standard (see ITU-R BT.709-6 Item 3.3)
+    return f'dot({res_var}, vec3(0.2126, 0.7152, 0.0722))'
 
 
 def node_by_type(nodes, ntype: str) -> bpy.types.Node:


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2467.

To convert RGB values to grayscale, Armory used different luma coefficients than Blender which could lead to visible differences between Armory and Blender materials. I wasn't exactly sure where the values come from, so I did some research:

- Previously, Armory used approximations of values from Rec. 601 (Rec. ITU-R BT.601-7 Section 2.5.1). Similar values (but not the same) were used in older Blender versions (see [this commit](https://github.com/blender/blender/commit/49247f0fc445ec014478d485883492a04ae5facb#diff-577a4d894f44ce57f77a4988305f510e77a95edee5b044c3802a4a9e953cf559L746)).
- Blender uses the [default coefficients from OpenColorIO](https://opencolorio.readthedocs.io/en/latest/guides/authoring/authoring.html#luma) (see https://blender.stackexchange.com/a/112554/58208) which are based on Rec. 709 (Rec. ITU-R BT.709-6 Item 3.3). See [Blender source](https://github.com/blender/blender/blob/594f47ecd2d5367ca936cf6fc6ec8168c2b360d0/source/blender/gpu/shaders/material/gpu_shader_material_rgb_to_bw.glsl).

Both sets of coefficients seem to be widely used (Rec. 601 for example is used in some OpenCV and matlab functions), but I guess it only makes sense to use the same in both cases.