### PR TITLE
Fix socket indices of Principled BSDF node

### DIFF
--- a/blender/arm/material/cycles_nodes/nodes_shader.py
+++ b/blender/arm/material/cycles_nodes/nodes_shader.py
@@ -49,7 +49,7 @@ def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket,
 
 def parse_bsdfprincipled(node: bpy.types.ShaderNodeBsdfPrincipled, out_socket: NodeSocket, state: ParserState) -> None:
     if state.parse_surface:
-        c.write_normal(node.inputs[20])
+        c.write_normal(node.inputs[22])
         state.out_basecol = c.parse_vector_input(node.inputs[0])
         # subsurface = c.parse_vector_input(node.inputs[1])
         # subsurface_radius = c.parse_vector_input(node.inputs[2])
@@ -68,7 +68,7 @@ def parse_bsdfprincipled(node: bpy.types.ShaderNodeBsdfPrincipled, out_socket: N
         # transmission = c.parse_vector_input(node.inputs[15])
         # transmission_roughness = c.parse_vector_input(node.inputs[16])
         if node.inputs[20].is_linked or node.inputs[20].default_value != 0.0:
-            state.out_emission = '({0}.x)'.format(c.parse_vector_input(node.inputs[20]))
+            state.out_emission = f'({c.rgb_to_bw(c.parse_vector_input(node.inputs[19]))} * {c.parse_value_input(node.inputs[20])})'
             state.emission_found = True
         # clearcoar_normal = c.parse_vector_input(node.inputs[21])
         # tangent = c.parse_vector_input(node.inputs[22])


### PR DESCRIPTION
Apparently, Blender changed the Principled BSDF sockets a second time between 3.0-3.3 without a note in the release notes, at least I can't find it anywhere.

This PR fixes parsing normals and emission values. Emission is still pretty broken since we have no space left in the gbuffers to save any emission color (https://github.com/armory3d/armory/issues/1774), and I don't think that we can fix it without a 3rd render target. However, this would mean that either the 3rd render target would be bound all the time during mesh rendering, or we'd need to sort the meshes each frame to prevent to many context switches and maybe also bandwidth issues (I'm not sure what affects the bandwidth in what way, more specifically where it matters). @ luboslenco do you have an opinion on this? I think the current emission support is a problem, but I can also understand if you say that improving it would waste too much performance.

Here's a comparison between Blender and Armory, the cubes on the left use the Principled BSDF node, and the cubes on the right use the emission node. If you want I can add this file to the [armory_calibration](https://github.com/armory3d/armory_calibration) repo, but as you can see it doesn't completely work yet:

![grafik](https://user-images.githubusercontent.com/17685000/193075316-9f5c53eb-56ee-4f39-91ba-c0257bd59b3b.png)


----

*Off-topic: what exactly is `rp_render_to_texture` supposed to do/solve? There's a bug with transparency if this flag is disabled, I found two possible fixes and my decision about what fix to choose depends on what this flag does.*

