### PR TITLE
Fix compilation error in Draw String node when Zui is disabled

### DIFF
--- a/Sources/armory/logicnode/DrawStringNode.hx
+++ b/Sources/armory/logicnode/DrawStringNode.hx
@@ -3,8 +3,9 @@ package armory.logicnode;
 import kha.Font;
 import kha.Color;
 
+#if arm_ui
 import armory.ui.Canvas;
-
+#end
 
 class DrawStringNode extends LogicNode {
 	var font: Font;
@@ -19,7 +20,11 @@ class DrawStringNode extends LogicNode {
 
 		var fontName = inputs[2].get();
 		if (fontName == "") {
+			#if arm_ui
 			fontName = Canvas.defaultFontName;
+			#else
+			return; // No default font is exported, there is nothing we can do here
+			#end
 		}
 
 		if (fontName != lastFontName) {

--- a/blender/arm/logicnode/renderpath/LN_draw_string.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_string.py
@@ -7,7 +7,9 @@ class DrawStringNode(ArmLogicTreeNode):
     @input Draw: Activate to draw the string on this frame. The input must
         be (indirectly) called from an `On Render2D` node.
     @input String: The string to draw.
-    @input Font File: The filename of the font.
+    @input Font File: The filename of the font (including the extension).
+        If empty and Zui is _enabled_, the default font is used. If empty
+        and Zui is _disabled_, nothing is rendered.
     @input Font Size: The size of the font in pixels.
     @input Color: The color of the string.
     @input X/Y: Position of the string, in pixels from the top left corner.


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2547.

Zui was disabled in the example file of the linked issue but the Draw String node tried to access it. With live patch enabled, all logic nodes are included in compilation so that they can be added at runtime.