### PR TITLE
Fix shape key export in optimized mesh export

### DIFF
--- a/blender/arm/material/make_morph_target.py
+++ b/blender/arm/material/make_morph_target.py
@@ -22,7 +22,7 @@ def morph_pos(vert):
     vert.write_attrib('spos.xyz /= posUnpack;')
 
 def morph_nor(vert, is_bone, prep):
-    vert.write_attrib('vec3 morphNor;')
+    vert.write_attrib('vec3 morphNor = vec3(0, 0, 0);')
     vert.write_attrib('getMorphedNormal(texCoordMorph, vec3(nor.xy, pos.w), morphNor);')
     if not is_bone:
         vert.write_attrib(prep + 'wnormal = normalize(N * morphNor);')


### PR DESCRIPTION
When `optimize data` was enabled in export settings, shape key data was not parsed. This PR adds shape key parsing in optimized mesh export.

This PR also fixes a minor issue with shader attribute not initialized properly, which lead to flickering of objects when shape keys were enabled. Thanks to @ wuaieyo on discord for bringing up this issue