### PR TITLE
Stop tweening when NavAgent is removed

### DIFF
--- a/Sources/armory/trait/NavAgent.hx
+++ b/Sources/armory/trait/NavAgent.hx
@@ -20,6 +20,7 @@ class NavAgent extends Trait {
 
 	public function new() {
 		super();
+		notifyOnRemove(stopTween);
 	}
 
 	public function setPath(path: Array<Vec4>) {


### PR DESCRIPTION
When NavAgent Object was removed, the tweening still continued, resulting in an error. This PR fixes this issue.