### PR TITLE
Fix support for Separate/Combine Color nodes

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -331,6 +331,7 @@ def parse_vector(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> str:
         'VALTORGB': nodes_converter.parse_valtorgb,  # ColorRamp
         'CURVE_VEC': nodes_vector.parse_curvevec,  # Vector Curves
         'CURVE_RGB': nodes_color.parse_curvergb,
+        'COMBINE_COLOR': nodes_converter.parse_combine_color,
         'COMBHSV': nodes_converter.parse_combhsv,
         'COMBRGB': nodes_converter.parse_combrgb,
         'WAVELENGTH': nodes_converter.parse_wavelength,
@@ -453,6 +454,7 @@ def parse_value(node, socket):
         'VALTORGB': nodes_converter.parse_valtorgb,
         'MATH': nodes_converter.parse_math,
         'RGBTOBW': nodes_converter.parse_rgbtobw,
+        'SEPARATE_COLOR': nodes_converter.parse_separate_color,
         'SEPHSV': nodes_converter.parse_sephsv,
         'SEPRGB': nodes_converter.parse_seprgb,
         'SEPXYZ': nodes_converter.parse_sepxyz,

--- a/blender/arm/material/cycles_nodes/nodes_converter.py
+++ b/blender/arm/material/cycles_nodes/nodes_converter.py
@@ -363,7 +363,8 @@ def parse_sephsv(node: bpy.types.ShaderNodeSeparateHSV, out_socket: bpy.types.No
     state.curshader.add_function(c_functions.str_hue_sat)
 
     hsv_var = c.node_name(node.name) + '_hsv'
-    state.curshader.write(f'const vec3 {hsv_var} = rgb_to_hsv({c.parse_vector_input(node.inputs["Color"])}.rgb);')
+    if not state.curshader.contains(hsv_var):  # Already written if a second output is parsed
+        state.curshader.write(f'const vec3 {hsv_var} = rgb_to_hsv({c.parse_vector_input(node.inputs["Color"])}.rgb);')
 
     if out_socket == node.outputs[0]:
         return f'{hsv_var}.x'

--- a/blender/arm/material/cycles_nodes/nodes_converter.py
+++ b/blender/arm/material/cycles_nodes/nodes_converter.py
@@ -131,6 +131,16 @@ def parse_valtorgb(node: bpy.types.ShaderNodeValToRGB, out_socket: bpy.types.Nod
         return f'mix({prev_stop_col}, {next_stop_col}, max({rel_pos}, 0.0))'
 
 
+def parse_combine_color(node: bpy.types.ShaderNodeCombineColor, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:
+    if node.mode == 'RGB':
+        return parse_combrgb(node, out_socket, state)
+    elif node.mode == 'HSV':
+        return parse_combhsv(node, out_socket, state)
+    elif node.mode == 'HSL':
+        log.warn('Combine Color node: HSL mode is not supported, using default value')
+        return c.to_vec3((0.0, 0.0, 0.0))
+
+
 def parse_combhsv(node: bpy.types.ShaderNodeCombineHSV, out_socket: bpy.types.NodeSocket, state: ParserState) -> vec3str:
     state.curshader.add_function(c_functions.str_hue_sat)
     h = c.parse_value_input(node.inputs[0])
@@ -337,6 +347,16 @@ def parse_math(node: bpy.types.ShaderNodeMath, out_socket: bpy.types.NodeSocket,
 
 def parse_rgbtobw(node: bpy.types.ShaderNodeRGBToBW, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:
     return c.rgb_to_bw(c.parse_vector_input(node.inputs[0]))
+
+
+def parse_separate_color(node: bpy.types.ShaderNodeSeparateColor, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:
+    if node.mode == 'RGB':
+        return parse_seprgb(node, out_socket, state)
+    elif node.mode == 'HSV':
+        return parse_sephsv(node, out_socket, state)
+    elif node.mode == 'HSL':
+        log.warn('Separate Color node: HSL mode is not supported, using default value')
+        return '0.0'
 
 
 def parse_sephsv(node: bpy.types.ShaderNodeSeparateHSV, out_socket: bpy.types.NodeSocket, state: ParserState) -> floatstr:


### PR DESCRIPTION
This fixes the first issue in https://github.com/armory3d/armory/issues/2578.

- Blender introduced new Separate/Combine Color nodes but it isn't mentioned in the release notes, so unfortunately we missed it in the last SDK release.

  Since I couldn't find a GPU-optimized implementation of a RGB->HSL routine (and vice versa) that we can use licence-wise and I haven't had time so far to really understand HSL, I didn't add support for the new HSL mode and instead added a warning. This is something to implement in the future.

  I didn't remove support for the replaced Separate/Combine RGB/HSV nodes for now, since they still exist in the Blender API and I'm not sure whether they can still be used in some older files or manually via Python. 

- I also fixed a shader compilation error due to a redefinition of a variable, which would happen if `parse_sephsv()` was called multiple times for different node outputs of the same node.