### PR TITLE
Add option for NavAgent height offset

### DIFF
--- a/Sources/armory/logicnode/GoToLocationNode.hx
+++ b/Sources/armory/logicnode/GoToLocationNode.hx
@@ -1,20 +1,36 @@
 package armory.logicnode;
 
+#if arm_physics
+import armory.trait.physics.bullet.PhysicsWorld;
+#end
 import armory.trait.navigation.Navigation;
 import iron.object.Object;
 import iron.math.Vec4;
 
 class GoToLocationNode extends LogicNode {
 
+	var object: Object;
+	var location: Vec4;
+	var speed: Float;
+	var turnDuration: Float;
+	var heightOffset: Float;
+	var useRaycast: Bool;
+	var rayCastDepth: Float;
+	var rayCastMask: Int;
+
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 	override function run(from: Int) {
-		var object: Object = inputs[1].get();
-		var location: Vec4 = inputs[2].get();
-		var speed: Float = inputs[3].get();
-		var turnDuration: Float = inputs[4].get();
+		object = inputs[1].get();
+		location = inputs[2].get();
+		speed = inputs[3].get();
+		turnDuration = inputs[4].get();
+		heightOffset = inputs[5].get();
+		useRaycast = inputs[6].get();
+		rayCastDepth = inputs[7].get();
+		rayCastMask = inputs[8].get();
 
 		assert(Error, object != null, "The object input not be null");
 		assert(Error, location != null, "The location to navigate to must not be null");
@@ -33,10 +49,34 @@ class GoToLocationNode extends LogicNode {
 			assert(Error, agent != null, "Object does not have a NavAgent trait");
 			agent.speed = speed;
 			agent.turnDuration = turnDuration;
+			agent.heightOffset = heightOffset;
+			agent.tickPos = tickPos;
+			agent.tickRot = tickRot;
 			agent.setPath(path);
 		});
 #end
 
 		runOutput(0);
+	}
+
+	function tickPos(){
+		#if arm_physics
+		if(useRaycast) setAgentHeight();
+		#end
+		runOutput(1);
+	}
+
+	function tickRot(){
+		runOutput(2);
+	}
+
+	function setAgentHeight(){
+		#if arm_physics
+		var fromLoc = object.transform.world.getLoc();
+		var toLoc = fromLoc.clone();
+		toLoc.z += rayCastDepth;
+		var hit = PhysicsWorld.active.rayCast(fromLoc, toLoc, rayCastMask);
+		if(hit != null) object.transform.loc.z = hit.pos.z + heightOffset;
+		#end
 	}
 }

--- a/Sources/armory/trait/NavAgent.hx
+++ b/Sources/armory/trait/NavAgent.hx
@@ -11,12 +11,17 @@ class NavAgent extends Trait {
 	public var speed: Float = 5;
 	@prop
 	public var turnDuration: Float = 0.4;
+	@prop
+	public var heightOffset: Float = 0.0;
 
 	var path: Array<Vec4> = null;
 	var index = 0;
 
 	var rotAnim: TAnim = null;
 	var locAnim: TAnim = null;
+
+	public var tickPos: Null<Void -> Void>;
+	public var tickRot: Null<Void -> Void>;
 
 	public function new() {
 		super();
@@ -60,14 +65,14 @@ class NavAgent extends Trait {
 
 		orient.subvecs(p, object.transform.loc).normalize;
 		var targetAngle = Math.atan2(orient.y, orient.x) + Math.PI / 2;
-		locAnim = Tween.to({ target: object.transform.loc, props: { x: p.x, y: p.y, z: p.z }, duration: dist / speed, done: function() {
+		locAnim = Tween.to({ target: object.transform.loc, props: { x: p.x, y: p.y, z: p.z + heightOffset }, duration: dist / speed, tick: tickPos, done: function() {
 			index++;
 			if (index < path.length) go();
 			else removeUpdate(update);
 		}});
 
 		var q = new Quat();
-		rotAnim = Tween.to({ target: object.transform, props: { rot: q.fromEuler(0, 0, targetAngle) }, duration: turnDuration});
+		rotAnim = Tween.to({ target: object.transform, props: { rot: q.fromEuler(0, 0, targetAngle) }, tick: tickRot, duration: turnDuration});
 	}
 
 	function update() {

--- a/Sources/armory/trait/NavMesh.hx
+++ b/Sources/armory/trait/NavMesh.hx
@@ -68,7 +68,6 @@ class NavMesh extends Trait {
 		recast.findPath(from.x, from.z, from.y, to.x, to.z, to.y, 200, function(path: Array<RecastWaypoint>) {
 			var ar: Array<Vec4> = [];
 			for (p in path) ar.push(new Vec4(p.x, p.z, p.y - cellHeight));
-			trace(ar);
 			done(ar);
 		});
 	}

--- a/Sources/armory/trait/NavMesh.hx
+++ b/Sources/armory/trait/NavMesh.hx
@@ -67,7 +67,8 @@ class NavMesh extends Trait {
 		if (!ready) return;
 		recast.findPath(from.x, from.z, from.y, to.x, to.z, to.y, 200, function(path: Array<RecastWaypoint>) {
 			var ar: Array<Vec4> = [];
-			for (p in path) ar.push(new Vec4(p.x, p.z, p.y));
+			for (p in path) ar.push(new Vec4(p.x, p.z, p.y - cellHeight));
+			trace(ar);
 			done(ar);
 		});
 	}

--- a/blender/arm/logicnode/navmesh/LN_go_to_location.py
+++ b/blender/arm/logicnode/navmesh/LN_go_to_location.py
@@ -1,10 +1,25 @@
 from arm.logicnode.arm_nodes import *
 
 class GoToLocationNode(ArmLogicTreeNode):
-    """Makes a NavMesh agent go to location."""
+    """Makes a NavMesh agent go to location.
+
+    @input In: Start navigation.
+    @input Object: The object to navigate. Object must have `NavAgent` trait applied.
+    @input Location: Closest point on the navmesh to navigate to.
+    @input Speed: Rate of movement.
+    @input Turn Duration: Rate of turn.
+    @input Height Offset: Height of the object from the navmesh.
+    @input Use Raycast: Use physics ray cast to get more precise z positioning.
+    @input Ray Cast Depth: Depth of ray cast from the object origin.
+    @input Ray Cast Mask: Ray cast mask for collision detection.
+
+    @output Out: Executed immidiately after start of the navigation.
+    @output Tick Position: Executed at every step of navigation translation.
+    @output Tick Rotation: Executed at every step of navigation rotation.
+    """
     bl_idname = 'LNGoToLocationNode'
     bl_label = 'Go to Location'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
@@ -12,6 +27,18 @@ class GoToLocationNode(ArmLogicTreeNode):
         self.add_input('ArmVectorSocket', 'Location')
         self.add_input('ArmFloatSocket', 'Speed', 5.0)
         self.add_input('ArmFloatSocket', 'Turn Duration', 0.4)
+        self.add_input('ArmFloatSocket', 'Height Offset', 0.0)
+        self.add_input('ArmBoolSocket','Use Raycast')
+        self.add_input('ArmFloatSocket', 'Ray Cast Depth', -5.0)
+        self.add_input('ArmIntSocket', 'Ray Cast Mask', 1)
 
         self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('ArmNodeSocketAction', 'Tick Position')
+        self.add_output('ArmNodeSocketAction', 'Tick Rotation')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement.Identity(self)
 


### PR DESCRIPTION
This PR adds the following:
1.  Option in the NavAgent trait to set the height offset from the NavMesh.
2.  Option in the Go To Location node to set the height offset. 
3.  Option to set the NavAgent height more precisely using physics ray cast.
4.  Compensates the height introduced by the NavMesh voxel height.
5.  Outputs to some functionality during rotational and transitional tweening.
<img src="https://user-images.githubusercontent.com/55564981/193939175-66f1ee8a-cfc8-4d84-bf21-019eabfe7d71.png" width="200" >

Thanks to @ Hreez on Discord for this feature request.
