### PR TITLE
Fix Get RB Velocity node

### DIFF
--- a/Sources/armory/logicnode/GetVelocityNode.hx
+++ b/Sources/armory/logicnode/GetVelocityNode.hx
@@ -13,8 +13,8 @@ class GetVelocityNode extends LogicNode {
 
 	override function get(from: Int): Dynamic {
 		var object: Object = inputs[0].get();
-		var localLinear: Bool = inputs.length > 1 ? inputs[1].get() : false;
-		var localAngular: Bool = inputs.length > 2 ? inputs[2].get() : false;
+		var localLinear: Bool = inputs[1].get();
+		var localAngular: Bool = inputs[2].get();
 
 		if (object == null) return null;
 
@@ -22,11 +22,11 @@ class GetVelocityNode extends LogicNode {
 		var rb: RigidBody = object.getTrait(RigidBody);
 
 		if (from == 0) {
-		!localLinear ? return rb.getLinearVelocity() : return object.transform.worldVecToOrientation(rb.getLinearVelocity());
+		!localLinear ? return rb.getLinearVelocity() : return object.transform.getWorldVectorAlongLocalAxis(rb.getLinearVelocity());
 		}
 
 		else {
-		!localAngular ? return rb.getAngularVelocity() : return object.transform.worldVecToOrientation(rb.getAngularVelocity());
+		!localAngular ? return rb.getAngularVelocity() : return object.transform.getWorldVectorAlongLocalAxis(rb.getAngularVelocity());
 		}
 #end
 

--- a/Sources/armory/object/TransformExtension.hx
+++ b/Sources/armory/object/TransformExtension.hx
@@ -54,4 +54,19 @@ class TransformExtension {
 		
 		return new Vec4().add(right).add(look).add(up);
 	}
+
+	/**
+	* Returns the given world vector in local orientation
+	* @param worldVec Vector in world orientation
+	* @return Local vector
+	**/
+	public static inline function getWorldVectorAlongLocalAxis(t: Transform, worldVec: Vec4): Vec4 {
+
+		var localVec = new Vec4();
+		localVec.x = worldVec.dot(t.right().normalize());
+		localVec.y = worldVec.dot(t.look().normalize());
+		localVec.z = worldVec.dot(t.up().normalize());
+
+		return localVec;
+	}
 }


### PR DESCRIPTION
When `On Local Axis` option in the `Get RB Velocity` node was enabled, the output was incorrect. This PR fixes this issue. 

Thanks to @ Power_Broker on Discord for reporting the issue.