### PR TITLE
Append khamake options to command on preset exporters

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -304,17 +304,16 @@ def compile(assets_only=False):
 
     node_path = arm.utils.get_node_path()
     khamake_path = arm.utils.get_khamake_path()
+    cmd = [node_path, khamake_path]
 
     # Custom exporter
     if state.target == "custom":
-        cmd = [node_path, khamake_path]
         item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
         if item.arm_project_target == 'custom' and item.arm_project_khamake != '':
             for s in item.arm_project_khamake.split(' '):
                 cmd.append(s)
         state.proc_build = run_proc(cmd, build_done)
     else:
-        cmd = [node_path, khamake_path]
         target_name = state.target
         kha_target_name = arm.utils.get_kha_target(target_name)
         if kha_target_name != '':
@@ -385,6 +384,10 @@ def compile(assets_only=False):
             if assets_only or compilation_server:
                 cmd.append('--nohaxe')
                 cmd.append('--noproject')
+            item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
+            if item.arm_project_khamake != "":
+                for s in item.arm_project_khamake.split(" "):
+                    cmd.append(s)
             state.proc_build = run_proc(cmd, assets_done if compilation_server else build_done)
             if bpy.app.background:
                 if state.proc_build.returncode == 0:

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -803,8 +803,7 @@ class ARM_PT_ArmoryExporterPanel(bpy.types.Panel):
             item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
             box = layout.box().column()
             box.prop(item, 'arm_project_target')
-            if item.arm_project_target == 'custom':
-                box.prop(item, 'arm_project_khamake')
+            box.prop(item, 'arm_project_khamake')
             box.prop(item, arm.utils.target_to_gapi(item.arm_project_target))
             box.prop_search(item, "arm_project_rp", wrd, "arm_rplist", text="Render Path")
             box.prop_search(item, 'arm_project_scene', bpy.data, 'scenes', text='Scene')


### PR DESCRIPTION
Do not hide `arm_project_khamake` exporter option when using preset exporters, but append its values to the khamake call.