### PR TITLE
Fix exception when marking object as asset

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -66,8 +66,11 @@ def on_depsgraph_update_post(self):
         if len(ops) > 0 and ops[-1] is not None:
             live_patch.on_operator(ops[-1].bl_idname)
 
-    # Hacky solution to update armory props after operator executions
-    last_operator = bpy.context.active_operator
+    # Hacky solution to update armory props after operator executions.
+    # bpy.context.active_operator doesn't always exist, in some cases
+    # like marking assets for example, this code is also executed before
+    # the operator actually finishes and sets the variable
+    last_operator = getattr(bpy.context, 'active_operator', None)
     if last_operator is not None:
         on_operator_post(last_operator.bl_idname)
 


### PR DESCRIPTION
This fixes https://github.com/armory3d/armory/issues/2642. It's not documented when exactly `bpy.context.active_operator` is available, so all we can do is to check whether it actually exists