### PR TITLE
Fixed GetDateTimeNode

### DIFF
--- a/Sources/armory/logicnode/GetDateTimeNode.hx
+++ b/Sources/armory/logicnode/GetDateTimeNode.hx
@@ -17,28 +17,32 @@ class GetDateTimeNode extends LogicNode {
 		super(tree);
 	}
 
+	override function run(from: Int) {
+		var dateTime = Date.now();
+		timeStamp = dateTime.getTime();
+		timezoneOffset = dateTime.getTimezoneOffset();
+		weekDay = dateTime.getDay();
+		day = dateTime.getDate();
+		month = dateTime.getMonth();
+		year = dateTime.getFullYear();
+		hours = dateTime.getHours();
+		minutes = dateTime.getMinutes();
+		seconds = dateTime.getSeconds();
+		runOutput(0);
+	}
+
 	override function get(from: Int): Dynamic {
 		if(property0 == "all"){
-			var dateTime = Date.now();
-			timeStamp = dateTime.getTime();
-			timezoneOffset = dateTime.getTimezoneOffset();
-			weekDay = dateTime.getDay();
-			day = dateTime.getDate();
-			month = dateTime.getMonth();
-			year = dateTime.getFullYear();
-			hours = dateTime.getHours();
-			minutes = dateTime.getMinutes();
-			seconds = dateTime.getSeconds();
 			return switch (from) {
-				case 0: timeStamp;
-				case 1: timezoneOffset;
-				case 2: weekDay;
-				case 3: day;
-				case 4: month;
-				case 5: year;
-				case 6: hours;
-				case 7: minutes;
-				case 8: seconds;
+				case 1: timeStamp;
+				case 2: timezoneOffset;
+				case 3: weekDay;
+				case 4: day;
+				case 5: month;
+				case 6: year;
+				case 7: hours;
+				case 8: minutes;
+				case 9: seconds;
 				default: null;
 			}		
 		} else if (property0 == "formatted"){

--- a/blender/arm/logicnode/native/LN_get_date_time.py
+++ b/blender/arm/logicnode/native/LN_get_date_time.py
@@ -47,6 +47,8 @@ class GetDateTimeNode(ArmLogicTreeNode):
             if (self.get_count_in(select_current) == 0):
                     self.add_output('ArmStringSocket', 'Date')
             elif (self.get_count_in(select_current) == 10):
+                    self.add_input('ArmNodeSocketAction', 'In')
+                    self.add_output('ArmNodeSocketAction', 'Out')
                     self.add_output('ArmIntSocket', 'Timestamp')
                     self.add_output('ArmIntSocket', 'Timezone Offset')
                     self.add_output('ArmIntSocket', 'Weekday')
@@ -92,6 +94,8 @@ class GetDateTimeNode(ArmLogicTreeNode):
 
 
     def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmIntSocket', 'Timestamp')
         self.add_output('ArmIntSocket', 'Timezone Offset')
         self.add_output('ArmIntSocket', 'Weekday')


### PR DESCRIPTION
Sorry, "All" Option would return different timestamps in the case of operating with the seconds/millisecond values. In/out action resolved this issue