### PR TITLE
Fix uniforms manager

### DIFF
--- a/Sources/armory/logicnode/CreateRenderTargetNode.hx
+++ b/Sources/armory/logicnode/CreateRenderTargetNode.hx
@@ -26,8 +26,6 @@ class CreateRenderTargetNode extends LogicNode {
 		var mat = inputs[3].get();
 		if(mat == null) return;
 
-		trace("A");
-		UniformsManager.printTexMap();
 		if(! perObject){
 			UniformsManager.removeTextureValue(object, mat, inputs[4].get());
 			object = Scene.active.root;
@@ -36,9 +34,6 @@ class CreateRenderTargetNode extends LogicNode {
 		var img = Image.createRenderTarget(inputs[5].get(), inputs[6].get(), TextureFormat.RGBA32);
 		UniformsManager.setTextureValue(mat, object, inputs[4].get(), img);
 
-		trace("B");
-		UniformsManager.printTexMap();
-		
 		runOutput(0);
 	}
 }

--- a/Sources/armory/logicnode/CreateRenderTargetNode.hx
+++ b/Sources/armory/logicnode/CreateRenderTargetNode.hx
@@ -26,13 +26,21 @@ class CreateRenderTargetNode extends LogicNode {
 		var mat = inputs[3].get();
 		if(mat == null) return;
 
+		trace("A");
+		UniformsManager.printTexMap();
 		if(! perObject){
-			UniformsManager.removeObjectFromMap(object, Texture);
+			UniformsManager.removeTextureValue(object, mat, inputs[4].get());
 			object = Scene.active.root;
+		}
+		else {
+			UniformsManager.removeTextureValue(Scene.active.root, mat, inputs[4].get());
 		}
 
 		var img = Image.createRenderTarget(inputs[5].get(), inputs[6].get(), TextureFormat.RGBA32);
 		UniformsManager.setTextureValue(mat, object, inputs[4].get(), img);
+
+		trace("B");
+		UniformsManager.printTexMap();
 		
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/CreateRenderTargetNode.hx
+++ b/Sources/armory/logicnode/CreateRenderTargetNode.hx
@@ -32,9 +32,6 @@ class CreateRenderTargetNode extends LogicNode {
 			UniformsManager.removeTextureValue(object, mat, inputs[4].get());
 			object = Scene.active.root;
 		}
-		else {
-			UniformsManager.removeTextureValue(Scene.active.root, mat, inputs[4].get());
-		}
 
 		var img = Image.createRenderTarget(inputs[5].get(), inputs[6].get(), TextureFormat.RGBA32);
 		UniformsManager.setTextureValue(mat, object, inputs[4].get(), img);

--- a/Sources/armory/logicnode/SetMaterialImageParamNode.hx
+++ b/Sources/armory/logicnode/SetMaterialImageParamNode.hx
@@ -13,24 +13,32 @@ class SetMaterialImageParamNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
+		var object: Object;
 		var perObject: Null<Bool>;
+		var mat: MaterialData;
+		var link: String;
+		var img: String;
 		
-		var object = inputs[1].get();
+		object = inputs[1].get();
 		if(object == null) return;
 
 		perObject = inputs[2].get();
 		if(perObject == null) perObject = false;
 
-		var mat = inputs[3].get();
+		mat = inputs[3].get();
 		if(mat == null) return;
 
+		link = inputs[4].get();
+		if(link == null) return;
+
+		img = inputs[5].get();
+		if(img == null) return;
+
 		if(! perObject){
-			UniformsManager.removeObjectFromMap(object, Texture);
+			UniformsManager.removeTextureValue(object, mat, link);
 			object = Scene.active.root;
 		}
 
-		var img = inputs[5].get();
-		if(img == null) return;
 		iron.data.Data.getImage(img, function(image: kha.Image) {
 			UniformsManager.setTextureValue(mat, object, inputs[4].get(), image);
 		});

--- a/Sources/armory/logicnode/SetMaterialRgbParamNode.hx
+++ b/Sources/armory/logicnode/SetMaterialRgbParamNode.hx
@@ -13,23 +13,33 @@ class SetMaterialRgbParamNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
+		var object: Object;
 		var perObject: Null<Bool>;
+		var mat: MaterialData;
+		var link: String;
+		var vec: Vec4;
 		
-		var object = inputs[1].get();
+		object = inputs[1].get();
 		if(object == null) return;
 
 		perObject = inputs[2].get();
 		if(perObject == null) perObject = false;
 
-		var mat = inputs[3].get();
+		mat = inputs[3].get();
 		if(mat == null) return;
 
+		link = inputs[4].get();
+		if(link == null) return;
+
+		vec = inputs[5].get();
+		if(vec == null) return;
+
 		if(! perObject){
-			UniformsManager.removeObjectFromMap(object, Vector);
+			UniformsManager.removeVectorValue(object, mat, link);
 			object = Scene.active.root;
 		}
 
-		UniformsManager.setVec3Value(mat, object, inputs[4].get(), inputs[5].get());
+		UniformsManager.setVec3Value(mat, object, inputs[4].get(), vec);
 		runOutput(0);
 	}
 }

--- a/Sources/armory/logicnode/SetMaterialValueParamNode.hx
+++ b/Sources/armory/logicnode/SetMaterialValueParamNode.hx
@@ -34,7 +34,7 @@ class SetMaterialValueParamNode extends LogicNode {
 		if(value == null) return;
 
 		if(! perObject){
-			UniformsManager.removeVectorValue(object, mat, link);
+			UniformsManager.removeFloatValue(object, mat, link);
 			object = Scene.active.root;
 		}
 

--- a/Sources/armory/logicnode/SetMaterialValueParamNode.hx
+++ b/Sources/armory/logicnode/SetMaterialValueParamNode.hx
@@ -12,23 +12,33 @@ class SetMaterialValueParamNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
+		var object: Object;
 		var perObject: Null<Bool>;
+		var mat: MaterialData;
+		var link: String;
+		var value: Null<kha.FastFloat>;
 		
-		var object = inputs[1].get();
+		object = inputs[1].get();
 		if(object == null) return;
 
 		perObject = inputs[2].get();
 		if(perObject == null) perObject = false;
 
-		var mat = inputs[3].get();
+		mat = inputs[3].get();
 		if(mat == null) return;
 
+		link = inputs[4].get();
+		if(link == null) return;
+
+		value = inputs[5].get();
+		if(value == null) return;
+
 		if(! perObject){
-			UniformsManager.removeObjectFromMap(object, Float);
+			UniformsManager.removeVectorValue(object, mat, link);
 			object = Scene.active.root;
 		}
 
-		UniformsManager.setFloatValue(mat, object, inputs[4].get(), inputs[5].get());
+		UniformsManager.setFloatValue(mat, object, inputs[4].get(), value);
 		runOutput(0);
 	}
 

--- a/Sources/armory/trait/internal/UniformsManager.hx
+++ b/Sources/armory/trait/internal/UniformsManager.hx
@@ -265,13 +265,17 @@ class UniformsManager extends Trait{
 
 	// Mehtod to get object specific material parameter texture value
 	public static function textureLink(object: Object, mat: MaterialData, link: String): kha.Image {
-		
-		
+
 		if(object == null || mat == null) return null;
 
-		if(! texturesMap.exists(object)){
-			object = Scene.active.root;
+		var res = getObjectTextureLink(object, mat, link);
+		if(res == null) {
+			res = getObjectTextureLink(Scene.active.root, mat, link);
 		}
+		return res;
+	}
+
+	static function getObjectTextureLink(object: Object, mat: MaterialData, link: String): kha.Image {
 
 		var material = texturesMap.get(object);
 		if (material == null) return null;

--- a/Sources/armory/trait/internal/UniformsManager.hx
+++ b/Sources/armory/trait/internal/UniformsManager.hx
@@ -227,14 +227,22 @@ class UniformsManager extends Trait{
 		entry.set(link, value); // parameter name, value
 	}
 
-	// Mehtod to get object specific material parameter float value
+	// Method to get object specific material parameter float value
 	public static function floatLink(object: Object, mat: MaterialData, link: String): Null<kha.FastFloat> {
-		
+
 		if(object == null || mat == null) return null;
 
-		if(! floatsMap.exists(object)){
-			object = Scene.active.root;
+		// First check if float exists per object
+		var res = getObjectFloatLink(object, mat, link);
+		if(res == null) {
+			// If not defined per object, use default scene root 
+			res = getObjectFloatLink(Scene.active.root, mat, link);
 		}
+		return res;
+	}
+
+	// Get float link
+	static function getObjectFloatLink(object: Object, mat: MaterialData, link: String): Null<kha.FastFloat> {
 
 		var material = floatsMap.get(object);
 		if (material == null) return null;
@@ -245,14 +253,22 @@ class UniformsManager extends Trait{
 		return entry.get(link);
 	}
 
-	// Mehtod to get object specific material parameter vec3 value
+	// Method to get object specific material parameter vector value
 	public static function vec3Link(object: Object, mat: MaterialData, link: String): iron.math.Vec4 {
-		
+
 		if(object == null || mat == null) return null;
 
-		if(! vectorsMap.exists(object)){
-			object = Scene.active.root;
+		// First check if vector exists per object
+		var res = getObjectVec3Link(object, mat, link);
+		if(res == null) {
+			// If not defined per object, use default scene root 
+			res = getObjectVec3Link(Scene.active.root, mat, link);
 		}
+		return res;
+	}
+
+	// Get vector link
+	static function getObjectVec3Link(object: Object, mat: MaterialData, link: String): iron.math.Vec4 {
 
 		var material = vectorsMap.get(object);
 		if (material == null) return null;
@@ -263,18 +279,21 @@ class UniformsManager extends Trait{
 		return entry.get(link);
 	}
 
-	// Mehtod to get object specific material parameter texture value
+	// Method to get object specific material parameter texture value
 	public static function textureLink(object: Object, mat: MaterialData, link: String): kha.Image {
 
 		if(object == null || mat == null) return null;
 
+		// First check if texture exists per object
 		var res = getObjectTextureLink(object, mat, link);
 		if(res == null) {
+			// If not defined per object, use default scene root 
 			res = getObjectTextureLink(Scene.active.root, mat, link);
 		}
 		return res;
 	}
 
+	// Get texture link
 	static function getObjectTextureLink(object: Object, mat: MaterialData, link: String): kha.Image {
 
 		var material = texturesMap.get(object);
@@ -323,6 +342,34 @@ class UniformsManager extends Trait{
 
 			case Texture: texturesMap.remove(object);
 		}
+	}
+
+	public static function removeFloatValue(object: Object, mat:MaterialData, link: String) {
+
+		var material = floatsMap.get(object);
+		if (material == null) return;
+
+		var entry = material.get(mat);
+		if (entry == null) return;
+
+		entry.remove(link);
+
+		if(! entry.keys().hasNext()) material.remove(mat);
+		if(! material.keys().hasNext()) floatsMap.remove(object);
+	}
+
+	public static function removeVectorValue(object: Object, mat:MaterialData, link: String) {
+
+		var material = vectorsMap.get(object);
+		if (material == null) return;
+
+		var entry = material.get(mat);
+		if (entry == null) return;
+
+		entry.remove(link);
+
+		if(! entry.keys().hasNext()) material.remove(mat);
+		if(! material.keys().hasNext()) vectorsMap.remove(object);
 	}
 
 	public static function removeTextureValue(object: Object, mat:MaterialData, link: String) {

--- a/Sources/armory/trait/internal/UniformsManager.hx
+++ b/Sources/armory/trait/internal/UniformsManager.hx
@@ -385,23 +385,6 @@ class UniformsManager extends Trait{
 		if(! entry.keys().hasNext()) material.remove(mat);
 		if(! material.keys().hasNext()) texturesMap.remove(object);
 	}
-
-	public static function printTexMap(){
-		for(o in texturesMap.keys()){
-			var oname = o.name;
-			var mmap = texturesMap.get(o);
-			for(m in mmap.keys()){
-				var mname = m.name;
-				var lmap = mmap.get(m);
-				for(l in lmap.keys()){
-					var lname = l;
-					var img = lmap.get(l);
-
-					trace("{ " + oname + " : " + mname + " : " + lname + " : " + img);
-				}
-			}
-		}
-	}
 }
 
 @:enum abstract UniformType(Int) from Int to Int {

--- a/Sources/armory/trait/internal/UniformsManager.hx
+++ b/Sources/armory/trait/internal/UniformsManager.hx
@@ -338,6 +338,23 @@ class UniformsManager extends Trait{
 		if(! entry.keys().hasNext()) material.remove(mat);
 		if(! material.keys().hasNext()) texturesMap.remove(object);
 	}
+
+	public static function printTexMap(){
+		for(o in texturesMap.keys()){
+			var oname = o.name;
+			var mmap = texturesMap.get(o);
+			for(m in mmap.keys()){
+				var mname = m.name;
+				var lmap = mmap.get(m);
+				for(l in lmap.keys()){
+					var lname = l;
+					var img = lmap.get(l);
+
+					trace("{ " + oname + " : " + mname + " : " + lname + " : " + img);
+				}
+			}
+		}
+	}
 }
 
 @:enum abstract UniformType(Int) from Int to Int {

--- a/Sources/armory/trait/internal/UniformsManager.hx
+++ b/Sources/armory/trait/internal/UniformsManager.hx
@@ -320,6 +320,20 @@ class UniformsManager extends Trait{
 			case Texture: texturesMap.remove(object);
 		}
 	}
+
+	public static function removeTextureValue(object: Object, mat:MaterialData, link: String) {
+
+		var material = texturesMap.get(object);
+		if (material == null) return;
+
+		var entry = material.get(mat);
+		if (entry == null) return;
+
+		entry.remove(link);
+
+		if(! entry.keys().hasNext()) material.remove(mat);
+		if(! material.keys().hasNext()) texturesMap.remove(object);
+	}
 }
 
 @:enum abstract UniformType(Int) from Int to Int {


### PR DESCRIPTION
Currently, if a default float/vector/texture material parameter of an object is changed to "per-object", all other default external links for that object were removed. This caused the default values to be lost and `null` values for uniforms. This PR intends to fix this by removing just the particular float/vector/texture from the external link maps in the `Uniforms Manager`.

Additionally some more comments and a few typos were fixed.