### PR TITLE
Support multiple canvas onReady callbacks

### DIFF
--- a/Sources/armory/logicnode/CanvasGetLocationNode.hx
+++ b/Sources/armory/logicnode/CanvasGetLocationNode.hx
@@ -5,8 +5,6 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasGetLocationNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
 	var x: Float;
 	var y: Float;
 
@@ -15,28 +13,21 @@ class CanvasGetLocationNode extends LogicNode {
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e == null) return;
-
-		x = e.x;
-		y = e.y;
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e == null) return;
+
+			x = e.x;
+			y = e.y;
+			runOutput(0);
+		});
 	}
-    override function get(from: Int): Dynamic {
+
+	override function get(from: Int): Dynamic {
 		if (from == 1) return x;
 		else if (from == 2) return y;
 		else return 0;

--- a/Sources/armory/logicnode/CanvasGetPBNode.hx
+++ b/Sources/armory/logicnode/CanvasGetPBNode.hx
@@ -5,8 +5,6 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasGetPBNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
 	var at: Int;
 	var max: Int;
 
@@ -15,28 +13,21 @@ class CanvasGetPBNode extends LogicNode {
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e == null) return;
-
-		at = canvas.getElement(element).progress_at;
-        max = canvas.getElement(element).progress_total;
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e == null) return;
+
+			at = canvas.getElement(element).progress_at;
+			max = canvas.getElement(element).progress_total;
+			runOutput(0);
+		});
 	}
-    override function get(from: Int): Dynamic {
+
+	override function get(from: Int): Dynamic {
 		if (from == 1) return at;
 		else if (from == 2) return max;
 		else return 0;

--- a/Sources/armory/logicnode/CanvasGetRotationNode.hx
+++ b/Sources/armory/logicnode/CanvasGetRotationNode.hx
@@ -5,8 +5,6 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasGetRotationNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
 	var rad: Float;
 
 	public function new(tree: LogicTree) {
@@ -14,27 +12,20 @@ class CanvasGetRotationNode extends LogicNode {
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e == null) return;
-
-		rad = e.rotation;
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e == null) return;
+
+			rad = e.rotation;
+			runOutput(0);
+		});
 	}
-    override function get(from: Int): Dynamic {
+
+	override function get(from: Int): Dynamic {
 		if (from == 1) return rad;
 		else return 0;
 	}

--- a/Sources/armory/logicnode/CanvasGetScaleNode.hx
+++ b/Sources/armory/logicnode/CanvasGetScaleNode.hx
@@ -5,8 +5,6 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasGetScaleNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
 	var width: Int;
 	var height: Int;
 
@@ -15,27 +13,20 @@ class CanvasGetScaleNode extends LogicNode {
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e == null) return;
-
-		height = e.height;
-		width = e.width;
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e == null) return;
+
+			height = e.height;
+			width = e.width;
+			runOutput(0);
+		});
 	}
+
 	override function get(from: Int): Dynamic {
 		if (from == 1) return height;
 		else if (from == 2) return width;

--- a/Sources/armory/logicnode/CanvasSetAssetNode.hx
+++ b/Sources/armory/logicnode/CanvasSetAssetNode.hx
@@ -5,33 +5,21 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasSetAssetNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var asset: String;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e != null) e.asset = asset;
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		asset = Std.string(inputs[2].get());
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
+		var asset = Std.string(inputs[2].get());
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e != null) e.asset = asset;
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/logicnode/CanvasSetCheckBoxNode.hx
+++ b/Sources/armory/logicnode/CanvasSetCheckBoxNode.hx
@@ -31,8 +31,8 @@ class CanvasSetCheckBoxNode extends LogicNode {
 	override function run(from: Int) {
 		element = inputs[1].get();
 		value = inputs[2].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+
+		canvas = CanvasScript.getActiveCanvas();
 
 		// Ensure canvas is ready
 		tree.notifyOnUpdate(update);

--- a/Sources/armory/logicnode/CanvasSetInputTextNode.hx
+++ b/Sources/armory/logicnode/CanvasSetInputTextNode.hx
@@ -5,36 +5,21 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasSetInputTextNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var text: String;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getHandle(element);
-		if (e != null) e.text = text;			
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
+		var element = inputs[1].get();
+		var text = Std.string(inputs[2].get());
 
-		element = inputs[1].get();
-		text = Std.string(inputs[2].get());
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
-
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
-
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getHandle(element);
+			if (e != null) e.text = text;
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/logicnode/CanvasSetLocationNode.hx
+++ b/Sources/armory/logicnode/CanvasSetLocationNode.hx
@@ -5,38 +5,25 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasSetLocationNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var newX: Float;
-	var newY: Float;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e != null) {
-			e.x = newX;
-			e.y = newY;
-		}
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		newX = inputs[2].get();
-		newY = inputs[3].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
+		var newX = inputs[2].get();
+		var newY = inputs[3].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e != null) {
+				e.x = newX;
+				e.y = newY;
+			}
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/logicnode/CanvasSetPBNode.hx
+++ b/Sources/armory/logicnode/CanvasSetPBNode.hx
@@ -5,38 +5,25 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasSetPBNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var newAt: Int;
-    var newMax: Int;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e != null) {
-			e.progress_at = newAt;
-			e.progress_total = newMax;
-		}
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		newAt = inputs[2].get();
-        newMax = inputs[3].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
+		var newAt = inputs[2].get();
+		var newMax = inputs[3].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e != null) {
+				e.progress_at = newAt;
+				e.progress_total = newMax;
+			}
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/logicnode/CanvasSetProgressBarColorNode.hx
+++ b/Sources/armory/logicnode/CanvasSetProgressBarColorNode.hx
@@ -7,33 +7,21 @@ import iron.math.Vec4;
 
 class CanvasSetProgressBarColorNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var color = new Vec4();
-	
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e != null) e.color_progress = Color.fromFloats(color.x, color.y, color.z, color.w);
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		color = inputs[2].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
+		var color: Vec4 = inputs[2].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e != null) e.color_progress = Color.fromFloats(color.x, color.y, color.z, color.w);
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/logicnode/CanvasSetRotationNode.hx
+++ b/Sources/armory/logicnode/CanvasSetRotationNode.hx
@@ -5,33 +5,21 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasSetRotationNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var rad: Float;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e != null) e.rotation = rad;
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		rad = inputs[2].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
+		var rad = inputs[2].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e != null) e.rotation = rad;
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/logicnode/CanvasSetScaleNode.hx
+++ b/Sources/armory/logicnode/CanvasSetScaleNode.hx
@@ -5,38 +5,25 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasSetScaleNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var height: Int;
-    var width: Int;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e != null) {
-			e.height = height;
-			e.width = width;
-		}
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		height = inputs[2].get();
-        width = inputs[3].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
+		var height = inputs[2].get();
+		var width = inputs[3].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e != null) {
+				e.height = height;
+				e.width = width;
+			}
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/logicnode/CanvasSetSliderNode.hx
+++ b/Sources/armory/logicnode/CanvasSetSliderNode.hx
@@ -31,8 +31,8 @@ class CanvasSetSliderNode extends LogicNode {
 	override function run(from: Int) {
 		element = inputs[1].get();
 		value = inputs[2].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+
+		canvas = CanvasScript.getActiveCanvas();
 
 		// Ensure canvas is ready
 		tree.notifyOnUpdate(update);

--- a/Sources/armory/logicnode/CanvasSetTextColorNode.hx
+++ b/Sources/armory/logicnode/CanvasSetTextColorNode.hx
@@ -6,39 +6,24 @@ import kha.Color;
 
 class CanvasSetTextColorNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var r: Float;
-	var g: Float;
-	var b: Float;
-	var a: Float;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e != null) e.color_text = Color.fromFloats(r, g, b, a);
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		r = inputs[2].get();
-		g = inputs[3].get();
-		b = inputs[4].get();
-		a = inputs[5].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
+		var r = inputs[2].get();
+		var g = inputs[3].get();
+		var b = inputs[4].get();
+		var a = inputs[5].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e != null) e.color_text = Color.fromFloats(r, g, b, a);
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/logicnode/CanvasSetTextNode.hx
+++ b/Sources/armory/logicnode/CanvasSetTextNode.hx
@@ -5,33 +5,21 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasSetTextNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var text: String;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var e = canvas.getElement(element);
-		if (e != null) e.text = text;
-		runOutput(0);
-	}
-
 	override function run(from: Int) {
-		element = inputs[1].get();
-		text = Std.string(inputs[2].get());
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
+		var text = Std.string(inputs[2].get());
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e != null) e.text = text;
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/logicnode/CanvasSetVisibleNode.hx
+++ b/Sources/armory/logicnode/CanvasSetVisibleNode.hx
@@ -5,32 +5,21 @@ import armory.trait.internal.CanvasScript;
 
 class CanvasSetVisibleNode extends LogicNode {
 
-	var canvas: CanvasScript;
-	var element: String;
-	var visible: Bool;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 #if arm_ui
-	function update() {
-		if (!canvas.ready) return;
-		tree.removeUpdate(update);
-
-		var element = canvas.getElement(element);
-		if (element != null) element.visible = this.visible;
-		runOutput(0);
-	}
 	override function run(from: Int) {
-		element = inputs[1].get();
-		visible = inputs[2].get();
-		canvas = Scene.active.getTrait(CanvasScript);
-		if (canvas == null) canvas = Scene.active.camera.getTrait(CanvasScript);
+		var element = inputs[1].get();
+		var visible = inputs[2].get();
 
-		// Ensure canvas is ready
-		tree.notifyOnUpdate(update);
-		update();
+		var canvas = CanvasScript.getActiveCanvas();
+		canvas.notifyOnReady(() -> {
+			var e = canvas.getElement(element);
+			if (e != null) e.visible = visible;
+			runOutput(0);
+		});
 	}
 #end
 }

--- a/Sources/armory/trait/internal/CanvasScript.hx
+++ b/Sources/armory/trait/internal/CanvasScript.hx
@@ -2,6 +2,7 @@ package armory.trait.internal;
 
 import iron.Trait;
 #if arm_ui
+import iron.Scene;
 import zui.Zui;
 import armory.ui.Canvas;
 #end
@@ -175,6 +176,15 @@ class CanvasScript extends Trait {
 	public function getHandle(name: String): Handle {
 		// Consider this a temporary solution
 		return Canvas.h.children[getElement(name).id];
+	}
+
+	public static function getActiveCanvas(): CanvasScript {
+		var activeCanvas = Scene.active.getTrait(CanvasScript);
+		if (activeCanvas == null) activeCanvas = Scene.active.camera.getTrait(CanvasScript);
+
+		assert(Error, activeCanvas != null, "Could not find a canvas trait on the active scene or camera");
+
+		return activeCanvas;
 	}
 
 #else

--- a/Sources/armory/trait/internal/CanvasScript.hx
+++ b/Sources/armory/trait/internal/CanvasScript.hx
@@ -17,6 +17,8 @@ class CanvasScript extends Trait {
 	public var ready(get, null): Bool;
 	function get_ready(): Bool { return canvas != null; }
 
+	var onReadyFuncs: Array<Void->Void> = null;
+
 	/**
 	 * Create new CanvasScript from canvas
 	 * @param canvasName Name of the canvas
@@ -78,13 +80,23 @@ class CanvasScript extends Trait {
 				if (all != null) for (entry in all) entry.onEvent();
 			}
 
-			if (onReady != null) { onReady(); onReady = null; }
+			if (onReadyFuncs != null) {
+				for (f in onReadyFuncs) {
+					f();
+				}
+				onReadyFuncs.resize(0);
+			}
 		});
 	}
 
-	var onReady: Void->Void = null;
+	/**
+		Run the given callback function `f` when the canvas is loaded and ready.
+
+		@see https://github.com/armory3d/armory/wiki/traits#canvas-trait-events
+	**/
 	public function notifyOnReady(f: Void->Void) {
-		onReady = f;
+		if (onReadyFuncs == null) onReadyFuncs = [];
+		onReadyFuncs.push(f);
 	}
 
 	/**


### PR DESCRIPTION
This PR changes `CanvasScript.notifyOnReady()` to allow registration of multiple callbacks instead of just one. Other trait callbacks (init, update, render, etc.) already allow multiple callbacks, so it only makes sense to make onReady work in the same way.

With that change it is also possible to remove a lot of redundancy from the canvas nodes. Some canvas nodes make use of a try/catch workaround for some issue that's unfortunately not further explained ([here for example](https://github.com/armory3d/armory/blob/fc3bdd8d23b8aa75c6e42424f8e8a7d84a0b012e/Sources/armory/logicnode/CanvasGetCheckboxNode.hx#L20-L21)), so in order to not break anything I left those nodes as they currently are and further tests are required here.