### PR TITLE
Deferred renderpath: fix volumetric light combined with translucent materials

### DIFF
--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -655,27 +655,6 @@ class RenderPathDeferred {
 		}
 		#end
 
-		#if rp_volumetriclight
-		{
-			path.setTarget("singlea");
-			path.bindTarget("_main", "gbufferD");
-						#if arm_shadowmap_atlas
-			Inc.bindShadowMapAtlas();
-			#else
-			Inc.bindShadowMap();
-			#end
-			path.drawShader("shader_datas/volumetric_light/volumetric_light");
-
-			path.setTarget("singleb");
-			path.bindTarget("singlea", "tex");
-			path.drawShader("shader_datas/blur_bilat_pass/blur_bilat_pass_x");
-
-			path.setTarget("tex");
-			path.bindTarget("singleb", "tex");
-			path.drawShader("shader_datas/blur_bilat_blend_pass/blur_bilat_blend_pass_y");
-		}
-		#end
-
 		#if (!kha_opengl)
 		path.setDepthFrom("tex", "gbuffer0"); // Re-bind depth
 		#end
@@ -699,6 +678,27 @@ class RenderPathDeferred {
 		#if rp_translucency
 		{
 			Inc.drawTranslucency("tex");
+		}
+		#end
+
+		#if rp_volumetriclight
+		{
+			path.setTarget("singlea");
+			path.bindTarget("_main", "gbufferD");
+			#if arm_shadowmap_atlas
+			Inc.bindShadowMapAtlas();
+			#else
+			Inc.bindShadowMap();
+			#end
+			path.drawShader("shader_datas/volumetric_light/volumetric_light");
+
+			path.setTarget("singleb");
+			path.bindTarget("singlea", "tex");
+			path.drawShader("shader_datas/blur_bilat_pass/blur_bilat_pass_x");
+
+			path.setTarget("tex");
+			path.bindTarget("singleb", "tex");
+			path.drawShader("shader_datas/blur_bilat_blend_pass/blur_bilat_blend_pass_y");
 		}
 		#end
 


### PR DESCRIPTION
Fixes an issue described in https://github.com/armory3d/armory/issues/2520 that would draw translucent materials on top of the volumetric light when using the deferred renderpath.

Previously the render order on deferred was `Volumetric Light -> World -> Translucenct Materials`, now it is `World -> Translucent Materials -> Volumetric Light`. As a side effect, the world shader is now also subject to light scattering, but god rays still work exactly as before. We discussed this a little on the Discord server and came to the conclusion that this change is acceptable and more correct.

I wasn't sure whether it is required to unbind depth for the volumetric lighting like it was done before, but it isn't done in the forward render path and it worked without issues on Krom (DirectX), html5 and HL (DirectX) on many different example files. On OpenGL platforms the depth un-binding is disabled anyways.