### PR TITLE
Fix initialization of tween and group nodes and ensure correct file version numbers

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -149,6 +149,15 @@ context_screen = None
 
 
 @persistent
+def on_save_pre(context):
+    # Ensure that files are saved with the correct version number
+    # (e.g. startup files with an "Arm" world may have old version numbers)
+    wrd = bpy.data.worlds['Arm']
+    wrd.arm_version = props.arm_version
+    wrd.arm_commit = props.arm_commit
+
+
+@persistent
 def on_load_pre(context):
     unload_py_libraries()
 
@@ -244,6 +253,7 @@ def load_library(asset_name):
 
 
 def register():
+    bpy.app.handlers.save_pre.append(on_save_pre)
     bpy.app.handlers.load_pre.append(on_load_pre)
     bpy.app.handlers.load_post.append(on_load_post)
     bpy.app.handlers.depsgraph_update_post.append(on_depsgraph_update_post)
@@ -272,5 +282,6 @@ def unregister():
 
     bpy.app.handlers.load_post.remove(on_load_post)
     bpy.app.handlers.load_pre.remove(on_load_pre)
+    bpy.app.handlers.save_pre.remove(on_save_pre)
     bpy.app.handlers.depsgraph_update_post.remove(on_depsgraph_update_post)
     # bpy.app.handlers.undo_post.remove(on_undo_post)

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -47,6 +47,7 @@ class ArmLogicTreeNode(bpy.types.Node):
     arm_section = 'default'
     arm_is_obsolete = False
 
+    @final
     def init(self, context):
         # make sure a given node knows the version of the NodeClass from when it was created
         if isinstance(type(self).arm_version, int):

--- a/blender/arm/logicnode/math/LN_tween_float.py
+++ b/blender/arm/logicnode/math/LN_tween_float.py
@@ -1,30 +1,24 @@
 from arm.logicnode.arm_nodes import *
 
-class TweenFloatNode( ArmLogicTreeNode):
-    '''Tween a float value
-    
+
+class TweenFloatNode(ArmLogicTreeNode):
+    """Tween a float value.
+
     @input Start: Start tweening
-     
     @input Stop: Stop a tweening. tweening can be re-started via the `Start`input
-
     @input From: Tween start value
-
     @input To: Tween final value
-
     @input Duration: Duartion of the tween in seconds
 
     @output Out: Executed immidiately after `Start` or `Stop` is called
-
     @output Tick: Executed at every time step in the tween duration
-
     @output Done: Executed when tween is successfully completed. Not executed if tweening is stopped mid-way
-
     @output Value: Current tween value
-    '''
+    """
     bl_idname = 'LNTweenFloatNode'
     bl_label = 'Tween Float'
     arm_version = 1
-    
+
     property0: HaxeEnumProperty(
         'property0',
         items = [('Linear', 'Linear', 'Linear'),
@@ -57,10 +51,10 @@ class TweenFloatNode( ArmLogicTreeNode):
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'Start')
         self.add_input('ArmNodeSocketAction', 'Stop')
-        self.add_input('ArmFloatSocket', 'From', default_value = 0.0)
-        self.add_input('ArmFloatSocket', 'To', default_value = 0.0)
-        self.add_input('ArmFloatSocket', 'Duration', default_value = 1.0)
-        
+        self.add_input('ArmFloatSocket', 'From', default_value=0.0)
+        self.add_input('ArmFloatSocket', 'To', default_value=0.0)
+        self.add_input('ArmFloatSocket', 'Duration', default_value=1.0)
+
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Tick')
         self.add_output('ArmNodeSocketAction', 'Done')
@@ -68,6 +62,6 @@ class TweenFloatNode( ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-    
+
     def draw_label(self) -> str:
         return f'{self.bl_label}: {self.property0}'

--- a/blender/arm/logicnode/math/LN_tween_float.py
+++ b/blender/arm/logicnode/math/LN_tween_float.py
@@ -54,7 +54,7 @@ class TweenFloatNode( ArmLogicTreeNode):
                 ('BackInOut', 'BackInOut', 'BackInOut')],
         name='', default='Linear')
 
-    def init(self, context):
+    def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'Start')
         self.add_input('ArmNodeSocketAction', 'Stop')
         self.add_input('ArmFloatSocket', 'From', default_value = 0.0)

--- a/blender/arm/logicnode/math/LN_tween_rotation.py
+++ b/blender/arm/logicnode/math/LN_tween_rotation.py
@@ -1,30 +1,24 @@
 from arm.logicnode.arm_nodes import *
 
-class TweenFloatNode( ArmLogicTreeNode):
-    '''Tween rotation
+
+class TweenFloatNode(ArmLogicTreeNode):
+    """Tween rotation.
 
     @input Start: Start tweening
-     
     @input Stop: Stop a tweening. tweening can be re-started via the `Start`input
-
     @input From: Tween start value
-
     @input To: Tween final value
-
     @input Duration: Duartion of the tween in seconds
 
     @output Out: Executed immidiately after `Start` or `Stop` is called
-
     @output Tick: Executed at every time step in the tween duration
-
     @output Done: Executed when tween is successfully completed. Not executed if tweening is stopped mid-way
-
     @output Value: Current tween value
-    '''
+    """
     bl_idname = 'LNTweenRotationNode'
     bl_label = 'Tween Rotation'
     arm_version = 1
-    
+
     property0: HaxeEnumProperty(
         'property0',
         items = [('Linear', 'Linear', 'Linear'),
@@ -59,8 +53,8 @@ class TweenFloatNode( ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'Stop')
         self.add_input('ArmRotationSocket', 'From')
         self.add_input('ArmRotationSocket', 'To')
-        self.add_input('ArmFloatSocket', 'Duration', default_value = 1.0)
-        
+        self.add_input('ArmFloatSocket', 'Duration', default_value=1.0)
+
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Tick')
         self.add_output('ArmNodeSocketAction', 'Done')
@@ -68,6 +62,6 @@ class TweenFloatNode( ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-    
+
     def draw_label(self) -> str:
         return f'{self.bl_label}: {self.property0}'

--- a/blender/arm/logicnode/math/LN_tween_rotation.py
+++ b/blender/arm/logicnode/math/LN_tween_rotation.py
@@ -54,7 +54,7 @@ class TweenFloatNode( ArmLogicTreeNode):
                 ('BackInOut', 'BackInOut', 'BackInOut')],
         name='', default='Linear')
 
-    def init(self, context):
+    def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'Start')
         self.add_input('ArmNodeSocketAction', 'Stop')
         self.add_input('ArmRotationSocket', 'From')

--- a/blender/arm/logicnode/math/LN_tween_transform.py
+++ b/blender/arm/logicnode/math/LN_tween_transform.py
@@ -1,30 +1,24 @@
 from arm.logicnode.arm_nodes import *
 
-class TweenTransformNode( ArmLogicTreeNode):
-    '''Tween Transform
+
+class TweenTransformNode(ArmLogicTreeNode):
+    """Tween Transform.
 
     @input Start: Start tweening
-     
     @input Stop: Stop a tweening. tweening can be re-started via the `Start`input
-
     @input From: Tween start value
-
     @input To: Tween final value
-
     @input Duration: Duartion of the tween in seconds
 
     @output Out: Executed immidiately after `Start` or `Stop` is called
-
     @output Tick: Executed at every time step in the tween duration
-
     @output Done: Executed when tween is successfully completed. Not executed if tweening is stopped mid-way
-
     @output Value: Current tween value
-    '''
+    """
     bl_idname = 'LNTweenTransformNode'
     bl_label = 'Tween Transform'
     arm_version = 1
-    
+
     property0: HaxeEnumProperty(
         'property0',
         items = [('Linear', 'Linear', 'Linear'),
@@ -57,10 +51,10 @@ class TweenTransformNode( ArmLogicTreeNode):
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'Start')
         self.add_input('ArmNodeSocketAction', 'Stop')
-        self.add_input('ArmDynamicSocket', 'From') 
+        self.add_input('ArmDynamicSocket', 'From')
         self.add_input('ArmDynamicSocket', 'To')
-        self.add_input('ArmFloatSocket', 'Duration', default_value = 1.0)
-        
+        self.add_input('ArmFloatSocket', 'Duration', default_value=1.0)
+
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Tick')
         self.add_output('ArmNodeSocketAction', 'Done')
@@ -68,6 +62,6 @@ class TweenTransformNode( ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-    
+
     def draw_label(self) -> str:
         return f'{self.bl_label}: {self.property0}'

--- a/blender/arm/logicnode/math/LN_tween_transform.py
+++ b/blender/arm/logicnode/math/LN_tween_transform.py
@@ -54,7 +54,7 @@ class TweenTransformNode( ArmLogicTreeNode):
                 ('BackInOut', 'BackInOut', 'BackInOut')],
         name='', default='Linear')
 
-    def init(self, context):
+    def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'Start')
         self.add_input('ArmNodeSocketAction', 'Stop')
         self.add_input('ArmDynamicSocket', 'From') 

--- a/blender/arm/logicnode/math/LN_tween_vector.py
+++ b/blender/arm/logicnode/math/LN_tween_vector.py
@@ -54,7 +54,7 @@ class TweenVectorNode( ArmLogicTreeNode):
                 ('BackInOut', 'BackInOut', 'BackInOut')],
         name='', default='Linear')
 
-    def init(self, context):
+    def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'Start')
         self.add_input('ArmNodeSocketAction', 'Stop')
         self.add_input('ArmVectorSocket', 'From')

--- a/blender/arm/logicnode/math/LN_tween_vector.py
+++ b/blender/arm/logicnode/math/LN_tween_vector.py
@@ -1,30 +1,24 @@
 from arm.logicnode.arm_nodes import *
 
-class TweenVectorNode( ArmLogicTreeNode):
-    '''Tween a vector value
-    
+
+class TweenVectorNode(ArmLogicTreeNode):
+    """Tween a vector value.
+
     @input Start: Start tweening
-     
     @input Stop: Stop a tweening. tweening can be re-started via the `Start`input
-
     @input From: Tween start value
-
     @input To: Tween final value
-
     @input Duration: Duartion of the tween in seconds
 
     @output Out: Executed immidiately after `Start` or `Stop` is called
-
     @output Tick: Executed at every time step in the tween duration
-
     @output Done: Executed when tween is successfully completed. Not executed if tweening is stopped mid-way
-
     @output Value: Current tween value
-    '''
+    """
     bl_idname = 'LNTweenVectorNode'
     bl_label = 'Tween Vector'
     arm_version = 1
-    
+
     property0: HaxeEnumProperty(
         'property0',
         items = [('Linear', 'Linear', 'Linear'),
@@ -59,8 +53,8 @@ class TweenVectorNode( ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'Stop')
         self.add_input('ArmVectorSocket', 'From')
         self.add_input('ArmVectorSocket', 'To')
-        self.add_input('ArmFloatSocket', 'Duration', default_value = 1.0)
-        
+        self.add_input('ArmFloatSocket', 'Duration', default_value=1.0)
+
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Tick')
         self.add_output('ArmNodeSocketAction', 'Done')
@@ -68,6 +62,6 @@ class TweenVectorNode( ArmLogicTreeNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
-    
+
     def draw_label(self) -> str:
         return f'{self.bl_label}: {self.property0}'

--- a/blender/arm/logicnode/miscellaneous/LN_group_input.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_input.py
@@ -25,7 +25,7 @@ class GroupInputsNode(ArmLogicTreeNode):
             arm.log.warn("Only one group input node per node tree is allowed")
             tree.nodes.remove(self)
         else:
-            self.arm_init(context)
+            super().init(context)
 
     def copy(self, node):
         tree = bpy.context.space_data.edit_tree

--- a/blender/arm/logicnode/miscellaneous/LN_group_output.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_output.py
@@ -25,7 +25,7 @@ class GroupOutputsNode(ArmLogicTreeNode):
             arm.log.warn("Only one group output node per node tree is allowed")
             tree.nodes.remove(self)
         else:
-            self.arm_init(context)
+            super().init(context)
 
     def copy(self, node):
         tree = bpy.context.space_data.edit_tree

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -502,14 +502,14 @@ def init_properties():
     create_wrd()
 
 def create_wrd():
-    if not 'Arm' in bpy.data.worlds:
+    if 'Arm' not in bpy.data.worlds:
         wrd = bpy.data.worlds.new('Arm')
         wrd.use_fake_user = True # Store data world object, add fake user to keep it alive
         wrd.arm_version = arm_version
         wrd.arm_commit = arm_commit
 
 def init_properties_on_load():
-    if not 'Arm' in bpy.data.worlds:
+    if 'Arm' not in bpy.data.worlds:
         init_properties()
     # New project?
     if bpy.data.filepath == '':

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -2519,7 +2519,7 @@ class ARM_OT_UpdateFileSDK(bpy.types.Operator):
 
     def execute(self, context):
         wrd = bpy.data.worlds['Arm']
-        # This allows for seamless migration from ealier versions of Armory
+        # This allows for seamless migration from earlier versions of Armory
         for rp in wrd.arm_rplist: # TODO: deprecated
             if rp.rp_gi != 'Off':
                 rp.rp_gi = 'Off'


### PR DESCRIPTION
This PR fixes two related issues:

1. The tween and group input/output nodes weren't correctly initialized, so their version number was set to 0 and always caused a node replacement that would fail with an exception because no replacement routine exists for those nodes. Instead of using `arm_init()`, the nodes were using `init()` which would override Blender's initialization callback that we use to initialize the version number.

   To make the error less silent, I marked `init` as `@final` although this is just a hint for mypy and not enforced at runtime. A good IDE with mypy support will show this however. It may be even better to make `ArmLogicTreeNode` abstract and require overriding `arm_init`, but this doesn't work because Blender will fail with an error due to the way its Python API works and it would not prevent misuse of the `init` function. Some nodes like the group input/output nodes even need to override `init`.

2. If the Blender startup file already had an `Arm` world (e.g. because it was saved when Armory was already installed), Armory would use the file version number of the startup file and not of the actually used Armory version when saving the file. This would then trigger some node replacement functions that were not meant to be called.

Thanks to @ QuantumCoderQC and 1k8 on Discord for reporting this!