### PR TITLE
Fix exception when drawing the UI for bundled traits

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -169,6 +169,7 @@ def on_load_post(context):
 
     props.init_properties_on_load()
     reload_blend_data()
+    arm.utils.fetch_bundled_script_names()
 
     wrd = bpy.data.worlds['Arm']
     wrd.arm_recompile = True

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -849,9 +849,6 @@ def draw_traits_panel(layout: bpy.types.UILayout, obj: Union[bpy.types.Object, b
             if item.type_prop == 'Haxe Script':
                 row.prop_search(item, "class_name_prop", bpy.data.worlds['Arm'], "arm_scripts_list", text="Class")
             else:
-                # Bundled scripts not yet fetched
-                if not bpy.data.worlds['Arm'].arm_bundled_scripts_list:
-                    arm.utils.fetch_bundled_script_names()
                 row.prop_search(item, "class_name_prop", bpy.data.worlds['Arm'], "arm_bundled_scripts_list", text="Class")
 
         elif item.type_prop == 'WebAssembly':


### PR DESCRIPTION
Newer Blender versions no longer allow changing collection properties in draw() methods, this commit fixes an oversight from https://github.com/armory3d/armory/commit/04bd360cf6d8409926b7777a129ee2ad3c1b4008. When a blend file was opened after Armory was already registered, the now replaced code was called and caused an exception.

Thanks to Hreez on Discord for the report :)