### PR TITLE
Warn about precision issues for very large UV coordinates

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1362,7 +1362,7 @@ class ArmoryExporter:
         return None
 
     @staticmethod
-    def check_uv_precision(mesh: bpy.types.Mesh, uv_max_dim: float, invscale_tex: float):
+    def check_uv_precision(mesh: bpy.types.Mesh, uv_max_dim: float, max_dim_uvmap: bpy.types.MeshUVLoopLayer, invscale_tex: float):
         """Check whether the pixel size (assuming max_texture_size below)
         can be represented inside the usual [0, 1] UV range with the
         given `invscale_tex` that is used to normalize the UV coords.
@@ -1376,9 +1376,9 @@ class ArmoryExporter:
         # UV coords with an absolute value > 1 can be reliably represented.
         if np.float32(1.0) == np.float32(1.0) - np.float32(pixel_size * invscale_tex):
             log.warn(
-                f'A UV map of the mesh "{mesh.name}" contains very large'
-                f' coordinates (max. distance from origin: {uv_max_dim}).'
-                f' The UV precision may suffer.'
+                f'Mesh "{mesh.name}": The UV map "{max_dim_uvmap.name}"'
+                ' contains very large coordinates (max. distance from'
+                f' origin: {uv_max_dim}). The UV precision may suffer.'
             )
 
     def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Object, o, has_armature=False):
@@ -1406,6 +1406,7 @@ class ArmoryExporter:
         if has_tex or has_morph_target:
             uv_layers = export_mesh.uv_layers
             maxdim = 1.0
+            maxdim_uvlayer = None
             if has_tex:
                 t0map = 0 # Get active uvmap
                 t0data = np.empty(num_verts * 2, dtype='<f4')
@@ -1432,6 +1433,7 @@ class ArmoryExporter:
                     t1data = np.empty(num_verts * 2, dtype='<f4')
                 # Scale for packed coords
                 lay0 = uv_layers[t0map]
+                maxdim_uvlayer = lay0
                 for v in lay0.data:
                     if abs(v.uv[0]) > maxdim:
                         maxdim = abs(v.uv[0])
@@ -1442,22 +1444,26 @@ class ArmoryExporter:
                     for v in lay1.data:
                         if abs(v.uv[0]) > maxdim:
                             maxdim = abs(v.uv[0])
+                            maxdim_uvlayer = lay1
                         if abs(v.uv[1]) > maxdim:
                             maxdim = abs(v.uv[1])
+                            maxdim_uvlayer = lay1
             if has_morph_target:
                 morph_data = np.empty(num_verts * 2, dtype='<f4')
                 lay2 = uv_layers[morph_uv_index]
                 for v in lay2.data:
                     if abs(v.uv[0]) > maxdim:
                         maxdim = abs(v.uv[0])
+                        maxdim_uvlayer = lay2
                     if abs(v.uv[1]) > maxdim:
                         maxdim = abs(v.uv[1])
+                        maxdim_uvlayer = lay2
             if maxdim > 1:
                 o['scale_tex'] = maxdim
                 invscale_tex = (1 / o['scale_tex']) * 32767
             else:
                 invscale_tex = 1 * 32767
-            self.check_uv_precision(export_mesh, maxdim, invscale_tex)
+            self.check_uv_precision(export_mesh, maxdim, maxdim_uvlayer, invscale_tex)
             if has_tang:
                 try:
                     export_mesh.calc_tangents(uvmap=lay0.name)

--- a/blender/arm/exporter_opt.py
+++ b/blender/arm/exporter_opt.py
@@ -139,6 +139,7 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
     if has_tex or has_morph_target:
         uv_layers = export_mesh.uv_layers
         maxdim = 1.0
+        maxdim_uvlayer = None
         if has_tex:
             t0map = 0 # Get active uvmap
             t0data = np.empty(num_verts * 2, dtype='<f4')
@@ -165,6 +166,7 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
                 t1data = np.empty(num_verts * 2, dtype='<f4')
             # Scale for packed coords
             lay0 = uv_layers[t0map]
+            maxdim_uvlayer = lay0
             for v in lay0.data:
                 if abs(v.uv[0]) > maxdim:
                     maxdim = abs(v.uv[0])
@@ -175,22 +177,26 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
                 for v in lay1.data:
                     if abs(v.uv[0]) > maxdim:
                         maxdim = abs(v.uv[0])
+                        maxdim_uvlayer = lay1
                     if abs(v.uv[1]) > maxdim:
                         maxdim = abs(v.uv[1])
+                        maxdim_uvlayer = lay1
         if has_morph_target:
             morph_data = np.empty(num_verts * 2, dtype='<f4')
             lay2 = uv_layers[morph_uv_index]
             for v in lay2.data:
                 if abs(v.uv[0]) > maxdim:
                     maxdim = abs(v.uv[0])
+                    maxdim_uvlayer = lay2
                 if abs(v.uv[1]) > maxdim:
                     maxdim = abs(v.uv[1])
+                    maxdim_uvlayer = lay2
         if maxdim > 1:
             o['scale_tex'] = maxdim
             invscale_tex = (1 / o['scale_tex']) * 32767
         else:
             invscale_tex = 1 * 32767
-        self.check_uv_precision(export_mesh, maxdim, invscale_tex)
+        self.check_uv_precision(export_mesh, maxdim, maxdim_uvlayer, invscale_tex)
 
     if has_col:
         cdata = np.empty(num_verts * 3, dtype='<f4')

--- a/blender/arm/exporter_opt.py
+++ b/blender/arm/exporter_opt.py
@@ -190,6 +190,7 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
             invscale_tex = (1 / o['scale_tex']) * 32767
         else:
             invscale_tex = 1 * 32767
+        self.check_uv_precision(export_mesh, maxdim, invscale_tex)
 
     if has_col:
         cdata = np.empty(num_verts * 3, dtype='<f4')


### PR DESCRIPTION
This PR adds a warning for a precision issue that would happen if a UV map has extremely large coordinates. Since exported UV coords are normalized based on the largest coordinate, such cases lead to situations where sufficiently small differences in UV coordinates cannot be represented anymore. In the case of UV coordinates many million units away from the origin, arbitrary coordinates in [0, 1] no longer work as expected.

There may be some cases in which we could attempt some automatic corrections, but since there can be cases where an entire UV island is scaled extremely large we cannot completely solve this issue. Also, the user might use procedural textures where there isn't any tiling.

Instead, there is now a function that checks whether we can represent pixel differences in the [0, 1] range, assuming that the user is mostly interested in that range. More accurate checks that compute the maximum error for all coordinates would be possible, but likely much slower. Also, for calculating the pixel sizes we use a hard-coded maximum texture size of 16k which in the future could be made configurable (e.g. if there would be a feature to auto-scale textures larger than some size). It is still possible to use UV coords many tens of thousands units away without triggering this warning, so it's pretty unobtrusive :)

Thanks to JoshuaBinswanger on Discord for reporting this and to @ QuantumCoderQC for help and discussion on this issue :)