### PR TITLE
Check if RenderPath preset is none

### DIFF
--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -45,6 +45,8 @@ def update_point_atlas_size_options(scene: bpy.types.Scene, context: bpy.types.C
 
 def update_preset(self, context):
     rpdat = arm.utils.get_rp()
+    if rpdat == None:
+        rpdat = self.arm_rplist[-1]
     if self.rp_preset == 'Desktop':
         rpdat.rp_renderer = 'Deferred'
         rpdat.arm_material_model = 'Full'


### PR DESCRIPTION
If was an already selected RenderPath that is invalid (i.e deleted or renamed), creating new RenderPath presets that didn't have matching settings (i.e. `Forward Clustering` for `Mobile` / `2D/Baked` and `Deffered Clustering` for `Desktop` / `Max`) would break new preset settings because of invalid preset list indexing. According to @ MoritzBrueckner, this issue was introduced in the Blender 3.3 LTS migration.
```python
Traceback (most recent call last):
  File "D:\Blender\Projects\RP\B3D_33\armsdk/armory\blender\arm\props_renderpath.py", line 643, in execute
    update_preset(wrd, context)
  File "D:\Blender\Projects\RP\B3D_33\armsdk/armory\blender\arm\props_renderpath.py", line 120, in update_preset
    rpdat.rp_renderer = 'Deferred'
AttributeError: 'NoneType' object has no attribute 'rp_renderer'
Error: Python: Traceback (most recent call last):
```
Thanks to @MoritzBrueckner for the code review on Discord.