### PR TITLE
Fix sleep node

### DIFF
--- a/Sources/armory/logicnode/SleepNode.hx
+++ b/Sources/armory/logicnode/SleepNode.hx
@@ -1,17 +1,31 @@
 package armory.logicnode;
 
+import iron.system.Tween;
+
 class SleepNode extends LogicNode {
+
+	var sleepArray: Array<TAnim>;
 
 	public function new(tree: LogicTree) {
 		super(tree);
+
+		sleepArray = new Array<TAnim>();
+		tree.notifyOnRemove(stop);
 	}
 
 	override function run(from: Int) {
 		var time: Float = inputs[1].get();
-		iron.system.Tween.timer(time, done);
+		var sleep = Tween.timer(time, done);
+		sleepArray.push(sleep);
 	}
 
 	function done() {
 		runOutput(0);
+	}
+
+	function stop() {
+		for(sleep in sleepArray) {
+			Tween.stop(sleep);
+		}
 	}
 }


### PR DESCRIPTION
When a trait containing sleep node is removed, the seep timer still continued even after the trait removal, causing errors.

Thanks to @ wuaieyo on Discord for pointing it out.