### PR TITLE
Fix rigid body angular/ rolling friction

### DIFF
--- a/Sources/armory/logicnode/AddRigidBodyNode.hx
+++ b/Sources/armory/logicnode/AddRigidBodyNode.hx
@@ -36,6 +36,7 @@ class AddRigidBodyNode extends LogicNode {
 		var marginLen: Float = 0.0;
 		var linDamp: Float = 0.0;
 		var angDamp: Float = 0.0;
+		var angFriction: Float = 0.0;
 		var useDeactiv: Bool = false;
 		var linearVelThreshold: Float = 0.0;
 		var angVelThreshold: Float = 0.0;
@@ -49,11 +50,12 @@ class AddRigidBodyNode extends LogicNode {
 			marginLen = inputs[10].get();
 			linDamp = inputs[11].get();
 			angDamp = inputs[12].get();
-			useDeactiv = inputs[13].get();
-			linearVelThreshold = inputs[14].get();
-			angVelThreshold = inputs[15].get();
-			group = inputs[16].get();
-			mask = inputs[17].get();
+			angFriction = inputs[13].get();
+			useDeactiv = inputs[14].get();
+			linearVelThreshold = inputs[15].get();
+			angVelThreshold = inputs[16].get();
+			group = inputs[17].get();
+			mask = inputs[18].get();
 		}
 
 		var rb: RigidBody = object.getTrait(RigidBody);
@@ -78,6 +80,7 @@ class AddRigidBodyNode extends LogicNode {
 			if (property1) {
 				rb.linearDamping = linDamp;
 				rb.angularDamping = angDamp;
+				rb.angularFriction = angFriction;
 				if (margin) rb.collisionMargin = marginLen;
 				if (useDeactiv) {
 					rb.setUpDeactivation(true, linearVelThreshold, angVelThreshold, 0.0);

--- a/Sources/armory/trait/physics/bullet/RigidBody.hx
+++ b/Sources/armory/trait/physics/bullet/RigidBody.hx
@@ -76,7 +76,7 @@ class RigidBody extends iron.Trait {
 	static var usersCache = new Map<MeshData, Int>();
 
 	public function new(shape = Shape.Box, mass = 1.0, friction = 0.5, restitution = 0.0, group = 1, mask = 1,
-						params: Array<Float> = null, flags: Array<Bool> = null) {
+						params: RigidBodyParams = null, flags: RigidBodyFlags = null) {
 		super();
 
 		if (nullvec) {
@@ -96,7 +96,19 @@ class RigidBody extends iron.Trait {
 		this.group = group;
 		this.mask = mask;
 
-		if (params == null) params = [0.04, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0];
+		if (params == null) params = { linearDamping: 0.04,
+									   angularDamping: 0.1,
+									   //angularFriction: 0.1,
+									   linearFactorsX: 1.0,
+									   linearFactorsY: 1.0,
+									   linearFactorsZ: 1.0,
+									   angularFactorsX: 1.0,
+									   angularFactorsY: 1.0,
+									   angularFactorsZ: 1.0,
+									   collisionMargin: 0.0,
+									   linearDeactivationThreshold: 0.0,
+									   angularDeactivationThrshold: 0.0,
+									   deactivationTime: 0.0};
 		/**
 		 * params:[ linear damping
 		 * 		    angular damping
@@ -112,7 +124,11 @@ class RigidBody extends iron.Trait {
 		 * 			deactivation time(Not used)]
 		 */
 
-		if (flags == null) flags = [false, false, false, false, true];
+		if (flags == null) flags = { animated: false,
+									 trigger: false,
+									 ccd: false,
+									 staticObj: false,
+									 useDeactivation: true};
 		/**
 		 * flags:[ is animated
 		 * 		   is trigger
@@ -121,17 +137,20 @@ class RigidBody extends iron.Trait {
 		 * 		   use deactivation]
 		 */
 
-		this.linearDamping = params[0];
-		this.angularDamping = params[1];
-		this.linearFactors = [params[2], params[3], params[4]];
-		this.angularFactors = [params[5], params[6], params[7]];
-		this.collisionMargin = params[8];
-		this.deactivationParams = [params[9], params[10], params[11]];
-		this.animated = flags[0];
-		this.trigger = flags[1];
-		this.ccd = flags[2];
-		this.staticObj = flags[3];
-		this.useDeactivation = flags[4];
+		trace(params);
+		trace(flags);
+
+		this.linearDamping = params.linearDamping;
+		this.angularDamping = params.angularDamping;
+		this.linearFactors = [params.linearFactorsX, params.linearFactorsY, params.linearFactorsZ];
+		this.angularFactors = [params.angularFactorsX, params.angularFactorsY, params.angularFactorsZ];
+		this.collisionMargin = params.collisionMargin;
+		this.deactivationParams = [params.linearDeactivationThreshold, params.angularDeactivationThrshold, params.deactivationTime];
+		this.animated = flags.animated;
+		this.trigger = flags.trigger;
+		this.ccd = flags.ccd;
+		this.staticObj = flags.staticObj;
+		this.useDeactivation = flags.useDeactivation;
 
 		notifyOnAdd(init);
 	}
@@ -259,7 +278,7 @@ class RigidBody extends iron.Trait {
 
 		var bodyColl: bullet.Bt.CollisionObject = body;
 		bodyColl.setFriction(friction);
-		// body.setRollingFriction(friction); // This causes bodies to get stuck, apply angular damping instead
+		body.setRollingFriction(friction); // This causes bodies to get stuck, apply angular damping instead
 		bodyColl.setRestitution(restitution);
 
 		if ( useDeactivation) {
@@ -658,4 +677,27 @@ class RigidBody extends iron.Trait {
 	var Terrain = 7;
 }
 
+typedef RigidBodyParams = {
+	var linearDamping: Float;
+	var angularDamping: Float;
+	//var angularFriction: Float;
+	var linearFactorsX: Float;
+	var linearFactorsY: Float;
+	var linearFactorsZ: Float;
+	var angularFactorsX: Float;
+	var angularFactorsY: Float;
+	var angularFactorsZ: Float;
+	var collisionMargin: Float;
+	var linearDeactivationThreshold: Float;
+	var angularDeactivationThrshold: Float;
+	var deactivationTime: Float;
+}
+
+typedef RigidBodyFlags = {
+	var animated: Bool;
+	var trigger: Bool;
+	var ccd: Bool;
+	var staticObj: Bool;
+	var useDeactivation: Bool;
+}
 #end

--- a/Sources/armory/trait/physics/bullet/RigidBody.hx
+++ b/Sources/armory/trait/physics/bullet/RigidBody.hx
@@ -21,6 +21,7 @@ class RigidBody extends iron.Trait {
 	public var transform: Transform = null;
 	public var mass: Float;
 	public var friction: Float;
+	public var angularFriction: Float;
 	public var restitution: Float;
 	public var collisionMargin: Float;
 	public var linearDamping: Float;
@@ -98,7 +99,7 @@ class RigidBody extends iron.Trait {
 
 		if (params == null) params = { linearDamping: 0.04,
 									   angularDamping: 0.1,
-									   //angularFriction: 0.1,
+									   angularFriction: 0.1,
 									   linearFactorsX: 1.0,
 									   linearFactorsY: 1.0,
 									   linearFactorsZ: 1.0,
@@ -136,12 +137,10 @@ class RigidBody extends iron.Trait {
 		 * 		   is static
 		 * 		   use deactivation]
 		 */
-
-		trace(params);
-		trace(flags);
-
+		
 		this.linearDamping = params.linearDamping;
 		this.angularDamping = params.angularDamping;
+		this.angularFriction = params.angularFriction;
 		this.linearFactors = [params.linearFactorsX, params.linearFactorsY, params.linearFactorsZ];
 		this.angularFactors = [params.angularFactorsX, params.angularFactorsY, params.angularFactorsZ];
 		this.collisionMargin = params.collisionMargin;
@@ -278,7 +277,7 @@ class RigidBody extends iron.Trait {
 
 		var bodyColl: bullet.Bt.CollisionObject = body;
 		bodyColl.setFriction(friction);
-		body.setRollingFriction(friction); // This causes bodies to get stuck, apply angular damping instead
+		bodyColl.setRollingFriction(angularFriction);
 		bodyColl.setRestitution(restitution);
 
 		if ( useDeactivation) {
@@ -680,7 +679,7 @@ class RigidBody extends iron.Trait {
 typedef RigidBodyParams = {
 	var linearDamping: Float;
 	var angularDamping: Float;
-	//var angularFriction: Float;
+	var angularFriction: Float;
 	var linearFactorsX: Float;
 	var linearFactorsY: Float;
 	var linearFactorsZ: Float;

--- a/Sources/armory/trait/physics/bullet/RigidBody.hx
+++ b/Sources/armory/trait/physics/bullet/RigidBody.hx
@@ -260,9 +260,6 @@ class RigidBody extends iron.Trait {
 		var bodyColl: bullet.Bt.CollisionObject = body;
 		bodyColl.setFriction(friction);
 		// body.setRollingFriction(friction); // This causes bodies to get stuck, apply angular damping instead
-		if (shape == Shape.Sphere || shape == Shape.Cylinder || shape == Shape.Cone || shape == Shape.Capsule) {
-			angularDamping += friction;
-		}
 		bodyColl.setRestitution(restitution);
 
 		if ( useDeactivation) {

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2670,8 +2670,6 @@ Make sure the mesh only has tris/quads.""")
             body_flags['ccd'] = bobject.arm_rb_ccd
             body_flags['staticObj'] = is_static
             body_flags['useDeactivation'] = rb.use_deactivation
-            print(arm.utils.get_haxe_json_string(body_params))
-            print(arm.utils.get_haxe_json_string(body_flags))
             x['parameters'].append(arm.utils.get_haxe_json_string(body_params))
             x['parameters'].append(arm.utils.get_haxe_json_string(body_flags))
             o['traits'].append(x)

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2641,15 +2641,15 @@ Make sure the mesh only has tris/quads.""")
                 ay = 0
             if bobject.lock_rotation[2]:
                 az = 0
-            col_margin = str(rb.collision_margin) if rb.use_margin else '0.0'
+            col_margin = rb.collision_margin if rb.use_margin else 0.0
             if rb.use_deactivation:
-                deact_lv = str(rb.deactivate_linear_velocity)
-                deact_av = str(rb.deactivate_angular_velocity)
-                deact_time = str(bobject.arm_rb_deactivation_time)
+                deact_lv = rb.deactivate_linear_velocity
+                deact_av = rb.deactivate_angular_velocity
+                deact_time = bobject.arm_rb_deactivation_time
             else:
-                deact_lv = '0.0'
-                deact_av = '0.0'
-                deact_time = '0.0'
+                deact_lv = 0.0
+                deact_av = 0.0
+                deact_time = 0.0
             body_params = {}
             body_params['linearDamping'] = rb.linear_damping
             body_params['angularDamping'] = rb.angular_damping
@@ -2665,11 +2665,13 @@ Make sure the mesh only has tris/quads.""")
             body_params['angularDeactivationThrshold'] = deact_av
             body_params['deactivationTime'] = deact_time
             body_flags = {}
-            body_flags['animated'] = str(rb.kinematic).lower()
-            body_flags['trigger'] = str(bobject.arm_rb_trigger).lower()
-            body_flags['ccd'] = str(bobject.arm_rb_ccd).lower()
-            body_flags['staticObj'] = str(is_static).lower()
-            body_flags['useDeactivation'] = str(rb.use_deactivation).lower()
+            body_flags['animated'] = rb.kinematic
+            body_flags['trigger'] = bobject.arm_rb_trigger
+            body_flags['ccd'] = bobject.arm_rb_ccd
+            body_flags['staticObj'] = is_static
+            body_flags['useDeactivation'] = rb.use_deactivation
+            print(arm.utils.get_haxe_json_string(body_params))
+            print(arm.utils.get_haxe_json_string(body_flags))
             x['parameters'].append(arm.utils.get_haxe_json_string(body_params))
             x['parameters'].append(arm.utils.get_haxe_json_string(body_flags))
             o['traits'].append(x)

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2650,23 +2650,28 @@ Make sure the mesh only has tris/quads.""")
                 deact_lv = '0.0'
                 deact_av = '0.0'
                 deact_time = '0.0'
-            body_params = '[{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}]'.format(
-                str(rb.linear_damping),
-                str(rb.angular_damping),
-                str(lx), str(ly), str(lz),
-                str(ax), str(ay), str(az),
-                col_margin,
-                deact_lv, deact_av, deact_time
-            )
-            body_flags = '[{0}, {1}, {2}, {3}, {4}]'.format(
-                str(rb.kinematic).lower(),
-                str(bobject.arm_rb_trigger).lower(),
-                str(bobject.arm_rb_ccd).lower(),
-                str(is_static).lower(),
-                str(rb.use_deactivation).lower()
-            )
-            x['parameters'].append(body_params)
-            x['parameters'].append(body_flags)
+            body_params = {}
+            body_params['linearDamping'] = rb.linear_damping
+            body_params['angularDamping'] = rb.angular_damping
+            body_params['linearFactorsX'] = lx
+            body_params['linearFactorsY'] = ly
+            body_params['linearFactorsZ'] = lz
+            body_params['angularFactorsX'] = ax
+            body_params['angularFactorsY'] = ay
+            body_params['angularFactorsZ'] = az
+            body_params['angularFriction'] = bobject.arm_rb_angular_friction
+            body_params['collisionMargin'] = col_margin
+            body_params['linearDeactivationThreshold'] = deact_lv
+            body_params['angularDeactivationThrshold'] = deact_av
+            body_params['deactivationTime'] = deact_time
+            body_flags = {}
+            body_flags['animated'] = str(rb.kinematic).lower()
+            body_flags['trigger'] = str(bobject.arm_rb_trigger).lower()
+            body_flags['ccd'] = str(bobject.arm_rb_ccd).lower()
+            body_flags['staticObj'] = str(is_static).lower()
+            body_flags['useDeactivation'] = str(rb.use_deactivation).lower()
+            x['parameters'].append(arm.utils.get_haxe_json_string(body_params))
+            x['parameters'].append(arm.utils.get_haxe_json_string(body_flags))
             o['traits'].append(x)
 
         # Phys traits

--- a/blender/arm/logicnode/physics/LN_Add_rigid_body.py
+++ b/blender/arm/logicnode/physics/LN_Add_rigid_body.py
@@ -31,6 +31,8 @@ class AddRigidBodyNode(ArmLogicTreeNode):
 
     @input Angular Damping: Damping for angular translation. Recommended range 0 to 1.
 
+    @input Angular Friction: Rolling or angular friction. Recommended range >= 0
+
     @input Use Deactivation: Deactive this rigid body when below the Linear and Angular velocity threshold. Enable to improve performance.
 
     @input Linear Velocity Threshold: Velocity below which decativation occurs if enabled.
@@ -48,7 +50,7 @@ class AddRigidBodyNode(ArmLogicTreeNode):
 
     bl_idname = 'LNAddRigidBodyNode'
     bl_label = 'Add Rigid Body'
-    arm_version = 1
+    arm_version = 2
 
     NUM_STATIC_INS = 9
 
@@ -111,6 +113,7 @@ class AddRigidBodyNode(ArmLogicTreeNode):
             self.add_input('ArmFloatSocket', 'Margin', 0.04)
             self.add_input('ArmFloatSocket', 'Linear Damping', 0.04)
             self.add_input('ArmFloatSocket', 'Angular Damping', 0.1)
+            self.add_input('ArmFloatSocket', 'Angular Friction', 0.1)
             self.add_input('ArmBoolSocket', 'Use Deacivation')
             self.add_input('ArmFloatSocket', 'Linear Velocity Threshold', 0.4)
             self.add_input('ArmFloatSocket', 'Angular Velocity Threshold', 0.5)
@@ -121,3 +124,17 @@ class AddRigidBodyNode(ArmLogicTreeNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, "property1")
         layout.prop(self, 'property0')
+    
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        in_socket_mapping={0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8}
+        if self.property1:
+            in_socket_mapping.update({9:9, 10:10, 11:11, 12:12, 13:14, 14:15, 15:16, 16:17, 17:18})
+
+        return NodeReplacement(
+            'LNAddRigidBodyNode', self.arm_version, 'LNAddRigidBodyNode', 2,
+            in_socket_mapping=in_socket_mapping,
+            out_socket_mapping={0:0, 1:1},
+            property_mapping={'property0':'property0', 'property1':'property1'})

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -303,6 +303,7 @@ def init_properties():
     bpy.types.Object.arm_soft_body_margin = FloatProperty(name="Soft Body Margin", description="Collision margin", default=0.04)
     bpy.types.Object.arm_rb_linear_factor = FloatVectorProperty(name="Linear Factor", size=3, description="Set to 0 to lock axis", default=[1,1,1])
     bpy.types.Object.arm_rb_angular_factor = FloatVectorProperty(name="Angular Factor", size=3, description="Set to 0 to lock axis", default=[1,1,1])
+    bpy.types.Object.arm_rb_angular_friction = FloatProperty(name="Angular Friction", description="Angular Friction", default=0.1)
     bpy.types.Object.arm_rb_trigger = BoolProperty(name="Trigger", description="Disable contact response", default=False)
     bpy.types.Object.arm_rb_deactivation_time = FloatProperty(name="Deactivation Time", description="Delay putting rigid body into sleep", default=0.0)
     bpy.types.Object.arm_rb_ccd = BoolProperty(name="Continuous Collision Detection", description="Improve collision for fast moving objects", default=False)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -232,6 +232,7 @@ class ARM_PT_PhysicsPropsPanel(bpy.types.Panel):
 
             layout.prop(obj, 'arm_rb_linear_factor')
             layout.prop(obj, 'arm_rb_angular_factor')
+            layout.prop(obj, 'arm_rb_angular_friction')
             layout.prop(obj, 'arm_rb_trigger')
             layout.prop(obj, 'arm_rb_ccd')
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -669,8 +669,8 @@ def safestr(s: str) -> str:
 
 def get_haxe_json_string(d: dict) -> str:
     s = str(d)
-    s = s.replace("'true'", 'true')
-    s = s.replace("'false'", 'false')
+    s = s.replace('True', 'true')
+    s = s.replace('False', 'false')
     s = s.replace("'", '"')
     return s
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -667,6 +667,13 @@ def safestr(s: str) -> str:
         s = s.replace(c, '_')
     return ''.join([i if ord(i) < 128 else '_' for i in s])
 
+def get_haxe_json_string(d: dict) -> str:
+    s = str(d)
+    s = s.replace("'true'", 'true')
+    s = s.replace("'false'", 'false')
+    s = s.replace("'", '"')
+    return s
+
 def asset_name(bdata):
     if bdata == None:
         return None


### PR DESCRIPTION
This PR fixes an issue with rolling friction in Rigid Bodies. Requires https://github.com/armory3d/iron/pull/170

To fix the issue #831, angular damping was used instead of angular friction. But this caused additional issues with rolling objects such as spheres and cylinders. The actual issue was that linear friction setting was also used for angular friction, since there was no option in Blender rigid body settings. This PR adds a field for angular friction setting in the Rigid Body settings and uses it instead.

<img src="https://user-images.githubusercontent.com/55564981/188506821-9c1c89f5-d0fb-448d-af71-ae4a2409115a.png" width="400" height="200" />

Additionally, the Rigid Body trait parameters is also changed form `Array<Float>` and `Array<Bool>` to `typedef` as this offers more information about the values.