### PR TITLE
Object Info node: make "random" output random per GPU instance

### DIFF
--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -6,6 +6,7 @@ import mathutils
 import arm.log as log
 import arm.material.cycles as c
 import arm.material.cycles_functions as c_functions
+import arm.material.mat_state as mat_state
 from arm.material.parser_state import ParserState, ParserContext
 from arm.material.shader import floatstr, vec3str
 import arm.utils
@@ -14,6 +15,7 @@ if arm.is_reload(__name__):
     log = arm.reload_module(log)
     c = arm.reload_module(c)
     c_functions = arm.reload_module(c_functions)
+    mat_state = arm.reload_module(mat_state)
     arm.material.parser_state = arm.reload_module(arm.material.parser_state)
     from arm.material.parser_state import ParserState, ParserContext
     arm.material.shader = arm.reload_module(arm.material.shader)
@@ -219,6 +221,14 @@ def parse_objectinfo(node: bpy.types.ShaderNodeObjectInfo, out_socket: bpy.types
     elif out_socket == node.outputs[4]:
         if state.context == ParserContext.WORLD:
             return '0.0'
+
+        # Use random value per instance
+        if mat_state.uses_instancing:
+            state.vert.add_out(f'flat float irand')
+            state.frag.add_in(f'flat float irand')
+            state.vert.write(f'irand = fract(sin(gl_InstanceID) * 43758.5453);')
+            return 'irand'
+
         state.curshader.add_uniform('float objectInfoRandom', link='_objectInfoRandom')
         return 'objectInfoRandom'
 

--- a/blender/arm/material/make_shader.py
+++ b/blender/arm/material/make_shader.py
@@ -184,6 +184,7 @@ def make_instancing_and_skinning(mat: Material, mat_users: Dict[Material, List[O
     if mat_users is not None and mat in mat_users:
         # Whether there are both an instanced object and a not instanced object with this material
         instancing_usage = [False, False]
+        mat_state.uses_instancing = False
 
         for bo in mat_users[mat]:
             if mat.arm_custom_material == '':
@@ -199,6 +200,7 @@ def make_instancing_and_skinning(mat: Material, mat_users: Dict[Material, List[O
             inst = bo.arm_instanced
             if inst != 'Off' or mat.arm_particle_flag:
                 instancing_usage[0] = True
+                mat_state.uses_instancing = True
 
                 if mat.arm_custom_material == '':
                     global_elems.append({'name': 'ipos', 'data': 'float3'})

--- a/blender/arm/material/mat_state.py
+++ b/blender/arm/material/mat_state.py
@@ -7,3 +7,4 @@ bind_textures = None # Merged with mat_context bind textures
 batch = False
 texture_grad = False # Sample textures using textureGrad()
 con_mesh = None # Mesh context
+uses_instancing = False  # Whether the current material has at least one user with instancing enabled

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -288,12 +288,14 @@ def init_properties():
     bpy.types.World.arm_winminimize = BoolProperty(name="Minimizable", description="Allow window minimize", default=True, update=assets.invalidate_compiler_cache)
     # For object
     bpy.types.Object.arm_instanced = EnumProperty(
-        items = [('Off', 'Off', 'Off'),
-                 ('Loc', 'Loc', 'Loc'),
-                 ('Loc + Rot', 'Loc + Rot', 'Loc + Rot'),
-                 ('Loc + Scale', 'Loc + Scale', 'Loc + Scale'),
-                 ('Loc + Rot + Scale', 'Loc + Rot + Scale', 'Loc + Rot + Scale')],
-        name="Instanced Children", default='Off', description='Use instacing to draw children', update=assets.invalidate_instance_cache)
+        items = [('Off', 'Off', 'No instancing of children'),
+                 ('Loc', 'Loc', 'Instances use their unique position (ipos)'),
+                 ('Loc + Rot', 'Loc + Rot', 'Instances use their unique position and rotation (ipos and irot)'),
+                 ('Loc + Scale', 'Loc + Scale', 'Instances use their unique position and scale (ipos and iscl)'),
+                 ('Loc + Rot + Scale', 'Loc + Rot + Scale', 'Instances use their unique position, rotation and scale (ipos, irot, iscl)')],
+        name="Instanced Children", default='Off',
+        description='Whether to use instancing to draw the children of this object. If enabled, this option defines what attributes may vary between the instances',
+        update=assets.invalidate_instance_cache)
     bpy.types.Object.arm_export = BoolProperty(name="Export", description="Export object data", default=True)
     bpy.types.Object.arm_spawn = BoolProperty(name="Spawn", description="Auto-add this object when creating scene", default=True)
     bpy.types.Object.arm_mobile = BoolProperty(name="Mobile", description="Object moves during gameplay", default=False)


### PR DESCRIPTION
This PR makes the "random" output of the Object Info node work like in Blender. This allows for random values per particle for example, which previously was only possible with a the Shader Data node as a workaround.

Thanks a lot to @ QuantumCoderQC for reminding me about `gl_InstanceID`, otherwise I probably would have implemented a much more over-complicated solution... :)