### PR TITLE
Tree variables: fix missing synchronization when adding getters/setters

### DIFF
--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -407,6 +407,14 @@ class ArmLogicVariableNodeMixin(ArmLogicTreeNode):
         else:
             return f'TV: {self.arm_logic_id}'
 
+    @classmethod
+    def synchronize(cls, tree: bpy.types.NodeTree, logic_id: str):
+        """Synchronizes the value of the master node of the given
+        `logic_id` to all replica nodes.
+        """
+        master_node = cls.get_master_node(tree, logic_id)
+        master_node._synchronize_to_replicas(master_node)
+
     @staticmethod
     def choose_new_master_node(tree: bpy.types.NodeTree, logic_id: str) -> bool:
         """Choose a new master node from the remaining replica nodes.

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -213,8 +213,7 @@ class ARM_OT_TreeVariableVariableAssignToNode(bpy.types.Operator):
         node.arm_logic_id = var_item.name
         node.use_custom_color = True
         node.color = var_item.color
-        master_node = arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.get_master_node(tree, node.arm_logic_id)
-        master_node._synchronize_to_replicas(master_node)
+        arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.synchronize(tree, node.arm_logic_id)
 
         return {'FINISHED'}
 
@@ -294,6 +293,8 @@ class ARM_OT_AddVarGetterNode(bpy.types.Operator):
         node.arm_logic_id = node_id
         node.use_custom_color = True
         node.color = tree.arm_treevariableslist[tree.arm_treevariableslist_index].color
+
+        arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.synchronize(tree, node.arm_logic_id)
 
         return node
 
@@ -515,6 +516,14 @@ def node_compat_sdk2203():
                     node.color = var_item.color
 
                 arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.choose_new_master_node(tree, logic_id)
+
+
+def node_compat_sdk2209():
+    # See https://github.com/armory3d/armory/pull/2538
+    for tree in bpy.data.node_groups:
+        if tree.bl_idname == "ArmLogicTreeType":
+            for item in tree.arm_treevariableslist:
+                arm.logicnode.arm_nodes.ArmLogicVariableNodeMixin.synchronize(tree, item.name)
 
 
 REG_CLASSES = (

--- a/blender/arm/make_logic.py
+++ b/blender/arm/make_logic.py
@@ -172,7 +172,7 @@ def build_node(node: bpy.types.Node, f: TextIO, name_prefix: str = None) -> Opti
     if name_prefix is not None:
         name = name_prefix + name
 
-    # Link nodes using IDs
+    # Link tree variable nodes using IDs
     if node.arm_logic_id != '':
         parse_id = node.arm_logic_id
         if name_prefix is not None:

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -537,6 +537,8 @@ def update_armory_world():
             arm.logicnode.replacement.node_compat_sdk2108()
         if file_version < (2022, 3):
             arm.logicnode.tree_variables.node_compat_sdk2203()
+        if file_version < (2022, 9):
+            arm.logicnode.tree_variables.node_compat_sdk2209()
 
         arm.logicnode.replacement.replace_all()
 


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2504.

Adding getters/setters for tree variables did not synchronize the variable values from the master node to all replica nodes, and because only the first logic node for a given variable is exported in place for all other nodes of the same variable, there was a race condition depending on which node was exported first. Files saved before the next SDK 22.09 will be automatically fixed upon loading.