### PR TITLE
add Draw Text Area String node

### DIFF
--- a/Sources/armory/logicnode/DrawTextAreaStringNode.hx
+++ b/Sources/armory/logicnode/DrawTextAreaStringNode.hx
@@ -60,9 +60,6 @@ class DrawTextAreaStringNode extends LogicNode {
 			return;
 		}
 		
-		
-		//mi codigo
-		
 		var len = string.length;
 		
 		var ar_lines = [];

--- a/Sources/armory/logicnode/DrawTextAreaStringNode.hx
+++ b/Sources/armory/logicnode/DrawTextAreaStringNode.hx
@@ -1,0 +1,133 @@
+package armory.logicnode;
+
+import kha.Font;
+import kha.Color;
+import armory.renderpath.RenderToTexture;
+
+import kha.graphics2.VerTextAlignment;
+import kha.graphics2.HorTextAlignment;
+
+using kha.graphics2.GraphicsExtension;
+
+#if arm_ui
+import armory.ui.Canvas;
+#end
+
+class DrawTextAreaStringNode extends LogicNode {
+	var font: Font;
+	var lastFontName = "";
+	
+	public var property0: String;
+	public var property1: String;
+	public var property2: String;
+	
+	var index: Int;
+	var max: Int;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		RenderToTexture.ensure2DContext("DrawTextAreaStringNode");
+
+		var string:String = Std.string(inputs[1].get());
+		var length:Int = inputs[3].get();
+		
+		var horA = TextLeft;
+		var verA = TextTop;
+		
+		
+		var fontName = inputs[2].get();
+		if (fontName == "") {
+			#if arm_ui
+			fontName = Canvas.defaultFontName;
+			#else
+			return; // No default font is exported, there is nothing we can do here
+			#end
+		}
+
+		if (fontName != lastFontName) {
+			// Load new font
+			lastFontName = fontName;
+			iron.data.Data.getFont(fontName, (f: Font) -> {
+				font = f;
+			});
+		}
+
+		if (font == null) {
+			runOutput(0);
+			return;
+		}
+		
+		
+		//mi codigo
+		
+		var len = string.length;
+		
+		var ar_lines = [];
+		
+		var ar_words = string.split(' ');
+		
+		if(property0 == 'Lines')
+			max = Std.int(len/length);
+		else max = length;
+		
+		while(ar_words.length > 0){
+			var str_line = '';
+			
+				while(str_line.length < max && ar_words.length > 0){
+					str_line +=' '+ar_words.shift();
+				}
+				
+			ar_lines.push(str_line);
+		
+		}
+		
+		var spacing = inputs[4].get();
+
+		final colorVec = inputs[6].get();
+		final colorVecB = inputs[7].get();
+
+		RenderToTexture.g.fontSize = inputs[5].get();
+		RenderToTexture.g.font = font;
+		
+		index = 0;
+		
+		var height = RenderToTexture.g.font.height(RenderToTexture.g.fontSize);
+		
+		var yoffset = 0.0;
+		
+		switch(property2){
+			case 'TextTop': verA = TextTop; 
+			case 'TextMiddle': { verA = TextMiddle; yoffset = -height * 0.5; }
+			case 'TextBottom': { verA = TextBottom; yoffset = -height; }
+		}
+
+		
+		for (line in ar_lines){
+		
+			var width = RenderToTexture.g.font.width(RenderToTexture.g.fontSize, line);
+			
+			var xoffset = 0.0;
+			
+			switch(property1){
+				case 'TextLeft': horA = TextLeft;
+				case 'TextCenter': {horA = TextCenter; xoffset = -width * 0.5; }
+				case 'TextRight': {horA = TextRight;  xoffset = -width; }
+			}
+
+			RenderToTexture.g.color = Color.fromFloats(colorVecB.x, colorVecB.y, colorVecB.z, colorVecB.w);
+			
+			RenderToTexture.g.fillRect(inputs[8].get()+xoffset, inputs[9].get()+yoffset+index*height*spacing, width, height);
+			
+			RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
+			
+			RenderToTexture.g.drawAlignedString(line, inputs[8].get(), inputs[9].get()+index*height*spacing, horA, verA);
+			++index;
+			
+		}
+		
+		runOutput(0);
+	}
+}

--- a/blender/arm/logicnode/renderpath/LN_draw_Text_Area_string.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_Text_Area_string.py
@@ -1,0 +1,66 @@
+from arm.logicnode.arm_nodes import *
+
+
+class DrawTextAreaStringNode(ArmLogicTreeNode):
+    """Draws a string.
+
+    @input Draw: Activate to draw the string on this frame. The input must
+        be (indirectly) called from an `On Render2D` node.
+    @input String: The string to draw.
+    @input Font File: The filename of the font (including the extension).
+        If empty and Zui is _enabled_, the default font is used. If empty
+        and Zui is _disabled_, nothing is rendered.
+    @input Font Size: The size of the font in pixels.
+    @input Color: The color of the string.
+    @input X/Y: Position of the string, in pixels from the top left corner.
+
+    @output Out: Activated after the string has been drawn.
+
+    @see [`kha.graphics2.Graphics.drawString()`](http://kha.tech/api/kha/graphics2/Graphics.html#drawString).
+    """
+    bl_idname = 'LNDrawTextAreaStringNode'
+    bl_label = 'Draw Text Area String'
+    arm_section = 'draw'
+    arm_version = 1
+
+    property0: HaxeEnumProperty(
+    'property0',
+    items = [('Lines', 'Length of Lines', 'Length of Lines'),
+             ('Chars', 'Length of Characters', 'Chars'),],
+    name='', default='Lines')
+    
+    property1: HaxeEnumProperty(
+    'property1',
+    items = [('TextLeft', 'Hor. Align. Left', 'Hor. Align. Left'),
+             ('TextCenter', 'Hor. Align. Center', 'Hor. Align. Center'),
+             ('TextRight', 'Hor. Align. Right', 'Hor. Align. Right'),],
+    name='', default='TextLeft')
+    
+    property2: HaxeEnumProperty(
+    'property2',
+    items = [('TextTop', 'Ver. Align. Top', 'Ver. Align. Top'),
+             ('TextMiddle', 'Ver. Align. Middle', 'Ver. Align. Middle'),
+             ('TextBottom', 'Ver. Align. Bottom', 'Ver. Align. Bottom'),],
+    name='', default='TextTop')
+    
+	
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'Draw')
+        self.add_input('ArmStringSocket', 'String')
+        self.add_input('ArmStringSocket', 'Font File')
+        self.add_input('ArmIntSocket', 'Length', default_value=3)
+        self.add_input('ArmFloatSocket', 'Lines Spacing', default_value=1.0)
+        self.add_input('ArmIntSocket', 'Font Size', default_value=16)
+        self.add_input('ArmColorSocket', 'Color Font', default_value=[1.0, 1.0, 1.0, 1.0])
+        self.add_input('ArmColorSocket', 'Color Background', default_value=[0.0, 0.0, 0.0, 1.0])
+        self.add_input('ArmFloatSocket', 'X')
+        self.add_input('ArmFloatSocket', 'Y')
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+        
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
+        layout.prop(self, 'property1')
+        layout.prop(self, 'property2')
+
+

--- a/blender/arm/logicnode/renderpath/LN_draw_Text_Area_string.py
+++ b/blender/arm/logicnode/renderpath/LN_draw_Text_Area_string.py
@@ -4,17 +4,20 @@ from arm.logicnode.arm_nodes import *
 class DrawTextAreaStringNode(ArmLogicTreeNode):
     """Draws a string.
 
+    @length property: length of the text text area string can be determined by the amount of lines desired or the amount of characters in a line.
     @input Draw: Activate to draw the string on this frame. The input must
         be (indirectly) called from an `On Render2D` node.
-    @input String: The string to draw.
+    @input String: The string to draw as a text area.
     @input Font File: The filename of the font (including the extension).
         If empty and Zui is _enabled_, the default font is used. If empty
         and Zui is _disabled_, nothing is rendered.
+    
+    @length: value according to specified property above. 
+    @line Spacing: changes the separation between lines.
     @input Font Size: The size of the font in pixels.
-    @input Color: The color of the string.
+    @input Color Font: The color of the string, supports alpha.
+    @input Color Background: The color background of the text area, supports alpha, if no color is wanted used alpha 0.
     @input X/Y: Position of the string, in pixels from the top left corner.
-
-    @output Out: Activated after the string has been drawn.
 
     @see [`kha.graphics2.Graphics.drawString()`](http://kha.tech/api/kha/graphics2/Graphics.html#drawString).
     """
@@ -49,7 +52,7 @@ class DrawTextAreaStringNode(ArmLogicTreeNode):
         self.add_input('ArmStringSocket', 'String')
         self.add_input('ArmStringSocket', 'Font File')
         self.add_input('ArmIntSocket', 'Length', default_value=3)
-        self.add_input('ArmFloatSocket', 'Lines Spacing', default_value=1.0)
+        self.add_input('ArmFloatSocket', 'Line Spacing', default_value=1.0)
         self.add_input('ArmIntSocket', 'Font Size', default_value=16)
         self.add_input('ArmColorSocket', 'Color Font', default_value=[1.0, 1.0, 1.0, 1.0])
         self.add_input('ArmColorSocket', 'Color Background', default_value=[0.0, 0.0, 0.0, 1.0])
@@ -62,5 +65,3 @@ class DrawTextAreaStringNode(ArmLogicTreeNode):
         layout.prop(self, 'property0')
         layout.prop(self, 'property1')
         layout.prop(self, 'property2')
-
-


### PR DESCRIPTION
This node extends the previous functionality of the draw string node that draws text in a line.

thanks @rpaladin @QuantumCoderQC @MoritzBrueckner for your comments.

Regarding the vertical alignment discussion, i  just left the code consistent with the actual aligned function. Robert did not merge the fix but he said  the actual code was deprecated and it was going to be replaced soon. Maybe then we can modify this too.

![image](https://user-images.githubusercontent.com/32546729/209890207-4050537f-3018-48b1-aef8-7673e35fc244.png)
![image](https://user-images.githubusercontent.com/32546729/209890245-c9a012ef-350c-4378-aa82-51122b59ab5c.png)
![image](https://user-images.githubusercontent.com/32546729/209890255-2ec31a10-3948-4732-8404-90d06f946bbb.png)
![image](https://user-images.githubusercontent.com/32546729/209890291-35d6230e-ae5f-4514-83b6-bb5b0c08b743.png)
