### PR TITLE
New "Combine RGBA" node and add alpha output to "Separate RGB" node

### DIFF
--- a/Sources/armory/logicnode/CombineColorNode.hx
+++ b/Sources/armory/logicnode/CombineColorNode.hx
@@ -1,0 +1,24 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+
+class CombineColorNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var r = inputs[0].get();
+		var g = inputs[1].get();
+		var b = inputs[2].get();
+		var a = inputs[3].get();
+
+		return new Vec4(
+			r == null ? 0.0 : r,
+			g == null ? 0.0 : g,
+			b == null ? 0.0 : b,
+			a == null ? 0.0 : a
+		);
+	}
+}

--- a/Sources/armory/logicnode/SeparateColorNode.hx
+++ b/Sources/armory/logicnode/SeparateColorNode.hx
@@ -12,8 +12,12 @@ class SeparateColorNode extends LogicNode {
 		var vector: Vec4 = inputs[0].get();
 		if (vector == null) return 0.0;
 
-		if (from == 0) return vector.x;
-		else if (from == 1) return vector.y;
-		else return vector.z;
+		return switch (from) {
+			case 0: vector.x;
+			case 1: vector.y;
+			case 2: vector.z;
+			case 3: vector.w;
+			default: throw "Unreachable";
+		}
 	}
 }

--- a/blender/arm/logicnode/math/LN_combine_rgb.py
+++ b/blender/arm/logicnode/math/LN_combine_rgb.py
@@ -1,0 +1,19 @@
+from arm.logicnode.arm_nodes import *
+
+
+class CombineColorNode(ArmLogicTreeNode):
+    """Combines the given RGBA (red, green, blue, and alpha) components to a color value.
+    If any input is `null`, the respective channel of the output color is set to `0.0`.
+    """
+    bl_idname = 'LNCombineColorNode'
+    bl_label = 'Combine RGBA'
+    arm_section = 'color'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmFloatSocket', 'R', default_value=0.0)
+        self.add_input('ArmFloatSocket', 'G', default_value=0.0)
+        self.add_input('ArmFloatSocket', 'B', default_value=0.0)
+        self.add_input('ArmFloatSocket', 'A', default_value=1.0)
+
+        self.add_output('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])

--- a/blender/arm/logicnode/math/LN_separate_rgb.py
+++ b/blender/arm/logicnode/math/LN_separate_rgb.py
@@ -1,11 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
+
 class SeparateColorNode(ArmLogicTreeNode):
-    """Splits the given color into RGB (red, green and blue)."""
+    """Splits the given color into its RGBA components (red, green, blue, and alpha).
+    If the input color is `null`, the outputs are each set to `0.0`.
+    """
     bl_idname = 'LNSeparateColorNode'
-    bl_label = 'Separate RGB'
+    bl_label = 'Separate RGBA'
     arm_section = 'color'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
         self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
@@ -13,3 +16,10 @@ class SeparateColorNode(ArmLogicTreeNode):
         self.add_output('ArmFloatSocket', 'R')
         self.add_output('ArmFloatSocket', 'G')
         self.add_output('ArmFloatSocket', 'B')
+        self.add_output('ArmFloatSocket', 'A')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement.Identity(self)


### PR DESCRIPTION
Closes https://github.com/armory3d/armory/issues/1721.

Following https://github.com/armory3d/armory/pull/2608, there still was no way to specifically set individual color values, which is possible now with the new "Combine RGBA" node. The "Separate RGB" node was expanded by an alpha output and is now called "Separate RGBA".