### PR TITLE
Fully support emission colors in all supported shader nodes

### DIFF
--- a/Shaders/custom_mat_presets/custom_mat_deferred.frag.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_deferred.frag.glsl
@@ -9,43 +9,43 @@
 in vec3 wnormal;
 
 /*
-    The G-Buffer output. Deferred rendering uses the following render target layout:
+	The G-Buffer output. Deferred rendering uses the following render target layout:
 
-    | Index             | Needs #define   || R            | G            | B               | A                  |
-    +===================+=================++==============+==============+=================+====================+
-    | GBUF_IDX_0        |                 || normal (XY)                 | roughness       | metallic/matID     |
-    +-------------------+-----------------++--------------+--------------+-----------------+--------------------+
-    | GBUF_IDX_1        |                 || base color (RGB)                              | occlusion/specular |
-    +-------------------+-----------------++--------------+--------------+-----------------+--------------------+
-    | GBUF_IDX_2        | _gbuffer2       || velocity (XY)               | ignore radiance | unused             |
-    +-------------------+-----------------++--------------+--------------+-----------------+--------------------+
-    | GBUF_IDX_EMISSION | _EmissionShaded || emission color (RGB)                          | unused             |
-    +-------------------+-----------------++--------------+--------------+-----------------+--------------------+
+	| Index             | Needs #define   || R            | G            | B               | A                  |
+	+===================+=================++==============+==============+=================+====================+
+	| GBUF_IDX_0        |                 || normal (XY)                 | roughness       | metallic/matID     |
+	+-------------------+-----------------++--------------+--------------+-----------------+--------------------+
+	| GBUF_IDX_1        |                 || base color (RGB)                              | occlusion/specular |
+	+-------------------+-----------------++--------------+--------------+-----------------+--------------------+
+	| GBUF_IDX_2        | _gbuffer2       || velocity (XY)               | ignore radiance | unused             |
+	+-------------------+-----------------++--------------+--------------+-----------------+--------------------+
+	| GBUF_IDX_EMISSION | _EmissionShaded || emission color (RGB)                          | unused             |
+	+-------------------+-----------------++--------------+--------------+-----------------+--------------------+
 
-    The indices as well as the GBUF_SIZE define are defined in "compiled.inc".
+	The indices as well as the GBUF_SIZE define are defined in "compiled.inc".
 */
 out vec4 fragColor[GBUF_SIZE];
 
 void main() {
-    // Pack normals into 2 components to fit into the gbuffer
-    vec3 n = normalize(wnormal);
-    n /= (abs(n.x) + abs(n.y) + abs(n.z));
-    n.xy = n.z >= 0.0 ? n.xy : octahedronWrap(n.xy);
+	// Pack normals into 2 components to fit into the gbuffer
+	vec3 n = normalize(wnormal);
+	n /= (abs(n.x) + abs(n.y) + abs(n.z));
+	n.xy = n.z >= 0.0 ? n.xy : octahedronWrap(n.xy);
 
-    // Define PBR material values
-    vec3 basecol = vec3(1.0);
-    float roughness = 0.0;
-    float metallic = 0.0;
-    float occlusion = 1.0;
-    float specular = 1.0;
-    uint materialId = 0;
-    vec3 emissionCol = vec3(0.0);
+	// Define PBR material values
+	vec3 basecol = vec3(1.0);
+	float roughness = 0.0;
+	float metallic = 0.0;
+	float occlusion = 1.0;
+	float specular = 1.0;
+	uint materialId = 0;
+	vec3 emissionCol = vec3(0.0);
 
-    // Store in gbuffer (see layout table above)
-    fragColor[GBUF_IDX_0] = vec4(n.xy, roughness, packFloatInt16(metallic, materialId));
-    fragColor[GBUF_IDX_1] = vec4(basecol.rgb, packFloat2(occlusion, specular));
+	// Store in gbuffer (see layout table above)
+	fragColor[GBUF_IDX_0] = vec4(n.xy, roughness, packFloatInt16(metallic, materialId));
+	fragColor[GBUF_IDX_1] = vec4(basecol.rgb, packFloat2(occlusion, specular));
 
-    #ifdef _EmissionShaded
-        fragColor[GBUF_IDX_EMISSION] = vec4(emissionCol, 0.0);
-    #endif
+	#ifdef _EmissionShaded
+		fragColor[GBUF_IDX_EMISSION] = vec4(emissionCol, 0.0);
+	#endif
 }

--- a/Shaders/custom_mat_presets/custom_mat_deferred.frag.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_deferred.frag.glsl
@@ -1,6 +1,6 @@
 #version 450
 
-#include "compiled.inc"
+#include "../compiled.inc"
 
 // Include functions for gbuffer operations (packFloat2() etc.)
 #include "../std/gbuffer.glsl"

--- a/Shaders/custom_mat_presets/custom_mat_deferred.vert.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_deferred.vert.glsl
@@ -15,6 +15,6 @@ in vec2 nor; // nor.xy
 out vec3 wnormal;
 
 void main() {
-    wnormal = normalize(N * vec3(nor.xy, pos.w));
-    gl_Position = WVP * vec4(pos.xyz, 1.0);
+	wnormal = normalize(N * vec3(nor.xy, pos.w));
+	gl_Position = WVP * vec4(pos.xyz, 1.0);
 }

--- a/Shaders/custom_mat_presets/custom_mat_forward.frag.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_forward.frag.glsl
@@ -4,6 +4,6 @@
 out vec4 fragColor;
 
 void main() {
-    // Shadeless white color
-    fragColor = vec4(1.0);
+	// Shadeless white color
+	fragColor = vec4(1.0);
 }

--- a/Shaders/debug_draw/line_deferred.frag.glsl
+++ b/Shaders/debug_draw/line_deferred.frag.glsl
@@ -1,9 +1,15 @@
 #version 450
 
+#include "compiled.inc"
+
 in vec3 color;
-out vec4 fragColor[2];
+out vec4 fragColor[GBUF_SIZE];
 
 void main() {
-	fragColor[0] = vec4(1.0, 1.0, 0.0, 1.0);
-	fragColor[1] = vec4(color, 1.0);
+	fragColor[GBUF_IDX_0] = vec4(1.0, 1.0, 0.0, 1.0);
+	fragColor[GBUF_IDX_1] = vec4(color, 1.0);
+
+	#ifdef _EmissionShaded
+		fragColor[GBUF_IDX_EMISSION] = vec4(0.0);
+	#endif
 }

--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -22,7 +22,10 @@ uniform sampler2D gbufferD;
 uniform sampler2D gbuffer0;
 uniform sampler2D gbuffer1;
 #ifdef _gbuffer2
-uniform sampler2D gbuffer2;
+	uniform sampler2D gbuffer2;
+#endif
+#ifdef _EmissionShaded
+	uniform sampler2D gbufferEmission;
 #endif
 
 #ifdef _VoxelAOvar
@@ -295,11 +298,22 @@ void main() {
 	// #endif
 #endif
 
-#ifdef _Emission
-	if (matid == 1) {
-		fragColor.rgb += g1.rgb; // materialid
-		albedo = vec3(0.0);
+#ifdef _EmissionShadeless
+	if (matid == 1) { // pure emissive material, color stored in basecol
+		fragColor.rgb += g1.rgb;
+		fragColor.a = 1.0; // Mark as opaque
+		return;
 	}
+#endif
+#ifdef _EmissionShaded
+	#ifdef _EmissionShadeless
+	else {
+	#endif
+		vec3 emission = textureLod(gbufferEmission, texCoord, 0.0).rgb;
+		fragColor.rgb += emission;
+	#ifdef _EmissionShadeless
+	}
+	#endif
 #endif
 
 	// Show voxels

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -14,16 +14,13 @@ class RenderPathDeferred {
 	static var voxelsLast = "voxels";
 	#end
 
-	public static function setTargetMeshes() {
-		#if rp_gbuffer2
-		{
-			path.setTarget("gbuffer0", ["gbuffer1", "gbuffer2"]);
-		}
-		#else
-		{
-			path.setTarget("gbuffer0", ["gbuffer1"]);
-		}
-		#end
+	public static inline function setTargetMeshes() {
+		// Always keep the order of render targets the same as defined in compiled.inc
+		path.setTarget("gbuffer0", [
+			"gbuffer1",
+			#if rp_gbuffer2 "gbuffer2", #end
+			#if rp_gbuffer_emission "gbuffer_emission" #end
+		]);
 	}
 
 	public static function drawMeshes() {
@@ -127,6 +124,19 @@ class RenderPathDeferred {
 			t.height = 0;
 			t.displayp = Inc.getDisplayp();
 			t.format = "RGBA32";
+			t.scale = Inc.getSuperSampling();
+			path.createRenderTarget(t);
+		}
+		#end
+
+		#if rp_gbuffer_emission
+		{
+			var t = new RenderTargetRaw();
+			t.name = "gbuffer_emission";
+			t.width = 0;
+			t.height = 0;
+			t.displayp = Inc.getDisplayp();
+			t.format = "RGBA64";
 			t.scale = Inc.getSuperSampling();
 			path.createRenderTarget(t);
 		}
@@ -571,6 +581,12 @@ class RenderPathDeferred {
 		#if rp_gbuffer2
 		{
 			path.bindTarget("gbuffer2", "gbuffer2");
+		}
+		#end
+
+		#if rp_gbuffer_emission
+		{
+			path.bindTarget("gbuffer_emission", "gbufferEmission");
 		}
 		#end
 

--- a/Sources/armory/trait/internal/DebugDraw.hx
+++ b/Sources/armory/trait/internal/DebugDraw.hx
@@ -148,7 +148,7 @@ class DebugDraw {
 
 		midPoint.set(x1 + x2, y1 + y2, z1 + z2);
 		midPoint.mult(0.5);
-		
+
 		midLine.set(x1, y1, z1);
 		midLine.sub(midPoint);
 

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -111,6 +111,7 @@ def remove_readonly(func, path, excinfo):
 
 def export_data(fp, sdk_path):
     wrd = bpy.data.worlds['Arm']
+    rpdat = arm.utils.get_rp()
 
     print('Armory v{0} ({1})'.format(wrd.arm_version, wrd.arm_commit))
     if wrd.arm_verbose_output:
@@ -236,6 +237,12 @@ def export_data(fp, sdk_path):
         res['shader_datas'] += make_world.shader_datas
 
         arm.utils.write_arm(shaders_path + '/shader_datas.arm', res)
+
+    if wrd.arm_debug_console and rpdat.rp_renderer == 'Deferred':
+        # Copy deferred shader so that it can include compiled.inc
+        line_deferred_src = os.path.join(sdk_path, 'armory', 'Shaders', 'debug_draw', 'line_deferred.frag.glsl')
+        line_deferred_dst = os.path.join(shaders_path, 'line_deferred.frag.glsl')
+        shutil.copyfile(line_deferred_src, line_deferred_dst)
 
     for ref in assets.shader_passes:
         for s in assets.shader_passes_assets[ref]:

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -1,3 +1,5 @@
+from typing import Callable, Optional
+
 import bpy
 
 import arm.api
@@ -15,7 +17,8 @@ if arm.is_reload(__name__):
 else:
     arm.enable_reload(__name__)
 
-callback = None
+callback: Optional[Callable[[], None]] = None
+
 
 def add_world_defs():
     wrd = bpy.data.worlds['Arm']
@@ -401,5 +404,16 @@ def build():
         assets.add_khafile_def('rp_gbuffer2')
         wrd.world_defs += '_gbuffer2'
 
-    if callback != None:
+    if callback is not None:
         callback()
+
+
+def get_num_gbuffer_rts_deferred() -> int:
+    """Return the number of render targets required for the G-Buffer."""
+    wrd = bpy.data.worlds['Arm']
+
+    num = 2
+    for flag in ('_gbuffer2', '_EmissionShaded'):
+        if flag in wrd.world_defs:
+            num += 1
+    return num

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -26,7 +26,7 @@ import arm.make_state
 import arm.material.cycles_functions as c_functions
 from arm.material.cycles_nodes import *
 import arm.material.mat_state as mat_state
-from arm.material.parser_state import EmissionKind, ParserState, ParserContext
+from arm.material.parser_state import ParserState, ParserContext
 from arm.material.shader import Shader, ShaderContext, floatstr, vec3str
 import arm.utils
 
@@ -103,7 +103,7 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
     state.procedurals_written = False
     wrd = bpy.data.worlds['Arm']
 
-    mat_state.is_shadeless = False
+    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
 
     # Surface
     if parse_surface or parse_opacity:
@@ -122,13 +122,10 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
             curshader.write(f'specular = {out_specular};')
             curshader.write(f'emissionCol = {out_emission_col};')
 
-            if state.emission_kind == EmissionKind.SHADELESS:
+            if mat_state.emission_kind == mat_state.EmissionKind.SHADELESS:
                 if '_EmissionShadeless' not in wrd.world_defs:
                     wrd.world_defs += '_EmissionShadeless'
-                # TODO: find better solution than this mat_state hack to
-                #  get information to make_mesh.py
-                mat_state.is_shadeless = True
-            elif state.emission_kind == EmissionKind.SHADED:
+            elif mat_state.emission_kind == mat_state.EmissionKind.SHADED:
                 if '_EmissionShaded' not in wrd.world_defs:
                     wrd.world_defs += '_EmissionShaded'
 
@@ -255,7 +252,7 @@ def parse_shader(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> Tuple[st
                 # Emission
                 if node.inputs[6].is_linked or node.inputs[6].default_value != 0.0:
                     state.out_emission_col = f'({state.out_basecol} * clamp({parse_value_input(node.inputs[6])}, 0.0, 1.0))'
-                    state.emission_kind = EmissionKind.SHADED
+                    mat_state.emission_kind = mat_state.EmissionKind.SHADED
             if state.parse_opacity:
                 state.out_opacity = parse_value_input(node.inputs[1])
         else:

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -103,7 +103,7 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
     state.procedurals_written = False
     wrd = bpy.data.worlds['Arm']
 
-    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
+    mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
 
     # Surface
     if parse_surface or parse_opacity:
@@ -122,10 +122,10 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
             curshader.write(f'specular = {out_specular};')
             curshader.write(f'emissionCol = {out_emission_col};')
 
-            if mat_state.emission_kind == mat_state.EmissionKind.SHADELESS:
+            if mat_state.emission_type == mat_state.EmissionType.SHADELESS:
                 if '_EmissionShadeless' not in wrd.world_defs:
                     wrd.world_defs += '_EmissionShadeless'
-            elif mat_state.emission_kind == mat_state.EmissionKind.SHADED:
+            elif mat_state.emission_type == mat_state.EmissionType.SHADED:
                 if '_EmissionShaded' not in wrd.world_defs:
                     wrd.world_defs += '_EmissionShaded'
 
@@ -252,7 +252,7 @@ def parse_shader(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> Tuple[st
                 # Emission
                 if node.inputs[6].is_linked or node.inputs[6].default_value != 0.0:
                     state.out_emission_col = f'({state.out_basecol} * clamp({parse_value_input(node.inputs[6])}, 0.0, 1.0))'
-                    mat_state.emission_kind = mat_state.EmissionKind.SHADED
+                    mat_state.emission_type = mat_state.EmissionType.SHADED
             if state.parse_opacity:
                 state.out_opacity = parse_value_input(node.inputs[1])
         else:

--- a/blender/arm/material/cycles_nodes/nodes_shader.py
+++ b/blender/arm/material/cycles_nodes/nodes_shader.py
@@ -3,12 +3,14 @@ from bpy.types import NodeSocket
 
 import arm
 import arm.material.cycles as c
-from arm.material.parser_state import EmissionKind, ParserState
+import arm.material.mat_state as mat_state
+from arm.material.parser_state import ParserState
 
 if arm.is_reload(__name__):
     c = arm.reload_module(c)
+    mat_state = arm.reload_module(mat_state)
     arm.material.parser_state = arm.reload_module(arm.material.parser_state)
-    from arm.material.parser_state import EmissionKind, ParserState
+    from arm.material.parser_state import ParserState
 else:
     arm.enable_reload(__name__)
 
@@ -29,7 +31,7 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
         state.out_occlusion = '({0} * {3} + {1} * {2})'.format(occ1, occ2, fac_var, fac_inv_var)
         state.out_specular = '({0} * {3} + {1} * {2})'.format(spec1, spec2, fac_var, fac_inv_var)
         state.out_emission_col = '({0} * {3} + {1} * {2})'.format(emi1, emi2, fac_var, fac_inv_var)
-        state.emission_kind = EmissionKind.SHADED
+        mat_state.emission_kind = mat_state.EmissionKind.SHADED
     if state.parse_opacity:
         state.out_opacity = '({0} * {3} + {1} * {2})'.format(opac1, opac2, fac_var, fac_inv_var)
 
@@ -44,7 +46,7 @@ def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket,
         state.out_occlusion = '({0} * 0.5 + {1} * 0.5)'.format(occ1, occ2)
         state.out_specular = '({0} * 0.5 + {1} * 0.5)'.format(spec1, spec2)
         state.out_emission_col = '({0} + {1})'.format(emi1, emi2)
-        state.emission_kind = EmissionKind.SHADED
+        mat_state.emission_kind = mat_state.EmissionKind.SHADED
     if state.parse_opacity:
         state.out_opacity = '({0} * 0.5 + {1} * 0.5)'.format(opac1, opac2)
 
@@ -74,7 +76,7 @@ def parse_bsdfprincipled(node: bpy.types.ShaderNodeBsdfPrincipled, out_socket: N
             emission_col = c.parse_vector_input(node.inputs[19])
             emission_strength = c.parse_value_input(node.inputs[20])
             state.out_emission_col = '({0} * {1})'.format(emission_col, emission_strength)
-            state.emission_kind = EmissionKind.SHADED
+            mat_state.emission_kind = mat_state.EmissionKind.SHADED
         # clearcoar_normal = c.parse_vector_input(node.inputs[21])
         # tangent = c.parse_vector_input(node.inputs[22])
     if state.parse_opacity:
@@ -121,7 +123,7 @@ def parse_emission(node: bpy.types.ShaderNodeEmission, out_socket: NodeSocket, s
         state.out_basecol = 'vec3(0.0)'
         state.out_specular = '0.0'
         state.out_metallic = '0.0'
-        state.emission_kind = EmissionKind.SHADELESS
+        mat_state.emission_kind = mat_state.EmissionKind.SHADELESS
 
 
 def parse_bsdfglass(node: bpy.types.ShaderNodeBsdfGlass, out_socket: NodeSocket, state: ParserState) -> None:

--- a/blender/arm/material/cycles_nodes/nodes_shader.py
+++ b/blender/arm/material/cycles_nodes/nodes_shader.py
@@ -4,11 +4,13 @@ from bpy.types import NodeSocket
 import arm
 import arm.material.cycles as c
 import arm.material.mat_state as mat_state
+import arm.material.mat_utils as mat_utils
 from arm.material.parser_state import ParserState
 
 if arm.is_reload(__name__):
     c = arm.reload_module(c)
     mat_state = arm.reload_module(mat_state)
+    mat_utils = arm.reload_module(mat_utils)
     arm.material.parser_state = arm.reload_module(arm.material.parser_state)
     from arm.material.parser_state import ParserState
 else:
@@ -16,14 +18,30 @@ else:
 
 
 def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket, state: ParserState) -> None:
+    # Skip mixing if only one input is effectively used
+    if not node.inputs[0].is_linked:
+        if node.inputs[0].default_value <= 0.0:
+            c.parse_shader_input(node.inputs[1])
+            return
+        elif node.inputs[0].default_value >= 1.0:
+            c.parse_shader_input(node.inputs[2])
+            return
+
     prefix = '' if node.inputs[0].is_linked else 'const '
     fac = c.parse_value_input(node.inputs[0])
     fac_var = c.node_name(node.name) + '_fac'
     fac_inv_var = c.node_name(node.name) + '_fac_inv'
     state.curshader.write('{0}float {1} = clamp({2}, 0.0, 1.0);'.format(prefix, fac_var, fac))
     state.curshader.write('{0}float {1} = 1.0 - {2};'.format(prefix, fac_inv_var, fac_var))
+
+    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
     bc1, rough1, met1, occ1, spec1, opac1, emi1 = c.parse_shader_input(node.inputs[1])
+    ek1 = mat_state.emission_kind
+
+    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
     bc2, rough2, met2, occ2, spec2, opac2, emi2 = c.parse_shader_input(node.inputs[2])
+    ek2 = mat_state.emission_kind
+
     if state.parse_surface:
         state.out_basecol = '({0} * {3} + {1} * {2})'.format(bc1, bc2, fac_var, fac_inv_var)
         state.out_roughness = '({0} * {3} + {1} * {2})'.format(rough1, rough2, fac_var, fac_inv_var)
@@ -31,14 +49,20 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
         state.out_occlusion = '({0} * {3} + {1} * {2})'.format(occ1, occ2, fac_var, fac_inv_var)
         state.out_specular = '({0} * {3} + {1} * {2})'.format(spec1, spec2, fac_var, fac_inv_var)
         state.out_emission_col = '({0} * {3} + {1} * {2})'.format(emi1, emi2, fac_var, fac_inv_var)
-        mat_state.emission_kind = mat_state.EmissionKind.SHADED
+        mat_state.emission_kind = mat_state.EmissionKind.get_effective_combination(ek1, ek2)
     if state.parse_opacity:
         state.out_opacity = '({0} * {3} + {1} * {2})'.format(opac1, opac2, fac_var, fac_inv_var)
 
 
 def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket, state: ParserState) -> None:
+    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
     bc1, rough1, met1, occ1, spec1, opac1, emi1 = c.parse_shader_input(node.inputs[0])
+    ek1 = mat_state.emission_kind
+
+    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
     bc2, rough2, met2, occ2, spec2, opac2, emi2 = c.parse_shader_input(node.inputs[1])
+    ek2 = mat_state.emission_kind
+
     if state.parse_surface:
         state.out_basecol = '({0} + {1})'.format(bc1, bc2)
         state.out_roughness = '({0} * 0.5 + {1} * 0.5)'.format(rough1, rough2)
@@ -46,7 +70,7 @@ def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket,
         state.out_occlusion = '({0} * 0.5 + {1} * 0.5)'.format(occ1, occ2)
         state.out_specular = '({0} * 0.5 + {1} * 0.5)'.format(spec1, spec2)
         state.out_emission_col = '({0} + {1})'.format(emi1, emi2)
-        mat_state.emission_kind = mat_state.EmissionKind.SHADED
+        mat_state.emission_kind = mat_state.EmissionKind.get_effective_combination(ek1, ek2)
     if state.parse_opacity:
         state.out_opacity = '({0} * 0.5 + {1} * 0.5)'.format(opac1, opac2)
 
@@ -71,12 +95,14 @@ def parse_bsdfprincipled(node: bpy.types.ShaderNodeBsdfPrincipled, out_socket: N
         # ior = c.parse_vector_input(node.inputs[14])
         # transmission = c.parse_vector_input(node.inputs[15])
         # transmission_roughness = c.parse_vector_input(node.inputs[16])
-        if (node.inputs[20].is_linked or node.inputs[20].default_value != 0.0)\
-                and (node.inputs[19].is_linked or node.inputs[19].default_value):
+        if (node.inputs['Emission Strength'].is_linked or node.inputs['Emission Strength'].default_value != 0.0)\
+                and (node.inputs['Emission'].is_linked or not mat_utils.equals_color_socket(node.inputs['Emission'], (0.0, 0.0, 0.0), comp_alpha=False)):
             emission_col = c.parse_vector_input(node.inputs[19])
             emission_strength = c.parse_value_input(node.inputs[20])
             state.out_emission_col = '({0} * {1})'.format(emission_col, emission_strength)
             mat_state.emission_kind = mat_state.EmissionKind.SHADED
+        else:
+            mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
         # clearcoar_normal = c.parse_vector_input(node.inputs[21])
         # tangent = c.parse_vector_input(node.inputs[22])
     if state.parse_opacity:

--- a/blender/arm/material/cycles_nodes/nodes_shader.py
+++ b/blender/arm/material/cycles_nodes/nodes_shader.py
@@ -34,13 +34,13 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
     state.curshader.write('{0}float {1} = clamp({2}, 0.0, 1.0);'.format(prefix, fac_var, fac))
     state.curshader.write('{0}float {1} = 1.0 - {2};'.format(prefix, fac_inv_var, fac_var))
 
-    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
+    mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
     bc1, rough1, met1, occ1, spec1, opac1, emi1 = c.parse_shader_input(node.inputs[1])
-    ek1 = mat_state.emission_kind
+    ek1 = mat_state.emission_type
 
-    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
+    mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
     bc2, rough2, met2, occ2, spec2, opac2, emi2 = c.parse_shader_input(node.inputs[2])
-    ek2 = mat_state.emission_kind
+    ek2 = mat_state.emission_type
 
     if state.parse_surface:
         state.out_basecol = '({0} * {3} + {1} * {2})'.format(bc1, bc2, fac_var, fac_inv_var)
@@ -49,19 +49,19 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
         state.out_occlusion = '({0} * {3} + {1} * {2})'.format(occ1, occ2, fac_var, fac_inv_var)
         state.out_specular = '({0} * {3} + {1} * {2})'.format(spec1, spec2, fac_var, fac_inv_var)
         state.out_emission_col = '({0} * {3} + {1} * {2})'.format(emi1, emi2, fac_var, fac_inv_var)
-        mat_state.emission_kind = mat_state.EmissionKind.get_effective_combination(ek1, ek2)
+        mat_state.emission_type = mat_state.EmissionType.get_effective_combination(ek1, ek2)
     if state.parse_opacity:
         state.out_opacity = '({0} * {3} + {1} * {2})'.format(opac1, opac2, fac_var, fac_inv_var)
 
 
 def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket, state: ParserState) -> None:
-    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
+    mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
     bc1, rough1, met1, occ1, spec1, opac1, emi1 = c.parse_shader_input(node.inputs[0])
-    ek1 = mat_state.emission_kind
+    ek1 = mat_state.emission_type
 
-    mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
+    mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
     bc2, rough2, met2, occ2, spec2, opac2, emi2 = c.parse_shader_input(node.inputs[1])
-    ek2 = mat_state.emission_kind
+    ek2 = mat_state.emission_type
 
     if state.parse_surface:
         state.out_basecol = '({0} + {1})'.format(bc1, bc2)
@@ -70,7 +70,7 @@ def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket,
         state.out_occlusion = '({0} * 0.5 + {1} * 0.5)'.format(occ1, occ2)
         state.out_specular = '({0} * 0.5 + {1} * 0.5)'.format(spec1, spec2)
         state.out_emission_col = '({0} + {1})'.format(emi1, emi2)
-        mat_state.emission_kind = mat_state.EmissionKind.get_effective_combination(ek1, ek2)
+        mat_state.emission_type = mat_state.EmissionType.get_effective_combination(ek1, ek2)
     if state.parse_opacity:
         state.out_opacity = '({0} * 0.5 + {1} * 0.5)'.format(opac1, opac2)
 
@@ -100,9 +100,9 @@ def parse_bsdfprincipled(node: bpy.types.ShaderNodeBsdfPrincipled, out_socket: N
             emission_col = c.parse_vector_input(node.inputs[19])
             emission_strength = c.parse_value_input(node.inputs[20])
             state.out_emission_col = '({0} * {1})'.format(emission_col, emission_strength)
-            mat_state.emission_kind = mat_state.EmissionKind.SHADED
+            mat_state.emission_type = mat_state.EmissionType.SHADED
         else:
-            mat_state.emission_kind = mat_state.EmissionKind.NO_EMISSION
+            mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
         # clearcoar_normal = c.parse_vector_input(node.inputs[21])
         # tangent = c.parse_vector_input(node.inputs[22])
     if state.parse_opacity:
@@ -149,7 +149,7 @@ def parse_emission(node: bpy.types.ShaderNodeEmission, out_socket: NodeSocket, s
         state.out_basecol = 'vec3(0.0)'
         state.out_specular = '0.0'
         state.out_metallic = '0.0'
-        mat_state.emission_kind = mat_state.EmissionKind.SHADELESS
+        mat_state.emission_type = mat_state.EmissionType.SHADELESS
 
 
 def parse_bsdfglass(node: bpy.types.ShaderNodeBsdfGlass, out_socket: NodeSocket, state: ParserState) -> None:

--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -8,6 +8,7 @@ import arm.log as log
 import arm.material.cycles as cycles
 import arm.material.make_shader as make_shader
 import arm.material.mat_batch as mat_batch
+import arm.material.mat_utils as mat_utils
 import arm.node_utils
 import arm.utils
 
@@ -16,6 +17,7 @@ if arm.is_reload(__name__):
     cycles = arm.reload_module(cycles)
     make_shader = arm.reload_module(make_shader)
     mat_batch = arm.reload_module(mat_batch)
+    mat_utils = arm.reload_module(mat_utils)
     arm.node_utils = arm.reload_module(arm.node_utils)
     arm.utils = arm.reload_module(arm.utils)
 else:
@@ -152,7 +154,7 @@ def material_needs_sss(material: Material) -> bool:
         if sss_node is not None and sss_node.outputs[0].is_linked and (sss_node.inputs[1].is_linked or sss_node.inputs[1].default_value != 0.0):
             return True
 
-    for sss_node in arm.node_utils.iter_nodes_armorypbr(material.node_tree):
+    for sss_node in mat_utils.iter_nodes_armorypbr(material.node_tree):
         if sss_node is not None and sss_node.outputs[0].is_linked and (sss_node.inputs[8].is_linked or sss_node.inputs[8].default_value != 0.0):
             return True
 

--- a/blender/arm/material/make_decal.py
+++ b/blender/arm/material/make_decal.py
@@ -70,8 +70,7 @@ def make(context_id):
     frag.write('float occlusion;')
     frag.write('float specular;')
     frag.write('float opacity;')
-    if '_Emission' in wrd.world_defs:
-        frag.write('float emission;')
+    frag.write('vec3 emissionCol;')  # Declared to prevent compiler errors, but decals currently don't output any emission
     cycles.parse(mat_state.nodes, con_decal, vert, frag, geom, tesc, tese)
 
     frag.write('n /= (abs(n.x) + abs(n.y) + abs(n.z));')

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -238,7 +238,7 @@ def make_deferred(con_mesh, rpasses):
     frag.write('n /= (abs(n.x) + abs(n.y) + abs(n.z));')
     frag.write('n.xy = n.z >= 0.0 ? n.xy : octahedronWrap(n.xy);')
 
-    is_shadeless = mat_state.emission_kind == mat_state.EmissionKind.SHADELESS
+    is_shadeless = mat_state.emission_type == mat_state.EmissionType.SHADELESS
     if is_shadeless or '_SSS' in wrd.world_defs or '_Hair' in wrd.world_defs:
         frag.write('uint matid = 0;')
         if is_shadeless:
@@ -713,8 +713,8 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
     if '_Clusters' in wrd.world_defs:
         make_cluster.write(vert, frag)
 
-    if mat_state.emission_kind != mat_state.EmissionKind.NO_EMISSION:
-        if mat_state.emission_kind == mat_state.EmissionKind.SHADELESS:
+    if mat_state.emission_type != mat_state.EmissionType.NO_EMISSION:
+        if mat_state.emission_type == mat_state.EmissionType.SHADELESS:
             frag.write('direct = vec3(0.0);')
         frag.write('indirect += emissionCol;')
 

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -238,11 +238,12 @@ def make_deferred(con_mesh, rpasses):
     frag.write('n /= (abs(n.x) + abs(n.y) + abs(n.z));')
     frag.write('n.xy = n.z >= 0.0 ? n.xy : octahedronWrap(n.xy);')
 
-    if '_EmissionShadeless' in wrd.world_defs or '_SSS' in wrd.world_defs or '_Hair' in wrd.world_defs:
+    is_shadeless = mat_state.emission_kind == mat_state.EmissionKind.SHADELESS
+    if is_shadeless or '_SSS' in wrd.world_defs or '_Hair' in wrd.world_defs:
         frag.write('uint matid = 0;')
-        if '_EmissionShadeless' in wrd.world_defs and mat_state.is_shadeless:
+        if is_shadeless:
             frag.write('matid = 1;')
-            frag.write('basecol = emissionCol;')  # We do not need
+            frag.write('basecol = emissionCol;')
         if '_SSS' in wrd.world_defs or '_Hair' in wrd.world_defs:
             frag.add_uniform('int materialID')
             frag.write('if (materialID == 2) matid = 2;')
@@ -712,8 +713,8 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
     if '_Clusters' in wrd.world_defs:
         make_cluster.write(vert, frag)
 
-    if '_EmissionShadeless' in wrd.world_defs or '_EmissionShaded' in wrd.world_defs:
-        if mat_state.is_shadeless:
+    if mat_state.emission_kind != mat_state.EmissionKind.NO_EMISSION:
+        if mat_state.emission_kind == mat_state.EmissionKind.SHADELESS:
             frag.write('direct = vec3(0.0);')
         frag.write('indirect += emissionCol;')
 

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable, Optional
+
 import bpy
 
 import arm.assets as assets
@@ -9,6 +11,7 @@ import arm.material.make_particle as make_particle
 import arm.material.make_cluster as make_cluster
 import arm.material.make_finalize as make_finalize
 import arm.material.make_attrib as make_attrib
+import arm.material.shader as shader
 import arm.utils
 
 if arm.is_reload(__name__):
@@ -21,14 +24,18 @@ if arm.is_reload(__name__):
     make_cluster = arm.reload_module(make_cluster)
     make_finalize = arm.reload_module(make_finalize)
     make_attrib = arm.reload_module(make_attrib)
+    shader = arm.reload_module(shader)
     arm.utils = arm.reload_module(arm.utils)
 else:
     arm.enable_reload(__name__)
 
 is_displacement = False
-write_material_attribs = None
-write_material_attribs_post = None
-write_vertex_attribs = None
+
+# User callbacks
+write_material_attribs: Optional[Callable[[dict[str, Any], shader.Shader], bool]] = None
+write_material_attribs_post: Optional[Callable[[dict[str, Any], shader.Shader], None]] = None
+write_vertex_attribs: Optional[Callable[[shader.Shader], bool]] = None
+
 
 def make(context_id, rpasses):
     wrd = bpy.data.worlds['Arm']
@@ -86,12 +93,10 @@ def make(context_id, rpasses):
 
     return con_mesh
 
+
 def make_base(con_mesh, parse_opacity):
     global is_displacement
-    global write_material_attribs
-    global write_material_attribs_post
     global write_vertex_attribs
-    wrd = bpy.data.worlds['Arm']
 
     vert = con_mesh.make_vert()
     frag = con_mesh.make_frag()
@@ -120,26 +125,18 @@ def make_base(con_mesh, parse_opacity):
     # No displacement
     else:
         frag.ins = vert.outs
-        if write_vertex_attribs != None:
+        if write_vertex_attribs is not None:
             vattr_written = write_vertex_attribs(vert)
 
     frag.add_include('compiled.inc')
 
-    written = False
-    if write_material_attribs != None:
-        written = write_material_attribs(con_mesh, frag)
-    if written == False:
-        frag.write('vec3 basecol;')
-        frag.write('float roughness;')
-        frag.write('float metallic;')
-        frag.write('float occlusion;')
-        frag.write('float specular;')
-        if '_Emission' in wrd.world_defs:
-            frag.write('float emission;')
-        if parse_opacity:
-            frag.write('float opacity;')
+    attribs_written = False
+    if write_material_attribs is not None:
+        attribs_written = write_material_attribs(con_mesh, frag)
+    if not attribs_written:
+        _write_material_attribs_default(frag, parse_opacity)
         cycles.parse(mat_state.nodes, con_mesh, vert, frag, geom, tesc, tese, parse_opacity=parse_opacity)
-    if write_material_attribs_post != None:
+    if write_material_attribs_post is not None:
         write_material_attribs_post(con_mesh, frag)
 
     vert.add_out('vec3 wnormal')
@@ -181,6 +178,7 @@ def make_base(con_mesh, parse_opacity):
         sh.write('wposition += wnormal * disp;')
         sh.write('gl_Position = VP * vec4(wposition, 1.0);')
 
+
 def make_deferred(con_mesh, rpasses):
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
@@ -201,11 +199,11 @@ def make_deferred(con_mesh, rpasses):
             opac = '0.9999' # 1.0 - eps
         frag.write('if (opacity < {0}) discard;'.format(opac))
 
-    gapi = arm.utils.get_gapi()
+    frag.add_out(f'vec4 fragColor[GBUF_SIZE]')
+
     if '_gbuffer2' in wrd.world_defs:
-        frag.add_out('vec4 fragColor[3]')
         if '_Veloc' in wrd.world_defs:
-            if tese == None:
+            if tese is None:
                 vert.add_uniform('mat4 prevWVP', link='_prevWorldViewProjectionMatrix')
                 vert.add_out('vec4 wvpposition')
                 vert.add_out('vec4 prevwvpposition')
@@ -230,8 +228,6 @@ def make_deferred(con_mesh, rpasses):
                     tese.add_uniform('mat4 prevVP', '_prevViewProjectionMatrix')
                     make_tess.interpolate(tese, 'prevwposition', 3)
                     tese.write('prevwvpposition = prevVP * vec4(prevwposition, 1.0);')
-    else:
-        frag.add_out('vec4 fragColor[2]')
 
     # Pack gbuffer
     frag.add_include('std/gbuffer.glsl')
@@ -242,29 +238,36 @@ def make_deferred(con_mesh, rpasses):
     frag.write('n /= (abs(n.x) + abs(n.y) + abs(n.z));')
     frag.write('n.xy = n.z >= 0.0 ? n.xy : octahedronWrap(n.xy);')
 
-    if '_Emission' in wrd.world_defs or '_SSS' in wrd.world_defs or '_Hair' in wrd.world_defs:
+    if '_EmissionShadeless' in wrd.world_defs or '_SSS' in wrd.world_defs or '_Hair' in wrd.world_defs:
         frag.write('uint matid = 0;')
-        if '_Emission' in wrd.world_defs:
-            frag.write('if (emission > 0) { basecol *= emission; matid = 1; }')
+        if '_EmissionShadeless' in wrd.world_defs and mat_state.is_shadeless:
+            frag.write('matid = 1;')
+            frag.write('basecol = emissionCol;')  # We do not need
         if '_SSS' in wrd.world_defs or '_Hair' in wrd.world_defs:
             frag.add_uniform('int materialID')
             frag.write('if (materialID == 2) matid = 2;')
     else:
         frag.write('const uint matid = 0;')
 
-    frag.write('fragColor[0] = vec4(n.xy, roughness, packFloatInt16(metallic, matid));')
-    frag.write('fragColor[1] = vec4(basecol, packFloat2(occlusion, specular));')
+    frag.write('fragColor[GBUF_IDX_0] = vec4(n.xy, roughness, packFloatInt16(metallic, matid));')
+    frag.write('fragColor[GBUF_IDX_1] = vec4(basecol, packFloat2(occlusion, specular));')
 
     if '_gbuffer2' in wrd.world_defs:
         if '_Veloc' in wrd.world_defs:
             frag.write('vec2 posa = (wvpposition.xy / wvpposition.w) * 0.5 + 0.5;')
             frag.write('vec2 posb = (prevwvpposition.xy / prevwvpposition.w) * 0.5 + 0.5;')
-            frag.write('fragColor[2].rg = vec2(posa - posb);')
+            frag.write('fragColor[GBUF_IDX_2].rg = vec2(posa - posb);')
 
         if mat_state.material.arm_ignore_irradiance:
-            frag.write('fragColor[2].b = 1.0;')
+            frag.write('fragColor[GBUF_IDX_2].b = 1.0;')
+
+    if '_EmissionShaded' in wrd.world_defs:
+        assets.add_khafile_def('rp_gbuffer_emission')
+        # Alpha channel is unused at the moment
+        frag.write('fragColor[GBUF_IDX_EMISSION] = vec4(emissionCol, 0.0);')
 
     return con_mesh
+
 
 def make_raytracer(con_mesh):
     con_mesh.data['vertex_elements'] = [{'name': 'pos', 'data': 'float3'}, {'name': 'nor', 'data': 'float3'}, {'name': 'tex', 'data': 'float2'}]
@@ -276,6 +279,7 @@ def make_raytracer(con_mesh):
     vert.write('n = nor;')
     vert.write('uv = tex;')
     vert.write('gl_Position = vec4(pos.xyz, 1.0);')
+
 
 def make_forward_mobile(con_mesh):
     wrd = bpy.data.worlds['Arm']
@@ -290,21 +294,13 @@ def make_forward_mobile(con_mesh):
     frag.ins = vert.outs
 
     frag.add_include('compiled.inc')
-    frag.write('vec3 basecol;')
-    frag.write('float roughness;')
-    frag.write('float metallic;')
-    frag.write('float occlusion;')
-    frag.write('float specular;')
-    if '_Emission' in wrd.world_defs:
-        frag.write('float emission;')
 
     arm_discard = mat_state.material.arm_discard
     blend = mat_state.material.arm_blending
     is_transluc = mat_utils.is_transluc(mat_state.material)
     parse_opacity = (blend and is_transluc) or arm_discard
-    if parse_opacity:
-        frag.write('float opacity;')
 
+    _write_material_attribs_default(frag, parse_opacity)
     cycles.parse(mat_state.nodes, con_mesh, vert, frag, geom, tesc, tese, parse_opacity=parse_opacity, parse_displacement=False)
 
     if arm_discard:
@@ -445,6 +441,7 @@ def make_forward_mobile(con_mesh):
     if '_LDR' in wrd.world_defs:
         frag.write('fragColor.rgb = pow(fragColor.rgb, vec3(1.0 / 2.2));')
 
+
 def make_forward_solid(con_mesh):
     wrd = bpy.data.worlds['Arm']
     vert = con_mesh.make_vert()
@@ -462,21 +459,13 @@ def make_forward_solid(con_mesh):
     frag.ins = vert.outs
 
     frag.add_include('compiled.inc')
-    frag.write('vec3 basecol;')
-    frag.write('float roughness;')
-    frag.write('float metallic;')
-    frag.write('float occlusion;')
-    frag.write('float specular;')
-    if '_Emission' in wrd.world_defs:
-        frag.write('float emission;')
 
     arm_discard = mat_state.material.arm_discard
     blend = mat_state.material.arm_blending
     is_transluc = mat_utils.is_transluc(mat_state.material)
     parse_opacity = (blend and is_transluc) or arm_discard
-    if parse_opacity:
-        frag.write('float opacity;')
 
+    _write_material_attribs_default(frag, parse_opacity)
     cycles.parse(mat_state.nodes, con_mesh, vert, frag, geom, tesc, tese, parse_opacity=parse_opacity, parse_displacement=False, basecol_only=True)
 
     if arm_discard:
@@ -508,6 +497,7 @@ def make_forward_solid(con_mesh):
     if '_LDR' in wrd.world_defs:
         frag.write('fragColor.rgb = pow(fragColor.rgb, vec3(1.0 / 2.2));')
 
+
 def make_forward(con_mesh):
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
@@ -534,7 +524,7 @@ def make_forward(con_mesh):
                 frag.add_uniform('sampler2DShadow shadowMapSpot[4]', included=True)
 
     if not blend:
-        mrt = rpdat.rp_ssr
+        mrt = rpdat.rp_ssr  # mrt: multiple render targets
         if mrt:
             # Store light gbuffer for post-processing
             frag.add_out('vec4 fragColor[2]')
@@ -554,6 +544,7 @@ def make_forward(con_mesh):
     # Particle opacity
     if mat_state.material.arm_particle_flag and arm.utils.get_rp().arm_particles == 'On' and mat_state.material.arm_particle_fade:
         frag.write('fragColor[0].rgb *= p_fade;')
+
 
 def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
     global is_displacement
@@ -721,8 +712,20 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
     if '_Clusters' in wrd.world_defs:
         make_cluster.write(vert, frag)
 
-    if '_Emission' in wrd.world_defs:
-        frag.write('if (emission > 0.0) {')
-        frag.write('    direct = vec3(0.0);')
-        frag.write('    indirect += basecol * emission;')
-        frag.write('}')
+    if '_EmissionShadeless' in wrd.world_defs or '_EmissionShaded' in wrd.world_defs:
+        if mat_state.is_shadeless:
+            frag.write('direct = vec3(0.0);')
+        frag.write('indirect += emissionCol;')
+
+
+def _write_material_attribs_default(frag: shader.Shader, parse_opacity: bool):
+    frag.write('vec3 basecol;')
+    frag.write('float roughness;')
+    frag.write('float metallic;')
+    frag.write('float occlusion;')
+    frag.write('float specular;')
+    # We may not use emission, but the attribute will then be removed
+    # by the shader compiler
+    frag.write('vec3 emissionCol;')
+    if parse_opacity:
+        frag.write('float opacity;')

--- a/blender/arm/material/make_shader.py
+++ b/blender/arm/material/make_shader.py
@@ -59,9 +59,6 @@ def build(material: Material, mat_users: Dict[Material, List[Object]], mat_armus
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
     rpasses = mat_utils.get_rpasses(material)
-    is_emissive = mat_utils.is_emmisive(material)
-    if is_emissive and '_Emission' not in wrd.world_defs:
-        wrd.world_defs += '_Emission'
     matname = arm.utils.safesrc(arm.utils.asset_name(material))
     rel_path = arm.utils.build_dir() + '/compiled/Shaders/'
     full_path = arm.utils.get_fp() + '/' + rel_path

--- a/blender/arm/material/mat_state.py
+++ b/blender/arm/material/mat_state.py
@@ -8,3 +8,4 @@ batch = False
 texture_grad = False # Sample textures using textureGrad()
 con_mesh = None # Mesh context
 uses_instancing = False  # Whether the current material has at least one user with instancing enabled
+is_shadeless = False

--- a/blender/arm/material/mat_state.py
+++ b/blender/arm/material/mat_state.py
@@ -1,3 +1,17 @@
+from enum import IntEnum
+
+
+class EmissionKind(IntEnum):
+    NO_EMISSION = 0
+    """The material has no emission at all."""
+
+    SHADELESS = 1
+    """The material is emissive and does not interact with lights/shadows."""
+
+    SHADED = 2
+    """The material is emissive and interacts with lights/shadows."""
+
+
 data = None # ShaderData
 material = None
 nodes = None
@@ -8,4 +22,4 @@ batch = False
 texture_grad = False # Sample textures using textureGrad()
 con_mesh = None # Mesh context
 uses_instancing = False  # Whether the current material has at least one user with instancing enabled
-is_shadeless = False
+emission_kind = EmissionKind.NO_EMISSION

--- a/blender/arm/material/mat_state.py
+++ b/blender/arm/material/mat_state.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 
 
-class EmissionKind(IntEnum):
+class EmissionType(IntEnum):
     NO_EMISSION = 0
     """The material has no emission at all."""
 
@@ -12,19 +12,19 @@ class EmissionKind(IntEnum):
     """The material is emissive and interacts with lights/shadows."""
 
     @staticmethod
-    def get_effective_combination(a: 'EmissionKind', b: 'EmissionKind') -> 'EmissionKind':
+    def get_effective_combination(a: 'EmissionType', b: 'EmissionType') -> 'EmissionType':
         # Shaded emission always has precedence over shadeless emission
-        if a == EmissionKind.SHADED or b == EmissionKind.SHADED:
-            return EmissionKind.SHADED
+        if a == EmissionType.SHADED or b == EmissionType.SHADED:
+            return EmissionType.SHADED
 
-        if a == EmissionKind.SHADELESS and b == EmissionKind.SHADELESS:
-            return EmissionKind.SHADELESS
+        if a == EmissionType.SHADELESS and b == EmissionType.SHADELESS:
+            return EmissionType.SHADELESS
 
         # If only one input is shadeless we still need shaded emission
-        if a == EmissionKind.SHADELESS or b == EmissionKind.SHADELESS:
-            return EmissionKind.SHADED
+        if a == EmissionType.SHADELESS or b == EmissionType.SHADELESS:
+            return EmissionType.SHADED
 
-        return EmissionKind.NO_EMISSION
+        return EmissionType.NO_EMISSION
 
 
 data = None # ShaderData
@@ -37,4 +37,4 @@ batch = False
 texture_grad = False # Sample textures using textureGrad()
 con_mesh = None # Mesh context
 uses_instancing = False  # Whether the current material has at least one user with instancing enabled
-emission_kind = EmissionKind.NO_EMISSION
+emission_type = EmissionType.NO_EMISSION

--- a/blender/arm/material/mat_state.py
+++ b/blender/arm/material/mat_state.py
@@ -11,6 +11,21 @@ class EmissionKind(IntEnum):
     SHADED = 2
     """The material is emissive and interacts with lights/shadows."""
 
+    @staticmethod
+    def get_effective_combination(a: 'EmissionKind', b: 'EmissionKind') -> 'EmissionKind':
+        # Shaded emission always has precedence over shadeless emission
+        if a == EmissionKind.SHADED or b == EmissionKind.SHADED:
+            return EmissionKind.SHADED
+
+        if a == EmissionKind.SHADELESS and b == EmissionKind.SHADELESS:
+            return EmissionKind.SHADELESS
+
+        # If only one input is shadeless we still need shaded emission
+        if a == EmissionKind.SHADELESS or b == EmissionKind.SHADELESS:
+            return EmissionKind.SHADED
+
+        return EmissionKind.NO_EMISSION
+
 
 data = None # ShaderData
 material = None

--- a/blender/arm/material/mat_utils.py
+++ b/blender/arm/material/mat_utils.py
@@ -1,3 +1,5 @@
+from typing import Generator
+
 import bpy
 
 import arm.utils
@@ -80,5 +82,26 @@ def is_transluc_traverse(node):
 
 def is_transluc_type(node: bpy.types.ShaderNode) -> bool:
     return node.type in ('BSDF_GLASS', 'BSDF_TRANSPARENT', 'BSDF_TRANSLUCENT') \
-        or (node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR') and (node.inputs['Opacity'].is_linked or node.inputs['Opacity'].default_value != 1.0)) \
+        or (is_armory_pbr_node(node) and (node.inputs['Opacity'].is_linked or node.inputs['Opacity'].default_value != 1.0)) \
         or (node.type == 'BSDF_PRINCIPLED' and (node.inputs['Alpha'].is_linked or node.inputs['Alpha'].default_value != 1.0))
+
+
+def is_armory_pbr_node(node: bpy.types.ShaderNode) -> bool:
+    return node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR')
+
+
+def iter_nodes_armorypbr(node_group: bpy.types.NodeTree) -> Generator[bpy.types.Node, None, None]:
+    for node in node_group.nodes:
+        if is_armory_pbr_node(node):
+            yield node
+
+
+def equals_color_socket(socket: bpy.types.NodeSocketColor, value: tuple[float, ...], *, comp_alpha=True) -> bool:
+    # NodeSocketColor.default_value is of bpy_prop_array type that doesn't
+    # support direct comparison
+    return (
+        socket.default_value[0] == value[0]
+        and socket.default_value[1] == value[1]
+        and socket.default_value[2] == value[2]
+        and (socket.default_value[3] == value[3] if comp_alpha else True)
+    )

--- a/blender/arm/material/mat_utils.py
+++ b/blender/arm/material/mat_utils.py
@@ -82,31 +82,3 @@ def is_transluc_type(node: bpy.types.ShaderNode) -> bool:
     return node.type in ('BSDF_GLASS', 'BSDF_TRANSPARENT', 'BSDF_TRANSLUCENT') \
         or (node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR') and (node.inputs['Opacity'].is_linked or node.inputs['Opacity'].default_value != 1.0)) \
         or (node.type == 'BSDF_PRINCIPLED' and (node.inputs['Alpha'].is_linked or node.inputs['Alpha'].default_value != 1.0))
-
-
-def is_emmisive(material):
-    nodes = material.node_tree.nodes
-    output_node = cycles.node_by_type(nodes, 'OUTPUT_MATERIAL')
-    if output_node == None or output_node.inputs[0].is_linked == False:
-        return False
-
-    surface_node = output_node.inputs[0].links[0].from_node
-    return is_emmisive_traverse(surface_node)
-
-def is_emmisive_traverse(node):
-    # TODO: traverse groups
-    if is_emmisive_type(node):
-        return True
-    for inp in node.inputs:
-        if inp.is_linked:
-            res = is_emmisive_traverse(inp.links[0].from_node)
-            if res:
-                return True
-    return False
-
-def is_emmisive_type(node):
-    if node.type == 'EMISSION' or \
-       (node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR') and (node.inputs[6].is_linked or node.inputs[6].default_value != 0.0)) or \
-       (node.type == 'BSDF_PRINCIPLED' and len(node.inputs) > 20 and (node.inputs[20].is_linked or node.inputs[20] != 0.0)):
-       return True
-    return False

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -52,8 +52,6 @@ class ParserState:
         self.parse_displacement = True
         self.basecol_only = False
 
-        self.emission_kind = EmissionKind.NO_EMISSION
-
         self.procedurals_written = False
         # Already exported radiance/irradiance (currently we can only convert
         # an already existing texture as radiance/irradiance)
@@ -87,14 +85,3 @@ class ParserState:
         """Return the shader output values as a tuple."""
         return (self.out_basecol, self.out_roughness, self.out_metallic, self.out_occlusion, self.out_specular,
                 self.out_opacity, self.out_emission_col)
-
-
-class EmissionKind(IntEnum):
-    NO_EMISSION = 0
-    """The material has no emission at all."""
-
-    SHADELESS = 1
-    """The material is emissive and does not interact with lights/shadows."""
-
-    SHADED = 2
-    """The material is emissive and interacts with lights/shadows."""

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -52,7 +52,8 @@ class ParserState:
         self.parse_displacement = True
         self.basecol_only = False
 
-        self.emission_found = False
+        self.emission_kind = EmissionKind.NO_EMISSION
+
         self.procedurals_written = False
         # Already exported radiance/irradiance (currently we can only convert
         # an already existing texture as radiance/irradiance)
@@ -70,7 +71,7 @@ class ParserState:
         self.out_occlusion: floatstr = '1.0'
         self.out_specular: floatstr = '1.0'
         self.out_opacity: floatstr = '1.0'
-        self.out_emission: floatstr = '0.0'
+        self.out_emission_col: vec3str = 'vec3(0.0)'
 
     def reset_outs(self):
         """Reset the shader output values to their default values."""
@@ -80,9 +81,20 @@ class ParserState:
         self.out_occlusion = '1.0'
         self.out_specular = '1.0'
         self.out_opacity = '1.0'
-        self.out_emission = '0.0'
+        self.out_emission_col = 'vec3(0.0)'
 
-    def get_outs(self) -> Tuple[vec3str, floatstr, floatstr, floatstr, floatstr, floatstr, floatstr]:
+    def get_outs(self) -> Tuple[vec3str, floatstr, floatstr, floatstr, floatstr, floatstr, vec3str]:
         """Return the shader output values as a tuple."""
         return (self.out_basecol, self.out_roughness, self.out_metallic, self.out_occlusion, self.out_specular,
-                self.out_opacity, self.out_emission)
+                self.out_opacity, self.out_emission_col)
+
+
+class EmissionKind(IntEnum):
+    NO_EMISSION = 0
+    """The material has no emission at all."""
+
+    SHADELESS = 1
+    """The material is emissive and does not interact with lights/shadows."""
+
+    SHADED = 2
+    """The material is emissive and interacts with lights/shadows."""

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -49,18 +49,6 @@ def iter_nodes_by_type(node_group: bpy.types.NodeTree, ntype: str) -> Generator[
             yield node
 
 
-def get_node_armorypbr(node_group: bpy.types.NodeTree) -> bpy.types.Node:
-    for node in node_group.nodes:
-        if node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR'):
-            return node
-
-
-def iter_nodes_armorypbr(node_group: bpy.types.NodeTree) -> Generator[bpy.types.Node, None, None]:
-    for node in node_group.nodes:
-        if node.type == 'GROUP' and node.node_tree.name.startswith('Armory PBR'):
-            yield node
-
-
 def input_get_connected_node(input_socket: bpy.types.NodeSocket) -> tuple[Optional[bpy.types.Node], Optional[bpy.types.NodeSocket]]:
     """Get the node and the output socket of that node that is connected
     to the given input, while following reroutes. If the input has

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -67,6 +67,7 @@ def remove_readonly(func, path, excinfo):
 def write_khafilejs(is_play, export_physics: bool, export_navigation: bool, export_ui: bool, is_publish: bool,
                     import_traits: List[str]) -> None:
     wrd = bpy.data.worlds['Arm']
+    rpdat = arm.utils.get_rp()
 
     sdk_path = arm.utils.get_sdk_path()
     rel_path = arm.utils.get_relative_paths()  # Convert absolute paths to relative
@@ -276,7 +277,12 @@ project.addSources('Sources');
 
         if wrd.arm_debug_console:
             assets.add_khafile_def('arm_debug')
-            khafile.write(add_shaders(sdk_path + "/armory/Shaders/debug_draw/**", rel_path=do_relpath_sdk))
+
+            if rpdat.rp_renderer == 'Forward':
+                # deferred line frag shader is currently handled in make.py,
+                # only add forward shader here
+                khafile.write(add_shaders(sdk_path + "/armory/Shaders/debug_draw/line.frag.glsl", rel_path=do_relpath_sdk))
+            khafile.write(add_shaders(sdk_path + "/armory/Shaders/debug_draw/line.vert.glsl", rel_path=do_relpath_sdk))
 
         if not is_publish and state.target == 'html5':
             khafile.write("project.addParameter('--debug');\n")


### PR DESCRIPTION
This PR implements what was discussed in https://github.com/armory3d/armory/pull/2606#issuecomment-1266620114 and fixes https://github.com/armory3d/armory/issues/1774.

It took me a bit longer than expected since I was also working on improving the Armory PBR node but there still are some unresolved issues concerning automatic compatibility updates from the old PBR node so that I decided to remove the Armory PBR changes again and postpone them to hopefully next month. This way I have more time to test everything, I don't want to break anything shortly before a release.

**Major changes**:
- If there is both base color and emission color in a material, it will use a dedicated render target to store the emission color. If the node setup has emission but doesn't require a base color (e.g. there are only emission nodes or mix nodes mixing them), no additional render target is used and the emission color is stored in place of the base color, just like before this PR. On the forward RP, only slight adjustments were required.

  Because of this, the emissive component of materials now looks exactly like in Eevee.

- Internally, the shader parser makes use of "emission types": a material can either be non-emissive, or it has shaded emission (= the emission color is stored in the emission render target and is simply added on top of everything), or it has shadeless emisson (= the emission color is used instead of the base color, and the base color is treated as being black to not interact with any lights). Previously, emissive materials were always "shadeless" in Armory.

- To ensure correct gbuffer indices, there are now some new defines in `compiled.glsl`: `GBUF_IDX_0`, `GBUF_IDX_1`, `GBUF_IDX_2`, `GBUF_IDX_EMISSION` and `GBUF_SIZE`. Even though the indices 0 and 1 always exist and the rendertarget 2 is also always at index 2 if it exists, it allows us to be more flexible in the future and the user doesn't have to add a bunch of \#ifdefs to their custom shaders to get the correct indices.

- The mix node now clamps the mix factor to [0, 1], like Blender does it.

**Emission in the Eevee viewport:**
![emission_viewport](https://user-images.githubusercontent.com/17685000/198373336-2d9e976f-432b-467d-a15c-c1e4432bc60f.png)

**Emission in Armory:**
![emission_armory](https://user-images.githubusercontent.com/17685000/198373302-f20736f2-1ce4-4d76-b880-19ab8d899bc1.png)

Since the emission calibration file also contains more stuff for testing the PBR node, I will open the PR for it once I've implemented the improved Armory PBR node (it will get an additional "Emission Color" socket and a socket to control the shading influence) as mentioned above.