### PR TITLE
Fix loading world shader contexts if world name contains special characters

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2438,7 +2438,7 @@ Make sure the mesh only has tris/quads.""")
             self.export_tilesheets()
 
             if self.scene.world is not None:
-                self.output['world_ref'] = self.scene.world.name
+                self.output['world_ref'] = arm.utils.safestr(self.scene.world.name)
 
             if self.scene.use_gravity:
                 self.output['gravity'] = [self.scene.gravity[0], self.scene.gravity[1], self.scene.gravity[2]]


### PR DESCRIPTION
This PR fixes a runtime error that would happen if the world name contained special characters:

```
Sources/iron/data/WorldData.hx:57: World data "World_äöüß" not found!
Sources/iron/data/ShaderData.hx:54: Shader data "World_World_äöüß" not found!
Trace: TypeError: Cannot read property 'getContext' of null
    at <anonymous>:3973:21
    at <anonymous>:6005:5
    at <anonymous>:7278:5
    at Function.getSceneRaw (<anonymous>:6016:4)
    at Function.parse (<anonymous>:7274:18)
    at Function.getShader (<anonymous>:5998:24)
    at iron_RenderPath.loadShader (<anonymous>:3972:18)
    at <anonymous>:5233:29
    at <anonymous>:5208:5
    at <anonymous>:4758:7
```

I'm wondering whether it would make sense to maintain a list for all cases where something was renamed during export (cleared at the beginning of each export) that would afterwards be printed to the console. This way users are informed about these changes which gets especially helpful if there is a name collision, e.g. `World_ä` and `World_ü`:

```
Warning: During export, the following entities were renamed because they contained special characters:
    "World_ä" -> "World__"
    "World_ü" -> "World__"
To prevent errors you should rename them in Blender.
```

A problem with this message is that it does not print the "location" of the original names (i.e. to which "entity" it belongs). So I'm not sure how helpful this message really is, not just objects etc. get renamed but also logic trees, files, the application name etc.