### PR TITLE
Fix for Armory baker

### DIFF
--- a/blender/arm/props_bake.py
+++ b/blender/arm/props_bake.py
@@ -157,7 +157,7 @@ class ArmBakeButton(bpy.types.Operator):
             ry = o.res_y * sc
             # Get image
             if img_name not in bpy.data.images or bpy.data.images[img_name].size[0] != rx or bpy.data.images[img_name].size[1] != ry:
-                img = bpy.data.images.new(img_name, rx, ry)
+                img = bpy.data.images.new(img_name, int(rx), int(ry))
                 img.name = img_name # Force img_name (in case Blender picked img_name.001)
             else:
                 img = bpy.data.images[img_name]

--- a/blender/arm/props_bake.py
+++ b/blender/arm/props_bake.py
@@ -188,14 +188,19 @@ class ArmBakeButton(bpy.types.Operator):
                 uv_layers.active_index = len(uv_layers) - 1
                 obs.active = ob
                 if scn.arm_bakelist_unwrap == 'Lightmap Pack':
+                    bpy.context.view_layer.objects.active = ob
+                    ob.select_set(True)
                     bpy.ops.uv.lightmap_pack('EXEC_SCREEN', PREF_CONTEXT='ALL_FACES')
                 else:
+                    bpy.ops.object.mode_set(mode='OBJECT')
                     bpy.ops.object.select_all(action='DESELECT')
+                    bpy.context.view_layer.objects.active = ob
                     ob.select_set(True)
                     bpy.ops.object.mode_set(mode='EDIT')
+                    bpy.ops.mesh.select_all(action='SELECT')
+                    bpy.ops.uv.smart_project()
                     bpy.ops.mesh.select_all(action='DESELECT')
                     bpy.ops.object.mode_set(mode='OBJECT')
-                    bpy.ops.uv.smart_project('EXEC_SCREEN')
             else:
                 for i in range(0, len(uv_layers)):
                     if uv_layers[i].name == 'UVMap_baked':


### PR DESCRIPTION
The native Armory baker (non-lightmapper) had been throwing some errors lately related to some 3.0+ changes. Now it should work again:

![image](https://user-images.githubusercontent.com/5429817/204103209-7880d9ef-dca8-46c1-8e94-94303b39b3e9.png)