### PR TITLE
Fix crash on recompile

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -308,10 +308,11 @@ def compile(assets_only=False):
 
     # Custom exporter
     if state.target == "custom":
-        item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
-        if item.arm_project_target == 'custom' and item.arm_project_khamake != '':
-            for s in item.arm_project_khamake.split(' '):
-                cmd.append(s)
+        if len(wrd.arm_exporterlist) > 0:
+            item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
+            if item.arm_project_target == 'custom' and item.arm_project_khamake != '':
+                for s in item.arm_project_khamake.split(' '):
+                    cmd.append(s)
         state.proc_build = run_proc(cmd, build_done)
     else:
         target_name = state.target
@@ -384,10 +385,11 @@ def compile(assets_only=False):
             if assets_only or compilation_server:
                 cmd.append('--nohaxe')
                 cmd.append('--noproject')
-            item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
-            if item.arm_project_khamake != "":
-                for s in item.arm_project_khamake.split(" "):
-                    cmd.append(s)
+            if len(wrd.arm_exporterlist) > 0:
+                item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
+                if item.arm_project_khamake != "":
+                    for s in item.arm_project_khamake.split(" "):
+                        cmd.append(s)
             state.proc_build = run_proc(cmd, assets_done if compilation_server else build_done)
             if bpy.app.background:
                 if state.proc_build.returncode == 0:


### PR DESCRIPTION
Fixes crash that was first introduced in #2731

**Steps to reproduce:** Attempting to recompile (with cache) with zero export presets available caused crashing on build export.

```
Traceback (most recent call last):
  File "D:\Blender\Projects\RP\B3D_33\armsdk/armory\blender\arm\props_ui.py", line 1171, in invoke
    return self.execute(context)
  File "D:\Blender\Projects\RP\B3D_33\armsdk/armory\blender\arm\props_ui.py", line 1190, in execute
    make.play()
  File "D:\Blender\Projects\RP\B3D_33\armsdk/armory\blender\arm\make.py", line 572, in play
    compile(assets_only=(not wrd.arm_recompile))
  File "D:\Blender\Projects\RP\B3D_33\armsdk/armory\blender\arm\make.py", line 387, in compile
    item = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
IndexError: bpy_prop_collection[index]: index 0 out of range, size 0
```