### PR TITLE
Fix background mode build

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -389,6 +389,8 @@ def compile(assets_only=False):
             cmd.append('--nohaxe')
             cmd.append('--noproject')
         state.proc_build = run_proc(cmd, assets_done if compilation_server else build_done)
+        if bpy.app.background and state.proc_build.returncode == 0:
+            build_success()
 
 def build(target, is_play=False, is_publish=False, is_export=False):
     global profile_time

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -389,8 +389,11 @@ def compile(assets_only=False):
             cmd.append('--nohaxe')
             cmd.append('--noproject')
         state.proc_build = run_proc(cmd, assets_done if compilation_server else build_done)
-        if bpy.app.background and state.proc_build.returncode == 0:
-            build_success()
+        if bpy.app.background:
+            if state.proc_build.returncode == 0:
+                build_success()
+            else:
+                log.error('Build failed')
 
 def build(target, is_play=False, is_publish=False, is_export=False):
     global profile_time


### PR DESCRIPTION
The `build_success` method was never called since `proc_build` cannot be used to check the return code when in blender background mode.