### PR TITLE
Fix emission ghosting effect on some platforms

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -128,6 +128,7 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
             elif mat_state.emission_type == mat_state.EmissionType.SHADED:
                 if '_EmissionShaded' not in wrd.world_defs:
                     wrd.world_defs += '_EmissionShaded'
+                    arm.assets.add_khafile_def('rp_gbuffer_emission')
 
         if parse_opacity:
             curshader.write('opacity = {0} - 0.0002;'.format(out_opacity))

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -262,10 +262,11 @@ def make_deferred(con_mesh, rpasses):
         if mat_state.material.arm_ignore_irradiance:
             frag.write('fragColor[GBUF_IDX_2].b = 1.0;')
 
-    if '_EmissionShaded' in wrd.world_defs:
-        assets.add_khafile_def('rp_gbuffer_emission')
-        # Alpha channel is unused at the moment
-        frag.write('fragColor[GBUF_IDX_EMISSION] = vec4(emissionCol, 0.0);')
+    # Even if the material doesn't use emission we need to write to the
+    # emission buffer (if used) to prevent undefined behaviour
+    frag.write('#ifdef _EmissionShaded')
+    frag.write('fragColor[GBUF_IDX_EMISSION] = vec4(emissionCol, 0.0);')  # Alpha channel is unused at the moment
+    frag.write('#endif')
 
     return con_mesh
 


### PR DESCRIPTION
This PR fixes ghosting artifacts on some platforms caused by undefined behaviour if the emission buffer was used. Materials without emission didn't write to the buffer, in which case some platforms wrote zeroes to it but on others didn't update the buffer at all and in turn caused the emission values from earlier frames to persist.

![Emission ghosting effect](https://user-images.githubusercontent.com/17685000/209854952-771e4108-10a2-4279-bb21-f403cb8ad62d.png)

Thanks to @ TriVoxel on Discord for the [report](https://discord.com/channels/486771218599510021/487613529990365184/1044950433686372353), from which I took the screenshot above.