### PR TITLE
Fix map range node

### DIFF
--- a/Sources/armory/logicnode/MapRangeNode.hx
+++ b/Sources/armory/logicnode/MapRangeNode.hx
@@ -15,6 +15,8 @@ class MapRangeNode extends LogicNode {
 
 		if (value == null || fromMin == null || fromMax == null || toMin == null || toMax == null) return null;
 
-		return (value - fromMin) * (toMax - fromMax) / (toMin - fromMin) + fromMax;
+		//Implements https://stackoverflow.com/a/5732390
+		var slope = (toMax - toMin) / (fromMax - fromMin);
+		return toMin + slope * (value - fromMin);
 	}
 }


### PR DESCRIPTION
Values in the map range node were incorrectly calculated, sometimes resulting in `infinity` and `NaN`. This PR fixes the calculations.