### PR TITLE
Anchor and rotation option for draw nodes + New draw ellipse node

### DIFF
--- a/Sources/armory/logicnode/DrawEllipseNode.hx
+++ b/Sources/armory/logicnode/DrawEllipseNode.hx
@@ -1,0 +1,47 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+import kha.Color;
+import armory.renderpath.RenderToTexture;
+
+using kha.graphics2.GraphicsExtension;
+
+class DrawEllipseNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		RenderToTexture.ensure2DContext("DrawEllipseNode");
+
+		final colorVec: Vec4 = inputs[1].get();
+		RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
+
+		final filled: Bool = inputs[2].get();
+		final strength: Float = inputs[3].get();
+		final segments: Int = inputs[4].get();
+		final cx: Float = inputs[5].get();
+		final cy: Float = inputs[6].get();
+		final width: Float = inputs[7].get();
+		final height: Float = inputs[8].get();
+		final angle: Float = inputs[9].get();
+		final scale = height / width;
+		final scaleInv = width / height;
+
+		RenderToTexture.g.scale(1.0, scale);
+		RenderToTexture.g.rotate(angle, cx, cy);
+
+		if (filled) {
+			RenderToTexture.g.fillCircle(cx, cy * scaleInv, 0.5 * width, segments);
+		}
+		else {
+			RenderToTexture.g.drawCircle(cx, cy * scaleInv, 0.5 * width, strength, segments);
+		}
+
+		RenderToTexture.g.rotate(-angle, cx, cy);
+		RenderToTexture.g.scale(1.0, scaleInv);
+
+		runOutput(0);
+	}
+}

--- a/Sources/armory/logicnode/DrawImageNode.hx
+++ b/Sources/armory/logicnode/DrawImageNode.hx
@@ -1,5 +1,6 @@
 package armory.logicnode;
 
+import iron.math.Vec4;
 import kha.Image;
 import kha.Color;
 import armory.renderpath.RenderToTexture;
@@ -15,7 +16,21 @@ class DrawImageNode extends LogicNode {
 	override function run(from: Int) {
 		RenderToTexture.ensure2DContext("DrawImageNode");
 
-		final imgName = inputs[1].get();
+		final imgName: String = inputs[1].get();
+		final colorVec: Vec4 = inputs[2].get();
+		final anchorH: Int = inputs[3].get();
+		final anchorV: Int = inputs[4].get();
+		final x: Float = inputs[5].get();
+		final y: Float = inputs[6].get();
+		final width: Float = inputs[7].get();
+		final height: Float = inputs[8].get();
+		final angle: Float = inputs[9].get();
+
+		final drawx = x - 0.5 * width * anchorH;
+		final drawy = y - 0.5 * height * anchorV;
+
+		RenderToTexture.g.rotate(angle, x, y);
+
 		if (imgName != lastImgName) {
 			// Load new image
 			lastImgName = imgName;
@@ -29,10 +44,9 @@ class DrawImageNode extends LogicNode {
 			return;
 		}
 
-		final colorVec = inputs[2].get();
 		RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
-
-		RenderToTexture.g.drawScaledImage(img, inputs[3].get(), inputs[4].get(), inputs[5].get(), inputs[6].get());
+		RenderToTexture.g.drawScaledImage(img, drawx, drawy, width, height);
+		RenderToTexture.g.rotate(-angle, x, y);
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/DrawRectNode.hx
+++ b/Sources/armory/logicnode/DrawRectNode.hx
@@ -1,5 +1,6 @@
 package armory.logicnode;
 
+import iron.math.Vec4;
 import kha.Color;
 import armory.renderpath.RenderToTexture;
 
@@ -12,15 +13,30 @@ class DrawRectNode extends LogicNode {
 	override function run(from: Int) {
 		RenderToTexture.ensure2DContext("DrawRectNode");
 
-		final colorVec = inputs[1].get();
+		final colorVec: Vec4 = inputs[1].get();
+		final filled: Bool = inputs[2].get();
+		final strength: Float = inputs[3].get();
+		final anchorH: Int = inputs[4].get();
+		final anchorV: Int = inputs[5].get();
+		final x: Float = inputs[6].get();
+		final y: Float = inputs[7].get();
+		final width: Float = inputs[8].get();
+		final height: Float = inputs[9].get();
+		final angle: Float = inputs[10].get();
+
+		final drawx = x - 0.5 * width * anchorH;
+		final drawy = y - 0.5 * height * anchorV;
+
+		RenderToTexture.g.rotate(angle, x, y);
 		RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
 
-		if (inputs[2].get()) {
-			RenderToTexture.g.fillRect(inputs[4].get(), inputs[5].get(), inputs[6].get(), inputs[7].get());
+		if (filled) {
+			RenderToTexture.g.fillRect(drawx, drawy, width, height);
 		} else {
-			RenderToTexture.g.drawRect(inputs[4].get(), inputs[5].get(), inputs[6].get(), inputs[7].get(), inputs[3].get());
+			RenderToTexture.g.drawRect(drawx, drawy, width, height, strength);
 		}
 
+		RenderToTexture.g.rotate(-angle, x, y);
 		runOutput(0);
 	}
 }

--- a/blender/arm/logicnode/renderpath/LN_draw_ellipse.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_ellipse.py
@@ -1,0 +1,41 @@
+from arm.logicnode.arm_nodes import *
+
+
+class DrawEllipseNode(ArmLogicTreeNode):
+    """Draws an ellipse.
+
+    @input Draw: Activate to draw the ellipse on this frame. The input must
+        be (indirectly) called from an `On Render2D` node.
+    @input Color: The color of the ellipse.
+    @input Filled: Whether the ellipse is filled or only the outline is drawn.
+    @input Strength: The line strength if the ellipse is not filled.
+    @input Segments: How many line segments should be used to draw the
+        ellipse. 0 (default) = automatic.
+    @input Center X/Y: The position of the ellipse's center in pixels.
+    @input Width: Width of the ellipse in pixels.
+    @input Height: Height of the ellipse in pixels.
+    @input Angle: Rotation angle in radians. Rotation is clockwise.
+
+    @output Out: Activated after the circle has been drawn.
+
+    @see [`kha.graphics2.GraphicsExtension.drawCircle()`](http://kha.tech/api/kha/graphics2/GraphicsExtension.html#drawCircle).
+    @see [`kha.graphics2.GraphicsExtension.fillCircle()`](http://kha.tech/api/kha/graphics2/GraphicsExtension.html#fillCircle).
+    """
+    bl_idname = 'LNDrawEllipseNode'
+    bl_label = 'Draw Ellipse'
+    arm_section = 'draw'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'Draw')
+        self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
+        self.add_input('ArmBoolSocket', 'Filled', default_value=False)
+        self.add_input('ArmFloatSocket', 'Strength', default_value=1.0)
+        self.add_input('ArmIntSocket', 'Segments')
+        self.add_input('ArmFloatSocket', 'Center X')
+        self.add_input('ArmFloatSocket', 'Center Y')
+        self.add_input('ArmFloatSocket', 'Width')
+        self.add_input('ArmFloatSocket', 'Height')
+        self.add_input('ArmFloatSocket', 'Angle')
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/blender/arm/logicnode/renderpath/LN_draw_image.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_image.py
@@ -42,6 +42,6 @@ class DrawImageNode(ArmLogicTreeNode):
         return NodeReplacement(
             "LNDrawImageNode", self.arm_version,
             "LNDrawImageNode", 2,
-            in_socket_mapping={0:0, 1:1, 2:2, 3:5, 4:6, 5:7, 6:9},
+            in_socket_mapping={0:0, 1:1, 2:2, 3:5, 4:6, 5:7, 6:8},
             out_socket_mapping={0:0},
         )

--- a/blender/arm/logicnode/renderpath/LN_draw_image.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_image.py
@@ -19,15 +19,29 @@ class DrawImageNode(ArmLogicTreeNode):
     bl_idname = 'LNDrawImageNode'
     bl_label = 'Draw Image'
     arm_section = 'draw'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'Draw')
         self.add_input('ArmStringSocket', 'Image File')
         self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
+        self.add_input('ArmIntSocket', 'Left/Center/Right', default_value=0)
+        self.add_input('ArmIntSocket', 'Top/Middle/Bottom', default_value=0)
         self.add_input('ArmFloatSocket', 'X')
         self.add_input('ArmFloatSocket', 'Y')
         self.add_input('ArmFloatSocket', 'Width')
         self.add_input('ArmFloatSocket', 'Height')
+        self.add_input('ArmFloatSocket', 'Angle')
 
         self.add_output('ArmNodeSocketAction', 'Out')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement(
+            "LNDrawImageNode", self.arm_version,
+            "LNDrawImageNode", 2,
+            in_socket_mapping={0:0, 1:1, 2:2, 3:5, 4:6, 5:7, 6:9},
+            out_socket_mapping={0:0},
+        )

--- a/blender/arm/logicnode/renderpath/LN_draw_image.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_image.py
@@ -8,9 +8,14 @@ class DrawImageNode(ArmLogicTreeNode):
         be (indirectly) called from an `On Render2D` node.
     @input Image: The filename of the image.
     @input Color: The color that the image's pixels are multiplied with.
-    @input X/Y: Position of the image, in pixels from the top left corner.
-    @input Width/Height: Size of the image in pixels. The image
-        grows towards the bottom right corner.
+    @input Left/Center/Right: Horizontal anchor point of the image.
+        0 = Left, 1 = Center, 2 = Right
+    @input Top/Middle/Bottom: Vertical anchor point of the image.
+        0 = Top, 1 = Middle, 2 = Bottom
+    @input X/Y: Position of the anchor point in pixels.
+    @input Width/Height: Size of the image in pixels.
+    @input Angle: Rotation angle in radians. Image will be rotated cloclwiswe
+        at the anchor point.
 
     @output Out: Activated after the image has been drawn.
 
@@ -25,8 +30,8 @@ class DrawImageNode(ArmLogicTreeNode):
         self.add_input('ArmNodeSocketAction', 'Draw')
         self.add_input('ArmStringSocket', 'Image File')
         self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
-        self.add_input('ArmIntSocket', 'Left/Center/Right', default_value=0)
-        self.add_input('ArmIntSocket', 'Top/Middle/Bottom', default_value=0)
+        self.add_input('ArmIntSocket', '0/1/2 = Left/Center/Right', default_value=0)
+        self.add_input('ArmIntSocket', '0/1/2 = Top/Middle/Bottom', default_value=0)
         self.add_input('ArmFloatSocket', 'X')
         self.add_input('ArmFloatSocket', 'Y')
         self.add_input('ArmFloatSocket', 'Width')

--- a/blender/arm/logicnode/renderpath/LN_draw_rect.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_rect.py
@@ -21,16 +21,30 @@ class DrawRectNode(ArmLogicTreeNode):
     bl_idname = 'LNDrawRectNode'
     bl_label = 'Draw Rect'
     arm_section = 'draw'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'Draw')
         self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
         self.add_input('ArmBoolSocket', 'Filled', default_value=False)
         self.add_input('ArmFloatSocket', 'Strength', default_value=1.0)
+        self.add_input('ArmIntSocket', 'Left/Center/Right', default_value=0)
+        self.add_input('ArmIntSocket', 'Top/Middle/Bottom', default_value=0)
         self.add_input('ArmFloatSocket', 'X')
         self.add_input('ArmFloatSocket', 'Y')
         self.add_input('ArmFloatSocket', 'Width')
         self.add_input('ArmFloatSocket', 'Height')
+        self.add_input('ArmFloatSocket', 'Angle')
 
         self.add_output('ArmNodeSocketAction', 'Out')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement(
+            "LNDrawRectNode", self.arm_version,
+            "LNDrawRectNode", 2,
+            in_socket_mapping={0:0, 1:1, 2:2, 3:3, 4:6, 5:7, 6:9, 7:10},
+            out_socket_mapping={0:0},
+        )

--- a/blender/arm/logicnode/renderpath/LN_draw_rect.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_rect.py
@@ -45,6 +45,6 @@ class DrawRectNode(ArmLogicTreeNode):
         return NodeReplacement(
             "LNDrawRectNode", self.arm_version,
             "LNDrawRectNode", 2,
-            in_socket_mapping={0:0, 1:1, 2:2, 3:3, 4:6, 5:7, 6:9, 7:10},
+            in_socket_mapping={0:0, 1:1, 2:2, 3:3, 4:6, 5:7, 6:8, 7:9},
             out_socket_mapping={0:0},
         )

--- a/blender/arm/logicnode/renderpath/LN_draw_rect.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_rect.py
@@ -9,9 +9,14 @@ class DrawRectNode(ArmLogicTreeNode):
     @input Color: The color of the rectangle.
     @input Filled: Whether the rectangle is filled or only the outline is drawn.
     @input Strength: The line strength if the rectangle is not filled.
-    @input X/Y: Position of the rectangle, in pixels from the top left corner.
-    @input Width/Height: Size of the rectangle in pixels. The rectangle
-        grows towards the bottom right corner.
+    @input Left/Center/Right: Horizontal anchor point of the rectangel.
+        0 = Left, 1 = Center, 2 = Right
+    @input Top/Middle/Bottom: Vertical anchor point of the rectangel.
+        0 = Top, 1 = Middle, 2 = Bottom
+    @input X/Y: Position of the anchor point in pixels.
+    @input Width/Height: Size of the rectangle in pixels.
+    @input Angle: Rotation angle in radians. Rectangle will be rotated cloclwiswe
+        at the anchor point.
 
     @output Out: Activated after the rectangle has been drawn.
 
@@ -28,8 +33,8 @@ class DrawRectNode(ArmLogicTreeNode):
         self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
         self.add_input('ArmBoolSocket', 'Filled', default_value=False)
         self.add_input('ArmFloatSocket', 'Strength', default_value=1.0)
-        self.add_input('ArmIntSocket', 'Left/Center/Right', default_value=0)
-        self.add_input('ArmIntSocket', 'Top/Middle/Bottom', default_value=0)
+        self.add_input('ArmIntSocket', '0/1/2 = Left/Center/Right', default_value=0)
+        self.add_input('ArmIntSocket', '0/1/2 = Top/Middle/Bottom', default_value=0)
         self.add_input('ArmFloatSocket', 'X')
         self.add_input('ArmFloatSocket', 'Y')
         self.add_input('ArmFloatSocket', 'Width')


### PR DESCRIPTION
1. Adds anchor point option for `Draw Rect` and `Draw Image` nodes. Option to rotate around the anchor point.
2. New draw ellipse node.

![image](https://user-images.githubusercontent.com/55564981/209447165-d7abf811-10d5-4f01-b2bd-707a83d014d2.png)
