### PR TITLE
Fix depth buffer access in SSS pass & fix numerical robustness of packFloatInt16()

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -187,7 +187,7 @@ in vec3 viewRay;
 out vec4 fragColor;
 
 void main() {
-	vec4 g0 = textureLod(gbuffer0, texCoord, 0.0); // Normal.xy, metallic/roughness, matid
+	vec4 g0 = textureLod(gbuffer0, texCoord, 0.0); // Normal.xy, roughness, metallic/matid
 
 	vec3 n;
 	n.z = 1.0 - abs(g0.x) - abs(g0.y);

--- a/Shaders/deferred_light_mobile/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_mobile/deferred_light.frag.glsl
@@ -121,7 +121,7 @@ in vec3 viewRay;
 out vec4 fragColor;
 
 void main() {
-	vec4 g0 = textureLod(gbuffer0, texCoord, 0.0); // Normal.xy, metallic/roughness, depth
+	vec4 g0 = textureLod(gbuffer0, texCoord, 0.0); // Normal.xy, roughness, metallic/matid
 
 	vec3 n;
 	n.z = 1.0 - abs(g0.x) - abs(g0.y);

--- a/Shaders/probe_cubemap/probe_cubemap.frag.glsl
+++ b/Shaders/probe_cubemap/probe_cubemap.frag.glsl
@@ -21,7 +21,7 @@ void main() {
 	texCoord.y = 1.0 - texCoord.y;
 	#endif
 
-	vec4 g0 = textureLod(gbuffer0, texCoord, 0.0); // Normal.xy, metallic/roughness, depth
+	vec4 g0 = textureLod(gbuffer0, texCoord, 0.0); // Normal.xy, roughness, metallic/matid
 
 	float roughness = g0.b;
 	if (roughness > 0.95) {

--- a/Shaders/probe_planar/probe_planar.frag.glsl
+++ b/Shaders/probe_planar/probe_planar.frag.glsl
@@ -21,7 +21,7 @@ void main() {
 	texCoord.y = 1.0 - texCoord.y;
 	#endif
 
-	vec4 g0 = textureLod(gbuffer0, texCoord, 0.0); // Normal.xy, metallic/roughness, depth
+	vec4 g0 = textureLod(gbuffer0, texCoord, 0.0); // Normal.xy, roughness, metallic/matid
 
 	float roughness = g0.b;
 	if (roughness > 0.95) {

--- a/Shaders/std/gbuffer.glsl
+++ b/Shaders/std/gbuffer.glsl
@@ -127,68 +127,27 @@ vec3 decNor(uint val) {
 	return normal;
 }
 
-// GBuffer helper - Sebastien Lagarde
-// https://seblagarde.wordpress.com/2018/09/02/gbuffer-helper-packing-integer-and-float-together/
-float packFloatInt8(const float f, const uint i) {
-	// Constant optimize by compiler
-	const int numBitTarget = 8;
-	const int numBitI = 4;
-	const float prec = float(1 << numBitTarget);
-	const float maxi = float(1 << numBitI);
-	const float precMinusOne = prec - 1.0;
-	const float t1 = ((prec / maxi) - 1.0) / precMinusOne;
-	const float t2 = (prec / maxi) / precMinusOne;
-	// Code
-	return t1 * f + t2 * float(i);
-}
-
+/**
+	Packs a float in [0, 1] and an integer in [0..15] into a single 16 bit float value.
+**/
 float packFloatInt16(const float f, const uint i) {
-	// Constant optimize by compiler
-	const int numBitTarget = 16;
-	const int numBitI = 4;
-	const float prec = float(1 << numBitTarget);
-	const float maxi = float(1 << numBitI);
-	const float precMinusOne = prec - 1.0;
-	const float t1 = ((prec / maxi) - 1.0) / precMinusOne;
-	const float t2 = (prec / maxi) / precMinusOne;
-	// Code
-	return t1 * f + t2 * float(i);
-}
+	const uint numBitFloat = 12;
+	const float maxValFloat = float((1 << numBitFloat) - 1);
 
-void unpackFloatInt8(const float val, out float f, out uint i) {
-	// Constant optimize by compiler
-	const int numBitTarget = 8;
-	const int numBitI = 4;
-	const float prec = float(1 << numBitTarget);
-	const float maxi = float(1 << numBitI);
-	const float precMinusOne = prec - 1.0;
-	const float t1 = ((prec / maxi) - 1.0) / precMinusOne;
-	const float t2 = (prec / maxi) / precMinusOne;
-	// Code
-	// extract integer part
-	// + rcp(precMinusOne) to deal with precision issue
-	i = int((val / t2) + (1.0 / precMinusOne));
-	// Now that we have i, solve formula in packFloatInt for f
-	//f = (val - t2 * float(i)) / t1 => convert in mads form
-	f = clamp((-t2 * float(i) + val) / t1, 0.0, 1.0); // Saturate in case of precision issue
+	const uint bitsInt = i << numBitFloat;
+	const uint bitsFloat = uint(f * maxValFloat);
+
+	return float(bitsInt | bitsFloat);
 }
 
 void unpackFloatInt16(const float val, out float f, out uint i) {
-	// Constant optimize by compiler
-	const int numBitTarget = 16;
-	const int numBitI = 4;
-	const float prec = float(1 << numBitTarget);
-	const float maxi = float(1 << numBitI);
-	const float precMinusOne = prec - 1.0;
-	const float t1 = ((prec / maxi) - 1.0) / precMinusOne;
-	const float t2 = (prec / maxi) / precMinusOne;
-	// Code
-	// extract integer part
-	// + rcp(precMinusOne) to deal with precision issue
-	i = int((val / t2) + (1.0 / precMinusOne));
-	// Now that we have i, solve formula in packFloatInt for f
-	//f = (val - t2 * float(i)) / t1 => convert in mads form
-	f = clamp((-t2 * float(i) + val) / t1, 0.0, 1.0); // Saturate in case of precision issue
+	const uint numBitFloat = 12;
+	const float maxValFloat = float((1 << numBitFloat) - 1);
+
+	const uint bitsValue = uint(val);
+
+	i = bitsValue >> numBitFloat;
+	f = (bitsValue & ~(0xF << numBitFloat)) / maxValFloat;
 }
 
 #endif

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -746,6 +746,10 @@ class RenderPathDeferred {
 
 		#if rp_sss
 		{
+			#if (!kha_opengl)
+			path.setDepthFrom("tex", "gbuffer1"); // Unbind depth so we can read it
+			#end
+
 			path.setTarget("buf");
 			path.bindTarget("tex", "tex");
 			path.bindTarget("_main", "gbufferD");
@@ -757,6 +761,10 @@ class RenderPathDeferred {
 			path.bindTarget("_main", "gbufferD");
 			path.bindTarget("gbuffer0", "gbuffer0");
 			path.drawShader("shader_datas/sss_pass/sss_pass_y");
+
+			#if (!kha_opengl)
+			path.setDepthFrom("tex", "gbuffer0"); // Re-bind depth
+			#end
 		}
 		#end
 


### PR DESCRIPTION
This PR fixes two related issues mentioned in https://forums.armory3d.org/t/personal-website-made-with-armory/4723/35:

1. The SSS pass tried to read from the depth buffer that was still bound to a different render target. I'm not exactly sure which change caused this issue to appear (according to the forum post it didn't happen last year), but it works now.

2. The implementation of `packFloatInt16` in gbuffer.glsl had some numerical robustness issues: a matid of 2 and a metallic value of 0.0 would result in a packed float value of 0.125, which then got unpacked into matid = 1 and metallic = 1.0 because both packed representations are very close to each other.

   My new implementation does not have this issue since the encoded output is basically an integer stored in a float. Unfortunately we cannot use [`uintBitsToFloat`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/intBitsToFloat.xhtml) here since possible NaN representations would result in undefined behaviour, so instead the packed bytes are converted back to a valid floating point value. As a result, the precision will be slightly worse for "large" integers than with the old implementation, but even then the worst case error should not be larger than ~0.008 if I'm not mistaken, so we should be fine (the largest currently used matID is 2 anyways I think). In a visual comparison of a color ramp that controls the metallic value, the color banding looks exactly the same for both implementations for a matID of 0. The packed integer value should be exactly preserved.

   I also removed the packFloatInt8 implementation which was not used (anymore?). If there was a reason for keeping it (or you think that my new packing implementation is not good), I can reverse this change. We need to find another solution then, however.

I tested the changes on html5, windows-krom and windows-hl (DirectX and OpenGL), with SSS materials, emission materials and regular materials.