### PR TITLE
Fix .arm reading issue when world color exceeds [0, 1] range

### DIFF
--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -617,10 +617,15 @@ def update_trait_collections():
                 col = bpy.data.collections['Trait|' + t.name]
             col.objects.link(o)
 
+
 def to_hex(val):
     return '#%02x%02x%02x%02x' % (int(val[3] * 255), int(val[0] * 255), int(val[1] * 255), int(val[2] * 255))
 
-def color_to_int(val):
+
+def color_to_int(val) -> int:
+    # Clamp values, otherwise the return value might not fit in 32 bit
+    # (and later cause problems, e.g. in the .arm file reader)
+    val = [max(0.0, min(v, 1.0)) for v in val]
     return (int(val[3] * 255) << 24) + (int(val[0] * 255) << 16) + (int(val[1] * 255) << 8) + int(val[2] * 255)
 
 


### PR DESCRIPTION
This PR fixes https://github.com/armory3d/armory/issues/2650.

`arm.utils.color_to_int()` is meant to convert a 4-component color into a 32 bit integer value (for direct use as `kha.Color`\*) but it could happen that the resulting value was bigger than that. As a result, the integer would be exported as unsigned 64 bit in the .arm file and because the reader in Iron [currently does not implement this (`0xcf` prefix)](https://github.com/armory3d/iron/blob/9f0d936045214fbc507dfb8442a8b6f1abc82998/Sources/iron/system/ArmPack.hx#L46-L66) the parser returned a wrong result.

Haxe still doesn't seem to have a UInt64 type on all targets, and even the Int64 type is simulated on some platforms IIRC. Armory doesn't seem to use them at the moment, but should we still read two 32 bit integers in case of 64 bit numbers and output a garbage value just to make sure that the parser can continue correctly (+ output a warning)? It's then easier in the future to find any similar issues. I'm also not sure btw if the uint32 case is correctly implemented (it's using `readInt32()`), but I don't know of any issues with that.

_\* this is why we can clamp the function's input value, it's only used for background clearing on the forward RP. Converting the return value into a 32 bit int would introduce overflow situations._