### PR TITLE
Fix building for Krom on Windows

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -560,8 +560,8 @@ def build_success():
             url = 'http://{}:{}/{}'.format(host, prefs.html5_server_port, path)
             browser = webbrowser.get().name
             if 'ARMORY_PLAY_HTML5' in os.environ:
-                str = Template(os.environ['ARMORY_PLAY_HTML5']).safe_substitute({'host': host, 'port': prefs.html5_server_port, 'width': width, 'height': height, 'url': url, 'path': path, 'dir': build_dir, 'browser': browser})
-                cmd = re.split(' +', str)
+                template_str = Template(os.environ['ARMORY_PLAY_HTML5']).safe_substitute({'host': host, 'port': prefs.html5_server_port, 'width': width, 'height': height, 'url': url, 'path': path, 'dir': build_dir, 'browser': browser})
+                cmd = re.split(' +', template_str)
             if len(cmd) == 0:
                 if browser == '':
                     webbrowser.open(url)
@@ -578,13 +578,13 @@ def build_success():
             pid = os.getpid()
             os.chdir(krom_location)
             if 'ARMORY_PLAY_KROM' in os.environ:
-                str = Template(os.environ['ARMORY_PLAY_KROM']).safe_substitute({'pid': pid,'audio': wrd.arm_audio != 'Disabled', 'location': krom_location, 'krom_path': krom_path, 'path': path, 'resources': path_resources, 'width': width, 'height': height })
-                cmd = re.split(' +', str)
+                template_str = Template(os.environ['ARMORY_PLAY_KROM']).safe_substitute({'pid': pid,'audio': wrd.arm_audio != 'Disabled', 'location': krom_location, 'krom_path': krom_path, 'path': path, 'resources': path_resources, 'width': width, 'height': height })
+                cmd = re.split(' +', template_str)
             if len(cmd) == 0:
                 cmd = [krom_path, path, path_resources]
                 if arm.utils.get_os() == 'win':
                     cmd.append('--consolepid')
-                    cmd.append(pid)
+                    cmd.append(str(pid))
                 if wrd.arm_audio == 'Disabled':
                     cmd.append('--nosound')
         if wrd.arm_verbose_output:


### PR DESCRIPTION
This fixes an exception when trying to build for Krom on Windows that was introduced in https://github.com/armory3d/armory/pull/2605/commits/435f155c8a01a606ea72fd93d63921042644da3d. Unfortunately, I didn't notice it in time for the 22.10 release. There were two different problems:

- `str` was used as a variable name, thus overwriting all uses of `str()`
- `pid` is an integer and was causing an exception on Windows because it was used in a `subprocess` command list that only accepts strings or byte objects

@luboslenco I would have pushed this to main directly, but since it's quite a major issue: could you please update the builds on itch\.io after this PR is merged? Thanks a lot, and sorry for the inconvenience :)