### PR TITLE
Debug Console: show active camera in outliner and hide "Set Active Camera" button for active cameras

### DIFF
--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -309,7 +309,7 @@ class DebugConsole extends Trait {
 					ui.indent();
 
 					if (selectedObject != null) {
-						if (Std.isOfType(selectedObject, iron.object.CameraObject)) {
+						if (Std.isOfType(selectedObject, iron.object.CameraObject) && selectedObject != iron.Scene.active.camera) {
 							ui.row([1/2, 1/2]);
 						}
 
@@ -317,9 +317,9 @@ class DebugConsole extends Trait {
 						h.selected = selectedObject.visible;
 						selectedObject.visible = ui.check(h, "Visible");
 
-						if (Std.isOfType(selectedObject, iron.object.CameraObject)) {
+						if (Std.isOfType(selectedObject, iron.object.CameraObject) && selectedObject != iron.Scene.active.camera) {
 							if (ui.button("Set Active Camera")) {
-								iron.Scene.active.camera = cast(selectedObject, iron.object.CameraObject);
+								iron.Scene.active.camera = cast selectedObject;
 							}
 						}
 

--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -210,10 +210,37 @@ class DebugConsole extends Trait {
 				if (ui.panel(Id.handle({selected: true}), "Outliner")) {
 					ui.indent();
 
+					var listX = ui._x;
+					var listW = ui._w;
+
+					function drawObjectNameInList(object: iron.object.Object, selected: Bool) {
+						var _y = ui._y;
+						ui.text(object.name);
+
+						if (object == iron.Scene.active.camera) {
+							var tagWidth = 100;
+							var offsetX = listW - tagWidth;
+
+							var prevX = ui._x;
+							var prevY = ui._y;
+							var prevW = ui._w;
+							ui._x = listX + offsetX;
+							ui._y = _y;
+							ui._w = tagWidth;
+							ui.g.color = selected ? kha.Color.White : kha.Color.fromFloats(0.941, 0.914, 0.329, 1.0);
+							ui.drawString(ui.g, "Active Camera", null, 0, Right);
+							ui._x = prevX;
+							ui._y = prevY;
+							ui._w = prevW;
+						}
+					}
+
 					var lineCounter = 0;
 					function drawList(listHandle: zui.Zui.Handle, currentObject: iron.object.Object) {
 						if (currentObject.name.charAt(0) == ".") return; // Hidden
 						var b = false;
+
+						var isLineSelected = currentObject == selectedObject;
 
 						// Highlight every other line
 						if (lineCounter % 2 == 0) {
@@ -223,7 +250,7 @@ class DebugConsole extends Trait {
 						}
 
 						// Highlight selected line
-						if (currentObject == selectedObject) {
+						if (isLineSelected) {
 							ui.g.color = 0xff205d9c;
 							ui.g.fillRect(0, ui._y, ui._windowW, ui.ELEMENT_H());
 							ui.g.color = 0xffffffff;
@@ -232,7 +259,7 @@ class DebugConsole extends Trait {
 						if (currentObject.children.length > 0) {
 							ui.row([1 / 13, 12 / 13]);
 							b = ui.panel(listHandle.nest(lineCounter, {selected: true}), "", true, false, false);
-							ui.text(currentObject.name);
+							drawObjectNameInList(currentObject, isLineSelected);
 						}
 						else {
 							ui._x += 18; // Sign offset
@@ -242,7 +269,7 @@ class DebugConsole extends Trait {
 							ui.g.drawLine(ui._x - 10, ui._y + ui.ELEMENT_H() / 2, ui._x, ui._y + ui.ELEMENT_H() / 2);
 							ui.g.color = 0xffffffff;
 
-							ui.text(currentObject.name);
+							drawObjectNameInList(currentObject, isLineSelected);
 							ui._x -= 18;
 						}
 

--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -209,6 +209,7 @@ class DebugConsole extends Trait {
 
 				if (ui.panel(Id.handle({selected: true}), "Outliner")) {
 					ui.indent();
+					ui._y -= ui.ELEMENT_OFFSET();
 
 					var listX = ui._x;
 					var listW = ui._w;


### PR DESCRIPTION
The active camera is now highlighted in the outliner, making it easier to find:

![Screenshot](https://user-images.githubusercontent.com/17685000/192371092-dc06c5d3-1892-41e1-856a-f319175f1bfa.png)

Also, the "Set Active Camera" button is no longer visible for already active cameras.

---

@ luboslenco (or @ anyone who knows Zui better than me): is it possible to add scrollbars not only to windows, but to areas inside of windows? The outliner can get pretty long in complex scenes which then pushes the object properties out of view. Also, is there a way to check in Zui whether the mouse currently hovers some UI elements/windows? Currently, you can click "through" the debug console which in some cases is a bit annoying.

I would like to implement both these things, but my Zui knowledge is rusty and I can't seem to find a good solution.