### PR TITLE
Fix array node indexes

### DIFF
--- a/blender/arm/logicnode/array/LN_array.py
+++ b/blender/arm/logicnode/array/LN_array.py
@@ -5,7 +5,7 @@ class ArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores the given array as a variable."""
     bl_idname = 'LNArrayNode'
     bl_label = 'Array Dynamic'
-    arm_version = 2
+    arm_version = 3
     arm_section = 'variable'
     min_inputs = 0
 
@@ -24,7 +24,7 @@ class ArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
         op.socket_type = 'ArmDynamicSocket'
         column = row.column(align=True)
         op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         if len(self.inputs) == self.min_inputs:
             column.enabled = False
 
@@ -43,7 +43,7 @@ class ArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
             inp.default_value_raw = master_node.inputs[i].get_default_value()
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/array/LN_array_add.py
+++ b/blender/arm/logicnode/array/LN_array_add.py
@@ -10,7 +10,7 @@ class ArrayAddNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNArrayAddNode'
     bl_label = 'Array Add'
-    arm_version = 2
+    arm_version = 3
     min_inputs = 5
 
     def __init__(self):
@@ -35,12 +35,12 @@ class ArrayAddNode(ArmLogicTreeNode):
         op.socket_type = 'ArmDynamicSocket'
         column = row.column(align=True)
         op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         if len(self.inputs) == self.min_inputs:
             column.enabled = False
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/array/LN_array_boolean.py
+++ b/blender/arm/logicnode/array/LN_array_boolean.py
@@ -5,7 +5,7 @@ class BooleanArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of boolean elements as a variable."""
     bl_idname = 'LNArrayBooleanNode'
     bl_label = 'Array Boolean'
-    arm_version = 2
+    arm_version = 3
     arm_section = 'variable'
     min_inputs = 0
 
@@ -25,7 +25,7 @@ class BooleanArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
         op.socket_type = 'ArmBoolSocket'
         column = row.column(align=True)
         op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         if len(self.inputs) == self.min_inputs:
             column.enabled = False
 
@@ -44,7 +44,7 @@ class BooleanArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
             inp.default_value_raw = master_node.inputs[i].get_default_value()
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/array/LN_array_color.py
+++ b/blender/arm/logicnode/array/LN_array_color.py
@@ -5,7 +5,7 @@ class ColorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of color elements as a variable."""
     bl_idname = 'LNArrayColorNode'
     bl_label = 'Array Color'
-    arm_version = 2
+    arm_version = 3
     arm_section = 'variable'
     min_inputs = 0
 
@@ -25,7 +25,7 @@ class ColorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
         op.socket_type = 'ArmColorSocket'
         column = row.column(align=True)
         op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         if len(self.inputs) == self.min_inputs:
             column.enabled = False
 
@@ -44,7 +44,7 @@ class ColorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
             inp.default_value_raw = master_node.inputs[i].get_default_value()
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/array/LN_array_float.py
+++ b/blender/arm/logicnode/array/LN_array_float.py
@@ -5,7 +5,7 @@ class FloatArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of float elements as a variable."""
     bl_idname = 'LNArrayFloatNode'
     bl_label = 'Array Float'
-    arm_version = 2
+    arm_version = 3
     arm_section = 'variable'
     min_inputs = 0
 
@@ -25,7 +25,7 @@ class FloatArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
         op.socket_type = 'ArmFloatSocket'
         column = row.column(align=True)
         op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         if len(self.inputs) == self.min_inputs:
             column.enabled = False
 
@@ -44,7 +44,7 @@ class FloatArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
             inp.default_value_raw = master_node.inputs[i].get_default_value()
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/array/LN_array_integer.py
+++ b/blender/arm/logicnode/array/LN_array_integer.py
@@ -5,7 +5,7 @@ class IntegerArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of integer elements as a variable."""
     bl_idname = 'LNArrayIntegerNode'
     bl_label = 'Array Integer'
-    arm_version = 2
+    arm_version = 3
     arm_section = 'variable'
     min_inputs = 0
 
@@ -25,7 +25,7 @@ class IntegerArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
         op.socket_type = 'ArmIntSocket'
         column = row.column(align=True)
         op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         if len(self.inputs) == self.min_inputs:
             column.enabled = False
 
@@ -44,7 +44,7 @@ class IntegerArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
             inp.default_value_raw = master_node.inputs[i].get_default_value()
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/array/LN_array_object.py
+++ b/blender/arm/logicnode/array/LN_array_object.py
@@ -5,7 +5,7 @@ class ObjectArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of object elements as a variable."""
     bl_idname = 'LNArrayObjectNode'
     bl_label = 'Array Object'
-    arm_version = 2
+    arm_version = 3
     arm_section = 'variable'
     min_inputs = 0
 
@@ -25,7 +25,7 @@ class ObjectArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
         op.socket_type = 'ArmNodeSocketObject'
         column = row.column(align=True)
         op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         if len(self.inputs) == self.min_inputs:
             column.enabled = False
 
@@ -44,7 +44,7 @@ class ObjectArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
             inp.default_value_raw = master_node.inputs[i].default_value_raw
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/array/LN_array_string.py
+++ b/blender/arm/logicnode/array/LN_array_string.py
@@ -5,7 +5,7 @@ class StringArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of string elements as a variable."""
     bl_idname = 'LNArrayStringNode'
     bl_label = 'Array String'
-    arm_version = 2
+    arm_version = 3
     arm_section = 'variable'
     min_inputs = 0
 
@@ -25,7 +25,7 @@ class StringArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
         op.socket_type = 'ArmStringSocket'
         column = row.column(align=True)
         op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         if len(self.inputs) == self.min_inputs:
             column.enabled = False
 
@@ -44,7 +44,7 @@ class StringArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
             inp.default_value_raw = master_node.inputs[i].get_default_value()
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/array/LN_array_vector.py
+++ b/blender/arm/logicnode/array/LN_array_vector.py
@@ -5,7 +5,7 @@ class VectorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
     """Stores an array of vector elements as a variable."""
     bl_idname = 'LNArrayVectorNode'
     bl_label = 'Array Vector'
-    arm_version = 2
+    arm_version = 3
     arm_section = 'variable'
     min_inputs = 0
 
@@ -25,7 +25,7 @@ class VectorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
         op.socket_type = 'ArmVectorSocket'
         column = row.column(align=True)
         op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
+        op.node_index = self.get_id_str()
         if len(self.inputs) == self.min_inputs:
             column.enabled = False
 
@@ -44,7 +44,7 @@ class VectorArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
             inp.default_value_raw = master_node.inputs[i].get_default_value()
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)


### PR DESCRIPTION
In the past with https://github.com/armory3d/armory/commit/cf086d770ee6af9de0fa15c50876bc5f62198b0a.

I foolishly assumed `self.get_id_str()` was the same as `str(id(self))`, which broke some of the array nodes. I revert those certain line changes of mine in this PR. Sorry I didn't catch this before, I swear when I had tested them before, all of them worked, but I must have not looked hard enough: all blame goes to me.

Special thanks to @t3du for reporting these issues on Discord.