### PR TITLE
PlaySoundNode: set volume to 1 by default

### DIFF
--- a/blender/arm/logicnode/sound/LN_play_sound.py
+++ b/blender/arm/logicnode/sound/LN_play_sound.py
@@ -67,7 +67,7 @@ class PlaySoundNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'Pause')
         self.add_input('ArmNodeSocketAction', 'Stop')
         self.add_input('ArmNodeSocketAction', 'Update Volume')
-        self.add_input('ArmFloatSocket', 'Volume')
+        self.add_input('ArmFloatSocket', 'Volume', default_value=1.0)
 
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Is Running')


### PR DESCRIPTION
Previously it was set to 0, so sounds weren't audible without changing this setting.