### PR TITLE
Update the Lightmapper to support Blender 3.3

### DIFF
--- a/blender/arm/lightmapper/utility/cycles/lightmap.py
+++ b/blender/arm/lightmapper/utility/cycles/lightmap.py
@@ -137,8 +137,10 @@ def bake(plus_pass=0):
                     print("IndirAO")
                     
                     if bpy.app.driver_namespace["tlm_plus_mode"] == 1:
-                        bpy.ops.object.bake(type="DIFFUSE", pass_filter={"DIRECT","INDIRECT"}, margin=scene.TLM_EngineProperties.tlm_dilation_margin, use_clear=False)
+                        print("IndirAO: 1")
+                        bpy.ops.object.bake(type="DIFFUSE", pass_filter={"INDIRECT"}, margin=scene.TLM_EngineProperties.tlm_dilation_margin, use_clear=False)
                     elif bpy.app.driver_namespace["tlm_plus_mode"] == 2:
+                        print("IndirAO: 2")
                         bpy.ops.object.bake(type="AO", margin=scene.TLM_EngineProperties.tlm_dilation_margin, use_clear=False)
                 
                 elif scene.TLM_EngineProperties.tlm_lighting_mode == "complete":

--- a/blender/arm/lightmapper/utility/denoiser/oidn.py
+++ b/blender/arm/lightmapper/utility/denoiser/oidn.py
@@ -25,7 +25,7 @@ class TLM_OIDN_Denoise:
 
         if oidnPath != "":
 
-            file = os.path.basename(os.path.realpath(oidnPath))
+            file = oidnPath
             filename, file_extension = os.path.splitext(file)
             
             

--- a/blender/arm/lightmapper/utility/denoiser/optix.py
+++ b/blender/arm/lightmapper/utility/denoiser/optix.py
@@ -24,7 +24,7 @@ class TLM_Optix_Denoise:
 
         if optixPath != "":
 
-            file = os.path.basename(os.path.realpath(optixPath))
+            file = optixPath
             filename, file_extension = os.path.splitext(file)
 
             if(file_extension == ".exe"):

--- a/blender/arm/lightmapper/utility/utility.py
+++ b/blender/arm/lightmapper/utility/utility.py
@@ -434,7 +434,7 @@ def Unwrap_Lightmap_Group_Xatlas_2_headless_call(obj):
 
     #get the path to xatlas
     #file_path = os.path.dirname(os.path.abspath(__file__))
-    scriptsDir = bpy.utils.user_resource('SCRIPTS', "addons")
+    scriptsDir = os.path.join(bpy.utils.user_resource('SCRIPTS'), "addons")
     file_path = os.path.join(scriptsDir, "blender_xatlas")
     if platform.system() == "Windows":
         xatlas_path = os.path.join(file_path, "xatlas", "xatlas-blender.exe")


### PR DESCRIPTION
The lightmapper was a bit broken with Blender 3.3. I added some fixes to render-tile paths, addon path, nodes fetching hadn't been updated to 3.3, and a fix for whatever [BF did to force filmic 8-bit output on bake results](https://developer.blender.org/rB2b80bfe):

![image](https://user-images.githubusercontent.com/5429817/192879407-b8063a74-a7b3-4c5e-b136-a8297de60450.png)