### PR TITLE
Implement Pause Active Camera Render Node

### DIFF
--- a/Sources/armory/logicnode/DrawCameraNode.hx
+++ b/Sources/armory/logicnode/DrawCameraNode.hx
@@ -1,5 +1,6 @@
 package armory.logicnode;
 
+import iron.RenderPath;
 import iron.Scene;
 import iron.math.Vec2;
 import iron.object.CameraObject;
@@ -66,6 +67,9 @@ class DrawCameraNode extends LogicNode {
 	}
 
 	function render(g:kha.graphics4.Graphics) {
+		final rpPaused = RenderPath.active.paused;
+		RenderPath.active.paused = false;
+
 		final sceneCam = iron.Scene.active.camera;
 
 		for (i in 0...cameras.length) {
@@ -81,6 +85,7 @@ class DrawCameraNode extends LogicNode {
 		}
 
 		iron.Scene.active.camera = sceneCam;
+		RenderPath.active.paused = rpPaused;
 	}
 
 	function render2D(g: kha.graphics2.Graphics) {

--- a/Sources/armory/logicnode/PauseActiveCameraRenderNode.hx
+++ b/Sources/armory/logicnode/PauseActiveCameraRenderNode.hx
@@ -1,6 +1,6 @@
 package armory.logicnode;
 
-import iron.Scene;
+import iron.RenderPath;
 
 class PauseActiveCameraRenderNode extends LogicNode {
 
@@ -11,7 +11,7 @@ class PauseActiveCameraRenderNode extends LogicNode {
 	override function run(from: Int) {
 		final isPaused: Bool = inputs[1].get();
 
-		Scene.active.pauseActiveCameraRender = isPaused;
+		RenderPath.active.paused = isPaused;
 		runOutput(0);
 	}
 }

--- a/Sources/armory/logicnode/PauseActiveCameraRenderNode.hx
+++ b/Sources/armory/logicnode/PauseActiveCameraRenderNode.hx
@@ -1,0 +1,17 @@
+package armory.logicnode;
+
+import iron.Scene;
+
+class PauseActiveCameraRenderNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		final isPaused: Bool = inputs[1].get();
+
+		Scene.active.pauseActiveCameraRender = isPaused;
+		runOutput(0);
+	}
+}

--- a/blender/arm/logicnode/renderpath/LN_pause_active_camera_render.py
+++ b/blender/arm/logicnode/renderpath/LN_pause_active_camera_render.py
@@ -1,0 +1,20 @@
+from arm.logicnode.arm_nodes import *
+
+class PauseActiveCameraRenderNode(ArmLogicTreeNode):
+    """Pause only the rendering of active camera. The logic behaviour remains active.
+
+    @input In: Activate to set property.
+    @input Pause: Pause the rendering when enabled.
+
+    @output Out: Activated after property is set.
+    """
+    bl_idname = 'LNPauseActiveCameraRenderNode'
+    bl_label = 'Pause Active Camera Render'
+    arm_section = 'draw'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmBoolSocket', 'Pause', default_value=False)
+
+        self.add_output('ArmNodeSocketAction', 'Out')


### PR DESCRIPTION
Requires https://github.com/armory3d/iron/pull/179

New node to pause only the rendering of the active camera. The logic will continue to run in the background. This could be used for example to render only certain camera projections to the render target using logic nodes and exclude redundant rendering effort.

Thanks to @ TriVoxel on Discord for the idea.

![image](https://user-images.githubusercontent.com/55564981/208293939-cc3a033e-c741-4d06-97a1-d92ed1475ec0.png)
