### PR TITLE
Document the event API

### DIFF
--- a/Sources/armory/system/Event.hx
+++ b/Sources/armory/system/Event.hx
@@ -1,18 +1,44 @@
 package armory.system;
 
+/**
+	Detailed documentation of the event system:
+	[Armory Wiki: Events](https://github.com/armory3d/armory/wiki/events).
+**/
 class Event {
 
 	static var events = new Map<String, Array<TEvent>>();
 
+	/**
+		Send an event with the given name to all corresponding listeners. This
+		function directly executes the `onEvent` callbacks of those listeners.
+
+		For an explanation of the `mask` value, please refer to the
+		[wiki](https://github.com/armory3d/armory/wiki/events#event-masks).
+	**/
 	public static function send(name: String, mask = -1) {
 		var entries = get(name);
 		if (entries != null) for (e in entries) if (mask == -1 || mask == e.mask ) e.onEvent();
 	}
 
+	/**
+		Return the array of event listeners registered for events with the
+		given name.
+
+		The return value is `null` if no listener with the given name was ever
+		registered or `remove()` was called for the given name.
+	**/
 	public static function get(name: String): Array<TEvent> {
 		return events.get(name);
 	}
 
+	/**
+		Add a listener to the event with the given name and return the
+		corresponding listener object. The `onEvent` callback will be called
+		when a matching event is sent.
+
+		For an explanation of the `mask` value, please refer to the
+		[wiki](https://github.com/armory3d/armory/wiki/events#event-masks).
+	**/
 	public static function add(name: String, onEvent: Void->Void, mask = -1): TEvent {
 		var e: TEvent = { name: name, onEvent: onEvent, mask: mask };
 		var entries = events.get(name);
@@ -21,18 +47,35 @@ class Event {
 		return e;
 	}
 
+	/**
+		Remove _all_ listeners that listen to events with the given `name`.
+	**/
 	public static function remove(name: String) {
 		events.remove(name);
 	}
 
+	/**
+		Remove a specific listener. If the listener is not registered/added,
+		this function does nothing.
+	**/
 	public static function removeListener(event: TEvent) {
 		var entries = events.get(event.name);
 		if (entries != null) entries.remove(event);
 	}
 }
 
+/**
+	Represents an event listener.
+
+	@see `armory.system.Event`
+**/
 typedef TEvent = {
+	/** The name of the events this listener is listening to. **/
 	var name: String;
+
+	/** The callback function that is called when a matching event is sent. **/
 	var onEvent: Void->Void;
+
+	/** The mask of the events this listener is listening to. **/
 	var mask: Int;
 }


### PR DESCRIPTION
In correspondence to the new wiki article: https://github.com/armory3d/armory/wiki/Events. Both the API docs and the wiki article use quite technical language, but I think they should be exact and leave little room for interpretation.

I noticed that `Event.get(name)` may return `[]` or `null` for events without listeners depending on how the API was used before. From an outside perspective this is pretty "random" behaviour, so I guess this should be changed?