### PR TITLE
Event.get(): always return null if no listeners exist

### DIFF
--- a/Sources/armory/system/Event.hx
+++ b/Sources/armory/system/Event.hx
@@ -22,10 +22,7 @@ class Event {
 
 	/**
 		Return the array of event listeners registered for events with the
-		given name.
-
-		The return value is `null` if no listener with the given name was ever
-		registered or `remove()` was called for the given name.
+		given name, or `null` if no listener is currently registered for the event.
 	**/
 	public static function get(name: String): Array<TEvent> {
 		return events.get(name);
@@ -60,7 +57,12 @@ class Event {
 	**/
 	public static function removeListener(event: TEvent) {
 		var entries = events.get(event.name);
-		if (entries != null) entries.remove(event);
+		if (entries != null) {
+			entries.remove(event);
+			if (entries.length == 0) {
+				events.remove(event.name);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Following the discussion in https://github.com/armory3d/armory/pull/2649. Previously, `Event.get()` either returned `null` or `[]` if no listeners existed depending on how the API was used prior to that, now only `null` is returned in that case. This is a theoretically a breaking change, but I doubt that it will cause much trouble and all the occurences of `Event.get()` in the SDK sources still seem correct :)