### PR TITLE
Fix set parent node

### DIFF
--- a/Sources/armory/logicnode/SetParentNode.hx
+++ b/Sources/armory/logicnode/SetParentNode.hx
@@ -11,24 +11,18 @@ class SetParentNode extends LogicNode {
 
 	override function run(from: Int) {
 		var object: Object = inputs[1].get();
+		var parentObject: Object = inputs[2].get();
+		var keepTransform: Bool = inputs[3].get();
+		var parentInverse: Bool = inputs[4].get();
 
-		var isUnparent = false;
-		if (Std.isOfType(inputs[2].fromNode, ObjectNode)) {
-			var parentNode = cast(inputs[2].fromNode, ObjectNode);
-			isUnparent = parentNode.objectName == "";
-		}
-
-		var parent: Object = isUnparent ? iron.Scene.active.root : inputs[2].get();
-
-		if (object == null || parent == null || object.parent == parent) return;
+		if (object == null || parentObject == null || object.parent == parentObject) return;
 
 		#if arm_physics
 		var rigidBody = object.getTrait(RigidBody);
 		if (rigidBody != null) rigidBody.setActivationState(0);
 		#end
 
-		object.setParent(parent, !isUnparent, isUnparent);
-
+		object.setParent(parentObject, parentInverse, keepTransform);
 		runOutput(0);
 	}
 }

--- a/blender/arm/logicnode/object/LN_set_object_parent.py
+++ b/blender/arm/logicnode/object/LN_set_object_parent.py
@@ -2,16 +2,31 @@ from arm.logicnode.arm_nodes import *
 
 class SetParentNode(ArmLogicTreeNode):
     """Sets the direct parent (nearest in the hierarchy) of the given object.
+    @input Object: Object to be parented.
+    @input Parent: New parent object. Use `Get Scene Root` node to unparent object.
+    @input Keep Transform: Keep transform after unparenting from old parent
+    @input Parent Inverse: Preserve object transform after parenting to new object.
 
     @seeNode Get Object Parent"""
     bl_idname = 'LNSetParentNode'
     bl_label = 'Set Object Parent'
     arm_section = 'relations'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('ArmNodeSocketObject', 'Parent')
+        self.add_input('ArmBoolSocket', 'Keep Transform')
+        self.add_input('ArmBoolSocket', 'Parent Inverse')
 
         self.add_output('ArmNodeSocketAction', 'Out')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+            
+        return NodeReplacement(
+            'LNSetParentNode', self.arm_version, 'LNSetParentNode', 2,
+            in_socket_mapping={0:0, 1:1, 2:2}, out_socket_mapping={0:0}
+        )

--- a/blender/arm/logicnode/object/LN_set_object_parent.py
+++ b/blender/arm/logicnode/object/LN_set_object_parent.py
@@ -17,7 +17,7 @@ class SetParentNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmNodeSocketObject', 'Object')
         self.add_input('ArmNodeSocketObject', 'Parent')
-        self.add_input('ArmBoolSocket', 'Keep Transform')
+        self.add_input('ArmBoolSocket', 'Keep Transform', default_value = True)
         self.add_input('ArmBoolSocket', 'Parent Inverse')
 
         self.add_output('ArmNodeSocketAction', 'Out')


### PR DESCRIPTION
Fixes #2580

The set parent node used to treat empty parent socket as an option to un-parent objects. This interfered with the working of the socket. This PR fixes it by treating empty socket as `self-object` (as is by default). To unparent, simply use `get scene root` node at the parent socket.

Also added some documentation for the node.

Some more pertinent references if required:
https://github.com/armory3d/armory/issues/356
https://github.com/armory3d/armory/issues/310