### PR TITLE
Allow to set custom letterbox color

### DIFF
--- a/Shaders/compositor_pass/compositor_pass.frag.glsl
+++ b/Shaders/compositor_pass/compositor_pass.frag.glsl
@@ -212,6 +212,13 @@ void main() {
 	texCo *= dynamicScale;
 #endif
 
+#ifdef _CLetterbox
+    if(texCo.y  < compoLetterboxSize || texCo.y > (1.0 - compoLetterboxSize) ) {
+		fragColor.rgb = compoLetterboxColor;
+        return;
+    }
+#endif
+
 #ifdef _CFishEye
 	#ifdef _CPostprocess
 		const float fishEyeStrength = -(PPComp2.y);
@@ -562,11 +569,6 @@ void main() {
 	#else
 		fragColor.rgb += textureLod(lensTexture, texCo, 0.0).rgb;
 	#endif
-#endif
-
-#ifdef _CLetterbox
-	// const float compoLetterboxSize = 0.1;
-	fragColor.rgb *= 1.0 - step(0.5 - compoLetterboxSize, abs(0.5 - texCo.y));
 #endif
 
 //3D LUT Implementation from GPUGems 2 by Nvidia

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -553,6 +553,7 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_chromatic_aberration_samples: IntProperty(name="Samples", default=32, min=8, update=assets.invalidate_shader_cache)
     # Compositor
     arm_letterbox: BoolProperty(name="Letterbox", default=False, update=assets.invalidate_shader_cache)
+    arm_letterbox_color: FloatVectorProperty(name="Color", size=3, default=[0, 0, 0], subtype='COLOR', min=0, max=1, update=assets.invalidate_shader_cache)
     arm_letterbox_size: FloatProperty(name="Size", default=0.1, update=assets.invalidate_shader_cache)
     arm_grain: BoolProperty(name="Film Grain", default=False, update=assets.invalidate_shader_cache)
     arm_grain_strength: FloatProperty(name="Strength", default=2.0, update=assets.invalidate_shader_cache)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1861,7 +1861,14 @@ class ARM_PT_RenderPathCompositorPanel(bpy.types.Panel):
         layout.separator()
 
         col = layout.column()
-        draw_conditional_prop(col, 'Letterbox', rpdat, 'arm_letterbox', 'arm_letterbox_size')
+        col.prop(rpdat, 'arm_letterbox')
+        col = col.column(align=True)
+        col.enabled = rpdat.arm_letterbox
+        col.prop(rpdat, 'arm_letterbox_color')
+        col.prop(rpdat, 'arm_letterbox_size')
+        layout.separator()
+
+        col = layout.column()
         draw_conditional_prop(col, 'Sharpen', rpdat, 'arm_sharpen', 'arm_sharpen_strength')
         draw_conditional_prop(col, 'Vignette', rpdat, 'arm_vignette', 'arm_vignette_strength')
         draw_conditional_prop(col, 'Film Grain', rpdat, 'arm_grain', 'arm_grain_strength')

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -657,6 +657,7 @@ const float autoExposureSpeed = """ + str(rpdat.arm_autoexposure_speed) + """;
         if rpdat.arm_letterbox:
             f.write(
 """const float compoLetterboxSize = """ + str(round(rpdat.arm_letterbox_size * 100) / 100) + """;
+const vec3 compoLetterboxColor = vec3(""" + str(round(rpdat.arm_letterbox_color[0] * 100) / 100) + """, """ + str(round(rpdat.arm_letterbox_color[1] * 100) / 100) + """, """ + str(round(rpdat.arm_letterbox_color[2] * 100) / 100) + """);
 """)
 
         if rpdat.arm_grain:


### PR DESCRIPTION
Allows to set a custom letterbox color.  

![screenshot-2022_10_30_025218](https://user-images.githubusercontent.com/203646/198859026-c889503a-5280-42ba-a646-3e5511bada8e.png)

Also moved the letterbox shader code to the top of the main function to skip other  (invisble) effects from being processed.


