### PR TITLE
Fix "Set Scene Active" node when using asset compression

### DIFF
--- a/Sources/armory/logicnode/SetSceneNode.hx
+++ b/Sources/armory/logicnode/SetSceneNode.hx
@@ -15,6 +15,8 @@ class SetSceneNode extends LogicNode {
 
 		#if arm_json
 		sceneName += ".json";
+		#elseif arm_compress
+		sceneName += ".lz4";
 		#end
 
 		iron.Scene.setActive(sceneName, function(o: iron.object.Object) {


### PR DESCRIPTION
The `Set Scene Active` node wouldn't take lz4 compressed scenes into account and cause a crash in published projects.

Thanks to 1k8 on Discord for reporting this!