### PR TITLE
Water ssr

### DIFF
--- a/Shaders/water_pass/water_pass.frag.glsl
+++ b/Shaders/water_pass/water_pass.frag.glsl
@@ -176,7 +176,7 @@ void main() {
 	intensity = clamp(intensity, 0.0, 1.0);
 	vec3 reflCol = textureLod(tex, coords.xy, 0.0).rgb;
 	fragColor.rgb = reflectedEnv * waterReflect / 4 * fresnel;
-	fragColor.rgb += reflCol * intensity * waterReflect;
+	fragColor.rgb += reflCol * intensity * waterReflect * fresnel;
 	fragColor.rgb += refracted;
 	#else
 	fragColor.rgb = mix(refracted, reflectedEnv, waterReflect * fresnel);

--- a/Shaders/water_pass/water_pass.frag.glsl
+++ b/Shaders/water_pass/water_pass.frag.glsl
@@ -17,7 +17,7 @@ uniform mat3 V3;
 uniform vec3 PPComp9;
 uniform vec3 PPComp10;
 #endif
-#endfi
+#endif
 
 #ifdef _Rad
 uniform sampler2D senvmapRadiance;
@@ -175,8 +175,9 @@ void main() {
 	#endif
 	intensity = clamp(intensity, 0.0, 1.0);
 	vec3 reflCol = textureLod(tex, coords.xy, 0.0).rgb;
-	fragColor.rgb = mix(refracted, reflCol * intensity * 0.5, waterReflect * fresnel * 0.5);
-	fragColor.rgb = mix(fragColor.rgb, reflectedEnv, waterReflect * fresnel);
+	fragColor.rgb = reflectedEnv * waterReflect / 4 * fresnel;
+	fragColor.rgb += reflCol * intensity * waterReflect;
+	fragColor.rgb += refracted;
 	#else
 	fragColor.rgb = mix(refracted, reflectedEnv, waterReflect * fresnel);
 	#endif

--- a/Shaders/water_pass/water_pass.json
+++ b/Shaders/water_pass/water_pass.json
@@ -61,11 +61,6 @@
 					"name": "P",
 					"link": "_projectionMatrix",
 					"ifdef": ["_SSR"]
-				},
-				{
-					"name": "V3",
-					"link": "_viewMatrix3",
-					"ifdef": ["_SSR"]
 				}
 			],
 			"texture_params": [],


### PR DESCRIPTION
There was a type in the shader, "endfi" instead of "endif".
I replaced the mix for additions with desired factors:
```
fragColor.rgb = reflectedEnv * waterReflect / 4 * fresnel;
fragColor.rgb += reflCol * intensity * waterReflect;
fragColor.rgb += refracted;`
```
With correct ocean and ssr settings, this yields something nice.


![waterssr](https://user-images.githubusercontent.com/29781855/193267559-781c30db-02ab-4a01-8f17-b32b24b1266c.png)
