### PR TITLE
Check if no sky texture for dark clouds

### DIFF
--- a/blender/arm/make_world.py
+++ b/blender/arm/make_world.py
@@ -379,13 +379,13 @@ def frag_write_clouds(world: bpy.types.World, frag: Shader):
 
     if world.arm_darken_clouds:
         func_trace_clouds += '\t// Darken clouds when the sun is low\n'
-
-        # Nishita sky
-        if 'vec3 sunDir' in frag.uniforms:
-            func_trace_clouds += '\tC *= smoothstep(-0.02, 0.25, sunDir.z);\n'
-        # Hosek
-        else:
-            func_trace_clouds += '\tC *= smoothstep(0.04, 0.32, hosekSunDirection.z);\n'
+        if '_EnvSky' in world.world_defs:
+            # Nishita sky
+            if 'vec3 sunDir' in frag.uniforms:
+                func_trace_clouds += '\tC *= smoothstep(-0.02, 0.25, sunDir.z);\n'
+            # Hosek
+            else:
+                func_trace_clouds += '\tC *= smoothstep(0.04, 0.32, hosekSunDirection.z);\n'
 
     func_trace_clouds += '\treturn vec3(C) + sky * T;\n}'
     frag.add_function(func_trace_clouds)


### PR DESCRIPTION
Errors were thrown if dark clouds were enabled and no sky texture was passed to the world node. Those errors are now fixed.

```
ERROR: D:\Blender\Projects\RP\0_Build_Files\Mine\A3D\Code_Testing\build_A3D_Code_Testing\compiled\Shaders\World_World.frag.glsl:71: 'hosekSunDirection' : undeclared identifier
ERROR: D:\Blender\Projects\RP\0_Build_Files\Mine\A3D\Code_Testing\build_A3D_Code_Testing\compiled\Shaders\World_World.frag.glsl:71: 'z' : vector swizzle selection out of range
ERROR: D:\Blender\Projects\RP\0_Build_Files\Mine\A3D\Code_Testing\build_A3D_Code_Testing\compiled\Shaders\World_World.frag.glsl:71: '' : compilation terminated
```

![image](https://user-images.githubusercontent.com/69180012/207970904-9eb2a460-b2c1-418e-8073-86490b843d7e.png)

![image](https://user-images.githubusercontent.com/69180012/207970997-c1b18d27-26c4-4249-bfa2-86a7158fffa1.png)