### PR TITLE
Fix for point lights and translucency

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -481,6 +481,11 @@ void main() {
 			, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w) // scale
 			, lightsArraySpot[li * 2 + 1].xyz // right
 			#endif
+			#ifdef _VoxelAOvar
+			#ifdef _VoxelShadow
+			, voxels, voxpos
+			#endif
+			#endif
 			#ifdef _MicroShadowing
 			, occspec.x
 			#endif

--- a/Shaders/water_pass/water_pass.frag.glsl
+++ b/Shaders/water_pass/water_pass.frag.glsl
@@ -177,7 +177,7 @@ void main() {
 	#endif
 	intensity = clamp(intensity, 0.0, 1.0);
 	vec3 reflCol = textureLod(tex, coords.xy, 0.0).rgb;
-	fragColor.rgb = mix(refracted, reflectedEnv * reflCol, fresnel * waterReflect);
+	fragColor.rgb = coords.rgb;//mix(refracted, reflCol, waterReflect);
 	fragColor.rgb *= waterColor;
 	fragColor.rgb += clamp(pow(max(dot(r, ld), 0.0), 200.0) * (200.0 + 8.0) / (PI * 8.0), 0.0, 2.0);
 	fragColor.rgb *= 1.0 - (clamp(-(p.z - waterLevel) * waterDensity, 0.0, 0.9));

--- a/Shaders/water_pass/water_pass.frag.glsl
+++ b/Shaders/water_pass/water_pass.frag.glsl
@@ -5,12 +5,21 @@
 #include "std/math.glsl"
 
 uniform sampler2D gbufferD;
+uniform sampler2D gbuffer0; // Normal, roughness
+uniform sampler2D gbuffer1; // basecol, spec
 uniform sampler2D tex;
 uniform sampler2D sbase;
 uniform sampler2D sdetail;
 uniform sampler2D sfoam;
+uniform mat4 P;
+uniform mat3 V3;
 #ifdef _Rad
 uniform sampler2D senvmapRadiance;
+#endif
+
+#ifdef _CPostprocess
+uniform vec3 PPComp9;
+uniform vec3 PPComp10;
 #endif
 
 uniform float time;
@@ -24,8 +33,60 @@ in vec2 texCoord;
 in vec3 viewRay;
 out vec4 fragColor;
 
-void main() {
+vec3 hitCoord;
+float depth;
 
+const int numBinarySearchSteps = 7;
+const int maxSteps = 18;
+
+vec2 getProjectedCoord(const vec3 hit) {
+	vec4 projectedCoord = P * vec4(hit, 1.0);
+	projectedCoord.xy /= projectedCoord.w;
+	projectedCoord.xy = projectedCoord.xy * 0.5 + 0.5;
+	#ifdef _InvY
+	projectedCoord.y = 1.0 - projectedCoord.y;
+	#endif
+	return projectedCoord.xy;
+}
+
+float getDeltaDepth(const vec3 hit) {
+	depth = textureLod(gbufferD, getProjectedCoord(hit), 0.0).r * 2.0 - 1.0;
+	vec3 viewPos = getPosView(viewRay, depth, cameraProj);
+	return viewPos.z - hit.z;
+}
+
+vec4 binarySearch(vec3 dir) {
+	float ddepth;
+	vec3 start = hitCoord;
+	for (int i = 0; i < numBinarySearchSteps; i++) {
+		dir *= 0.5;
+		hitCoord -= dir;
+		ddepth = getDeltaDepth(hitCoord);
+		if (ddepth < 0.0) hitCoord += dir;
+	}
+	// Ugly discard of hits too far away
+	#ifdef _CPostprocess
+		if (abs(ddepth) > PPComp9.z / 500) return vec4(0.0);
+	#else
+		if (abs(ddepth) > ssrSearchDist / 500) return vec4(0.0);
+	#endif
+	return vec4(getProjectedCoord(hitCoord), 0.0, 1.0);
+}
+
+vec4 rayCast(vec3 dir) {
+	#ifdef _CPostprocess
+		dir *= PPComp9.x;
+	#else
+		dir *= ssrRayStep;
+	#endif
+	for (int i = 0; i < maxSteps; i++) {
+		hitCoord += dir;
+		if (getDeltaDepth(hitCoord) > 0.0) return binarySearch(dir);
+	}
+	return vec4(0.0);
+}
+
+void main() {
 	float gdepth = textureLod(gbufferD, texCoord, 0.0).r * 2.0 - 1.0;
 	if (gdepth == 1.0) {
 		fragColor = vec4(0.0);
@@ -37,7 +98,6 @@ void main() {
 		fragColor = vec4(0.0);
 		return;
 	}
-
 	// Displace surface
 	vec3 vray = normalize(viewRay);
 	vec3 p = getPos(eye, eyeLook, vray, gdepth, cameraProj);
@@ -49,14 +109,13 @@ void main() {
 		fragColor = vec4(0.0);
 		return;
 	}
-
 	// Hit plane to determine uvs
 	vec3 v = normalize(eye - p.xyz);
 	float t = -(dot(eye, vec3(0.0, 0.0, 1.0)) - waterLevel) / dot(v, vec3(0.0, 0.0, 1.0));
 	vec3 hit = eye + t * v;
 	hit.xy *= waterFreq;
 	hit.z += waterLevel;
-
+	
 	// Sample normal maps
 	vec2 tcnor0 = hit.xy / 3.0;
 	vec3 n0 = textureLod(sdetail, tcnor0 + vec2(speed / 60.0, speed / 120.0), 0.0).rgb;
@@ -74,12 +133,51 @@ void main() {
 	fresnel = pow(fresnel, 30.0) * 0.45;
 	vec3 r = reflect(-v, n2);
 	#ifdef _Rad
-	vec3 reflected =  textureLod(senvmapRadiance, envMapEquirect(r), 0).rgb;
+	vec3 reflectedEnv =  textureLod(senvmapRadiance, envMapEquirect(r), 0).rgb;
 	#else
-	const vec3 reflected = vec3(0.5);
+	const vec3 reflectedEnv = vec3(0.5);
 	#endif
 	vec3 refracted = textureLod(tex, tc, 0.0).rgb;
-	fragColor.rgb = mix(refracted, reflected, fresnel * waterReflect);
+	
+	vec4 g0 = textureLod(gbuffer0, texCoord, 0.0);
+	float roughness = unpackFloat(g0.b).y;
+	if (roughness == 1.0) { fragColor.rgb = vec3(0.0); return; }
+
+	float spec = fract(textureLod(gbuffer1, texCoord, 0.0).a);
+	if (spec == 0.0) { fragColor.rgb = vec3(0.0); return; }
+	
+	vec2 enc = g0.rg;
+	vec3 n;
+	n.z = 1.0 - abs(enc.x) - abs(enc.y);
+	n.xy = n.z >= 0.0 ? enc.xy : octahedronWrap(enc.xy);
+	n = normalize(n);
+
+	vec3 viewNormal = V3 * n;
+	vec3 viewPos = getPosView(viewRay, gdepth, cameraProj);
+	vec3 reflected = normalize(reflect(viewPos, viewNormal));
+	hitCoord = viewPos;
+
+	#ifdef _CPostprocess
+		vec3 dir = reflected * (1.0 - rand(texCoord) * PPComp10.y * roughness) * 2.0;
+	#else
+		vec3 dir = reflected * (1.0 - rand(texCoord) * ssrJitter * roughness) * 2.0;
+	#endif
+
+	// * max(ssrMinRayStep, -viewPos.z)
+	vec4 coords = rayCast(dir);
+
+	vec2 deltaCoords = abs(vec2(0.5, 0.5) - coords.xy);
+	float screenEdgeFactor = clamp(1.0 - (deltaCoords.x + deltaCoords.y), 0.0, 1.0);
+
+	float reflectivity = 1.0 - roughness;
+	#ifdef _CPostprocess
+		float intensity = pow(reflectivity, PPComp10.x) * screenEdgeFactor * clamp(-reflected.z, 0.0, 1.0) * clamp((PPComp9.z - length(viewPos - hitCoord)) * (1.0 / PPComp9.z), 0.0, 1.0) * coords.w;
+	#else
+		float intensity = pow(reflectivity, ssrFalloffExp) * screenEdgeFactor * clamp(-reflected.z, 0.0, 1.0) * clamp((ssrSearchDist - length(viewPos - hitCoord)) * (1.0 / ssrSearchDist), 0.0, 1.0) * coords.w;
+	#endif
+	intensity = clamp(intensity, 0.0, 1.0);
+	vec3 reflCol = textureLod(tex, coords.xy, 0.0).rgb;
+	fragColor.rgb = mix(refracted, reflectedEnv * reflCol, fresnel * waterReflect);
 	fragColor.rgb *= waterColor;
 	fragColor.rgb += clamp(pow(max(dot(r, ld), 0.0), 200.0) * (200.0 + 8.0) / (PI * 8.0), 0.0, 2.0);
 	fragColor.rgb *= 1.0 - (clamp(-(p.z - waterLevel) * waterDensity, 0.0, 0.9));

--- a/Shaders/water_pass/water_pass.json
+++ b/Shaders/water_pass/water_pass.json
@@ -56,6 +56,14 @@
 					"name": "senvmapRadiance",
 					"link": "_envmapRadiance",
 					"ifdef": ["_Rad"]
+				},
+				{
+					"name": "P",
+					"link": "_projectionMatrix"
+				},
+				{
+					"name": "V3",
+					"link": "_viewMatrix3"
 				}
 			],
 			"texture_params": [],

--- a/Shaders/water_pass/water_pass.json
+++ b/Shaders/water_pass/water_pass.json
@@ -2,7 +2,7 @@
 	"contexts": [
 		{
 			"name": "water_pass",
-			"depth_write": false,
+			"depth_write": true,
 			"compare_mode": "always",
 			"cull_mode": "none",
 			"blend_source": "source_alpha",

--- a/Shaders/water_pass/water_pass.json
+++ b/Shaders/water_pass/water_pass.json
@@ -2,7 +2,7 @@
 	"contexts": [
 		{
 			"name": "water_pass",
-			"depth_write": true,
+			"depth_write": false,
 			"compare_mode": "always",
 			"cull_mode": "none",
 			"blend_source": "source_alpha",

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -402,6 +402,10 @@ class Inc {
 			#end
 		}
 		#end
+		
+		path.bindTarget("_main", "gbufferD");
+		path.bindTarget("gbuffer0", "gbuffer0");
+		path.bindTarget("gbuffer1", "gbuffer0");
 		path.drawMeshes("translucent");
 		#if rp_render_to_texture
 		{

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -414,7 +414,6 @@ class Inc {
 		#end
 		path.bindTarget("accum", "gbuffer0");
 		path.bindTarget("revealage", "gbuffer1");
-		path.bindTarget("gbufferD", "gbufferD");
 		path.drawShader("shader_datas/translucent_resolve/translucent_resolve");
 	}
 	#end

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -414,6 +414,7 @@ class Inc {
 		#end
 		path.bindTarget("accum", "gbuffer0");
 		path.bindTarget("revealage", "gbuffer1");
+		path.bindTarget("gbufferD", "gbufferD");
 		path.drawShader("shader_datas/translucent_resolve/translucent_resolve");
 	}
 	#end

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -405,7 +405,7 @@ class Inc {
 		
 		path.bindTarget("_main", "gbufferD");
 		path.bindTarget("gbuffer0", "gbuffer0");
-		path.bindTarget("gbuffer1", "gbuffer0");
+		path.bindTarget("gbuffer1", "gbuffer1");
 		path.drawMeshes("translucent");
 		#if rp_render_to_texture
 		{

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -557,7 +557,6 @@ class RenderPathDeferred {
 			}
 		}
 		#end
-
 		// ---
 		// Deferred light
 		// ---
@@ -680,7 +679,7 @@ class RenderPathDeferred {
 			Inc.drawTranslucency("tex");
 		}
 		#end
-
+		
 		#if rp_volumetriclight
 		{
 			path.setTarget("singlea");

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -649,6 +649,8 @@ class RenderPathDeferred {
 			path.drawShader("shader_datas/copy_pass/copy_pass");
 			path.setTarget("tex");
 			path.bindTarget("_main", "gbufferD");
+			path.bindTarget("gbuffer0", "gbuffer0");
+			path.bindTarget("gbuffer1", "gbuffer1");
 			path.bindTarget("buf", "tex");
 			path.drawShader("shader_datas/water_pass/water_pass");
 		}

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -651,28 +651,9 @@ class RenderPathDeferred {
 			path.setTarget("tex");
 			path.bindTarget("_main", "gbufferD");
 			path.bindTarget("buf", "tex");
+			path.bindTarget("gbuffer0", "gbuffer0");
+			path.bindTarget("gbuffer1", "gbuffer1");	
 			path.drawShader("shader_datas/water_pass/water_pass");
-		}
-		#end
-
-		#if rp_volumetriclight
-		{
-			path.setTarget("singlea");
-			path.bindTarget("_main", "gbufferD");
-						#if arm_shadowmap_atlas
-			Inc.bindShadowMapAtlas();
-			#else
-			Inc.bindShadowMap();
-			#end
-			path.drawShader("shader_datas/volumetric_light/volumetric_light");
-
-			path.setTarget("singleb");
-			path.bindTarget("singlea", "tex");
-			path.drawShader("shader_datas/blur_bilat_pass/blur_bilat_pass_x");
-
-			path.setTarget("tex");
-			path.bindTarget("singleb", "tex");
-			path.drawShader("shader_datas/blur_bilat_blend_pass/blur_bilat_blend_pass_y");
 		}
 		#end
 
@@ -699,6 +680,27 @@ class RenderPathDeferred {
 		#if rp_translucency
 		{
 			Inc.drawTranslucency("tex");
+		}
+		#end
+
+		#if rp_volumetriclight
+		{
+			path.setTarget("singlea");
+			path.bindTarget("_main", "gbufferD");
+			#if arm_shadowmap_atlas
+			Inc.bindShadowMapAtlas();
+			#else
+			Inc.bindShadowMap();
+			#end
+			path.drawShader("shader_datas/volumetric_light/volumetric_light");
+
+			path.setTarget("singleb");
+			path.bindTarget("singlea", "tex");
+			path.drawShader("shader_datas/blur_bilat_pass/blur_bilat_pass_x");
+
+			path.setTarget("tex");
+			path.bindTarget("singleb", "tex");
+			path.drawShader("shader_datas/blur_bilat_blend_pass/blur_bilat_blend_pass_y");
 		}
 		#end
 
@@ -993,3 +995,4 @@ class RenderPathDeferred {
 	}
 	#end
 }
+

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -993,4 +993,3 @@ class RenderPathDeferred {
 	}
 	#end
 }
-

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -651,8 +651,6 @@ class RenderPathDeferred {
 			path.setTarget("tex");
 			path.bindTarget("_main", "gbufferD");
 			path.bindTarget("buf", "tex");
-			path.bindTarget("gbuffer0", "gbuffer0");
-			path.bindTarget("gbuffer1", "gbuffer1");	
 			path.drawShader("shader_datas/water_pass/water_pass");
 		}
 		#end

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -24,9 +24,11 @@ def add_world_defs():
     # Screen-space ray-traced shadows
     if rpdat.arm_ssrs:
         wrd.world_defs += '_SSRS'
+        assets.add_khafile_def('rp_ssrs')
 
     if rpdat.arm_micro_shadowing:
         wrd.world_defs += '_MicroShadowing'
+        assets.add_khafile_def('rp_microshadowing')
 
     if rpdat.arm_two_sided_area_light:
         wrd.world_defs += '_TwoSidedAreaLight'

--- a/blender/arm/material/make_attrib.py
+++ b/blender/arm/material/make_attrib.py
@@ -6,6 +6,7 @@ import arm.material.make_skin as make_skin
 import arm.material.make_particle as make_particle
 import arm.material.make_inst as make_inst
 import arm.material.make_tess as make_tess
+import arm.material.mat_utils as mat_utils
 import arm.material.make_morph_target as make_morph_target
 from arm.material.shader import Shader, ShaderContext
 import arm.utils
@@ -72,8 +73,12 @@ def write_norpos(con_mesh: ShaderContext, vert: Shader, declare=False, write_nor
 
 def write_tex_coords(con_mesh: ShaderContext, vert: Shader, frag: Shader, tese: Optional[Shader]):
     rpdat = arm.utils.get_rp()
+    rpasses = mat_utils.get_rpasses(con_mesh.material)
+    for rp in rpasses:
+        if rp == 'translucent':
+        	is_transluc = True
 
-    if con_mesh.is_elem('tex'):
+    if con_mesh.is_elem('tex') or is_transluc:
         vert.add_out('vec2 texCoord')
         vert.add_uniform('float texUnpack', link='_texUnpack')
         if mat_state.material.arm_tilesheet_flag:
@@ -87,7 +92,7 @@ def write_tex_coords(con_mesh: ShaderContext, vert: Shader, frag: Shader, tese: 
 
         if tese is not None:
             tese.write_pre = True
-            make_tess.interpolate(tese, 'texCoord', 2, declare_out=frag.contains('texCoord'))
+            make_tess.interpolate(tese, 'texCoord', 2, declare_out=True)
             tese.write_pre = False
 
     if con_mesh.is_elem('tex1'):

--- a/blender/arm/material/make_attrib.py
+++ b/blender/arm/material/make_attrib.py
@@ -78,7 +78,7 @@ def write_tex_coords(con_mesh: ShaderContext, vert: Shader, frag: Shader, tese: 
         if rp == 'translucent':
         	is_transluc = True
 
-    if con_mesh.is_elem('tex') or is_transluc:
+    if con_mesh.is_elem('tex'):
         vert.add_out('vec2 texCoord')
         vert.add_uniform('float texUnpack', link='_texUnpack')
         if mat_state.material.arm_tilesheet_flag:

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -5,7 +5,7 @@ def write(vert, frag):
     wrd = bpy.data.worlds['Arm']
     is_shadows = '_ShadowMap' in wrd.world_defs
     is_shadows_atlas = '_ShadowMapAtlas' in wrd.world_defs
-    is_single_atlas = '_SingleAtlas' in wrd.world_defs
+    is_single_atlas = is_shadows_atlas and '_SingleAtlas' in wrd.world_defs
 
     frag.add_include_front('std/clusters.glsl')
     frag.add_uniform('vec2 cameraProj', link='_cameraPlaneProj')
@@ -25,8 +25,6 @@ def write(vert, frag):
             frag.add_uniform('samplerCubeShadow shadowMapPoint[4]', included=True)
 
     vert.add_out('vec4 wvpposition')
-    if arm.utils.get_rp().arm_rp_displacement == 'Tessellation':
-    	frag.add_in('vec4 wvpposition')
 
     vert.write('wvpposition = gl_Position;')
     # wvpposition.z / wvpposition.w
@@ -58,17 +56,33 @@ def write(vert, frag):
 
     if '_MicroShadowing' in wrd.world_defs:
         frag.add_include('std/gbuffer.glsl')
+        frag.add_uniform('sampler2D gbuffer0')
         frag.add_uniform('sampler2D gbuffer1')
-        frag.add_in('vec2 texCoord')
+        frag.add_uniform('sampler2D gbufferD')
+        frag.add_uniform('vec3 eyeLook', link='_cameraLook')
+        frag.write('vec4 g0 = textureLod(gbuffer0, texCoord, 0.0);')
+        frag.write('vec3 n2;')
+        frag.write('n2.z = 1.0 - abs(g0.x) - abs(g0.y);')
+        frag.write('n2.xy = n2.z >= 0.0 ? g0.xy : octahedronWrap(g0.xy);')
+        frag.write('n2 = normalize(n2);')
         frag.write('vec4 g1 = textureLod(gbuffer1, texCoord, 0.0);')
         frag.write('vec2 occspec = unpackFloat2(g1.a);')
-        frag.write('occspec.x = mix(1.0, occspec.x, dotNV); // AO Fresnel')
+        frag.write('float depth = textureLod(gbufferD, texCoord, 0.0).r * 2.0 - 1.0;')
+        frag.write('vec3 p = getPos(eye, eyeLook, normalize(viewRay), depth, cameraProj);')
+        frag.write('vec3 v = normalize(eye - p);')
+        frag.write('float dotNV2 = max(dot(n2, v), 0.0);')
+        frag.write('occspec.x = mix(1.0, occspec.x, dotNV2); // AO Fresnel')
 
     frag.write('direct += sampleLight(')
     frag.write('    wposition,')
-    frag.write('    n,')
-    frag.write('    vVec,')
-    frag.write('    dotNV,')
+    if 'Microshadowing' in wrd.world_defs:
+        frag.write('    n2,')
+        frag.write('    vVec,')
+        frag.write('    dotNV2,')
+    else:
+        frag.write('    n,')
+        frag.write('    vVec,')
+        frag.write('    dotNV,')
     frag.write('    lightsArray[li * 3].xyz,') # lp
     frag.write('    lightsArray[li * 3 + 1].xyz,') # lightCol
     frag.write('    albedo,')
@@ -89,7 +103,8 @@ def write(vert, frag):
     if '_MicroShadowing' in wrd.world_defs:
         frag.write(' , occspec.x')
     if '_SSRS' in wrd.world_defs:
-        frag.add_uniform('sampler2D gbufferD')
+        if not '_Microshadowing' in wrd.world_defs:
+            frag.add_uniform('sampler2D gbufferD')
         frag.add_uniform('mat4 invVP')
        	frag.write(' , gbufferD, invVP, eye')
     frag.write(');')

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -1,4 +1,5 @@
 import bpy
+import arm.utils
 
 def write(vert, frag):
     wrd = bpy.data.worlds['Arm']
@@ -22,7 +23,11 @@ def write(vert, frag):
             frag.add_uniform('vec4 pointLightDataArray[maxLightsCluster]', link='_pointLightsAtlasArray', included=True)
         else:
             frag.add_uniform('samplerCubeShadow shadowMapPoint[4]', included=True)
+
     vert.add_out('vec4 wvpposition')
+    if arm.utils.get_rp().arm_rp_displacement == 'Tessellation':
+    	frag.add_in('vec4 wvpposition')
+
     vert.write('wvpposition = gl_Position;')
     # wvpposition.z / wvpposition.w
     frag.write('float viewz = linearize(gl_FragCoord.z, cameraProj);')
@@ -51,6 +56,14 @@ def write(vert, frag):
     frag.write('for (int i = 0; i < min(numLights, maxLightsCluster); i++) {')
     frag.write('int li = int(texelFetch(clustersData, ivec2(clusterI, i + 1), 0).r * 255);')
 
+    if '_MicroShadowing' in wrd.world_defs:
+        frag.add_include('std/gbuffer.glsl')
+        frag.add_uniform('sampler2D gbuffer1')
+        frag.add_in('vec2 texCoord')
+        frag.write('vec4 g1 = textureLod(gbuffer1, texCoord, 0.0);')
+        frag.write('vec2 occspec = unpackFloat2(g1.a);')
+        frag.write('occspec.x = mix(1.0, occspec.x, dotNV); // AO Fresnel')
+
     frag.write('direct += sampleLight(')
     frag.write('    wposition,')
     frag.write('    n,')
@@ -73,6 +86,12 @@ def write(vert, frag):
         frag.write('\t, lightsArraySpot[li * 2 + 1].xyz') # right
     if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:
         frag.write('  , voxels, voxpos')
+    if '_MicroShadowing' in wrd.world_defs:
+        frag.write(' , occspec.x')
+    if '_SSRS' in wrd.world_defs:
+        frag.add_uniform('sampler2D gbufferD')
+        frag.add_uniform('mat4 invVP')
+       	frag.write(' , gbufferD, invVP, eye')
     frag.write(');')
 
     frag.write('}') # for numLights

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -590,7 +590,6 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
 
     frag.write_attrib('vec3 vVec = normalize(eyeDir);')
     frag.write_attrib('float dotNV = max(dot(n, vVec), 0.0);')
-
     sh = tese if tese is not None else vert
     sh.add_out('vec3 eyeDir')
     sh.add_uniform('vec3 eye', '_cameraPosition')
@@ -708,6 +707,21 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
             else:
                 frag.add_uniform('vec2 lightProj', link='_lightPlaneProj', included=True)
                 frag.add_uniform('samplerCubeShadow shadowMapPoint[1]', included=True)
+        if '_MicroShadowing' in wrd.world_defs:
+            frag.add_include('std/gbuffer.glsl')
+            frag.add_uniform('sampler2D gbuffer1')
+            frag.add_uniform('sampler2D gbufferD')
+            frag.add_uniform('vec3 eyeLook')
+            frag.add_uniform('vec2 cameraProj')
+            frag.add_in('vec2 texCoord')
+            frag.add_in('vec3 viewRay')
+            frag.write('vec4 g1 = textureLod(gbuffer1, texCoord, 0.0);')
+            frag.write('vec2 occspec = unpackFloat2(g1.a);')
+            frag.write('float depth = textureLod(gbufferD, texCoord, 0.0).r * 2.0 - 1.0;')
+            frag.write('vec3 p = getPos(eye, eyeLook, normalize(viewRay), depth, cameraProj);')
+            frag.write('vec3 v = normalize(eye - p);')
+            frag.write('occspec.x = mix(1.0, occspec.x, dotNV); // AO Fresnel')
+
         frag.write('direct += sampleLight(')
         frag.write('  wposition, n, vVec, dotNV, pointPos, pointCol, albedo, roughness, specular, f0')
         if is_shadows:
@@ -717,12 +731,11 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
         if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:
             frag.write('  , voxels, voxpos')
         if '_MicroShadowing' in wrd.world_defs:
-            frag.add_uniform('float occ')
-            frag.write(' , occ')
+            frag.write(' , occspec.x')
         if '_SSRS' in wrd.world_defs:
-            frag.add_include('std/ssrs.glsl')
+       	    frag.add_include('std/ssrs.glsl')
+            frag.add_uniform('sampler2D gbufferD')
             frag.add_uniform('mat4 invVP')
-            frag.add_uniform('sampler2D gbufferD') 
        	    frag.write(' , gbufferD, invVP, eye')
         frag.write(');')
 

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -710,16 +710,9 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
         if '_MicroShadowing' in wrd.world_defs:
             frag.add_include('std/gbuffer.glsl')
             frag.add_uniform('sampler2D gbuffer1')
-            frag.add_uniform('sampler2D gbufferD')
-            frag.add_uniform('vec3 eyeLook')
-            frag.add_uniform('vec2 cameraProj')
             frag.add_in('vec2 texCoord')
-            frag.add_in('vec3 viewRay')
             frag.write('vec4 g1 = textureLod(gbuffer1, texCoord, 0.0);')
             frag.write('vec2 occspec = unpackFloat2(g1.a);')
-            frag.write('float depth = textureLod(gbufferD, texCoord, 0.0).r * 2.0 - 1.0;')
-            frag.write('vec3 p = getPos(eye, eyeLook, normalize(viewRay), depth, cameraProj);')
-            frag.write('vec3 v = normalize(eye - p);')
             frag.write('occspec.x = mix(1.0, occspec.x, dotNV); // AO Fresnel')
 
         frag.write('direct += sampleLight(')
@@ -733,7 +726,6 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
         if '_MicroShadowing' in wrd.world_defs:
             frag.write(' , occspec.x')
         if '_SSRS' in wrd.world_defs:
-       	    frag.add_include('std/ssrs.glsl')
             frag.add_uniform('sampler2D gbufferD')
             frag.add_uniform('mat4 invVP')
        	    frag.write(' , gbufferD, invVP, eye')

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -716,6 +716,14 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
             frag.write('  , true, spotData.x, spotData.y, spotDir, spotData.zw, spotRight')
         if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:
             frag.write('  , voxels, voxpos')
+        if '_MicroShadowing' in wrd.world_defs:
+            frag.add_uniform('float occ')
+            frag.write(' , occ')
+        if '_SSRS' in wrd.world_defs:
+            frag.add_include('std/ssrs.glsl')
+            frag.add_uniform('mat4 invVP')
+            frag.add_uniform('sampler2D gbufferD') 
+       	    frag.write(' , gbufferD, invVP, eye')
         frag.write(');')
 
     if '_Clusters' in wrd.world_defs:

--- a/blender/arm/material/make_transluc.py
+++ b/blender/arm/material/make_transluc.py
@@ -18,7 +18,7 @@ else:
 
 
 def make(context_id):
-	con_transluc = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'less', 'cull_mode': 'none', \
+	con_transluc = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'less', 'cull_mode': 'clockwise', \
 		'blend_source': 'blend_one', 'blend_destination': 'blend_one', 'blend_operation': 'add', \
 		'alpha_blend_source': 'blend_zero', 'alpha_blend_destination': 'inverse_source_alpha', 'alpha_blend_operation': 'add' })
 

--- a/blender/arm/material/make_transluc.py
+++ b/blender/arm/material/make_transluc.py
@@ -18,7 +18,7 @@ else:
 
 
 def make(context_id):
-	con_transluc = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'less', 'cull_mode': 'clockwise', \
+	con_transluc = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'less', 'cull_mode': 'none', \
 		'blend_source': 'blend_one', 'blend_destination': 'blend_one', 'blend_operation': 'add', \
 		'alpha_blend_source': 'blend_zero', 'alpha_blend_destination': 'inverse_source_alpha', 'alpha_blend_operation': 'add' })
 

--- a/blender/arm/material/make_transluc.py
+++ b/blender/arm/material/make_transluc.py
@@ -18,9 +18,10 @@ else:
 
 
 def make(context_id):
-	con_transluc = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'less', 'cull_mode': 'clockwise', \
+	vs = [{'name': 'pos', 'data': 'float4'}, {'name': 'nor', 'data': 'float3'}, {'name': 'tex', 'data': 'float2'}] 
+	con_transluc = mat_state.data.add_context({'vertex_elements': vs,  'name': context_id, 'depth_write': False, 'compare_mode': 'less', 'cull_mode': 'clockwise', \
 		'blend_source': 'blend_one', 'blend_destination': 'blend_one', 'blend_operation': 'add', \
-		'alpha_blend_source': 'blend_zero', 'alpha_blend_destination': 'inverse_source_alpha', 'alpha_blend_operation': 'add' })
+		'alpha_blend_source': 'blend_zero', 'alpha_blend_destination': 'inverse_source_alpha', 'alpha_blend_operation': 'add'})
 
 	make_mesh.make_forward_base(con_transluc, parse_opacity=True, transluc_pass=True)
 


### PR DESCRIPTION
There was a bug with translucent materials, when calling make_forward_base() and a point light is used, the number of arguments passed to sampleLight in the shader doesn't correspond with the definition.
Because the definition takes into account the SSRS and Microshadowing options, but not the part that I had to modify.
I'm not sure this is the proper way of setting the options, since it does only concern the point lights, I don't know about spots nor areas.
Seems effective though, with a glass candlestick and tesselation it looks like this:
None:
![Capture d’écran du 2022-07-25 13-54-18](https://user-images.githubusercontent.com/29781855/180775253-de6e4ad5-e3d5-4af0-85f8-9851fcb42107.png)
Microshadowing:
![Capture d’écran du 2022-07-25 13-54-40](https://user-images.githubusercontent.com/29781855/180775367-608f2cff-1360-4037-bd4a-1505db624f59.png)
Microshadowing and ssrs:
![Capture d’écran du 2022-07-25 13-55-02](https://user-images.githubusercontent.com/29781855/180775420-581b4018-c81a-4769-8e28-774ae7e3fceb.png)
ssrs without microshadowing:

Thing is microshadowing with ssr on seems to have no effect, we can see the wood being more lit hence some of it we can see through the glass ; but not on the glass itself.
![Capture d’écran du 2022-07-25 13-58-58](https://user-images.githubusercontent.com/29781855/180775484-71f735fa-268d-4a6b-baf4-830be46b7746.png)