### PR TITLE
Gate node: fix accessing vector methods when DCE is on

### DIFF
--- a/Sources/armory/logicnode/GateNode.hx
+++ b/Sources/armory/logicnode/GateNode.hx
@@ -18,11 +18,11 @@ class GateNode extends LogicNode {
 
 		switch (property0) {
 		case "Equal":
-			cond = Std.isOfType(v1, Vec4) ? v1.equals(v2) : v1 == v2;
+			cond = Std.isOfType(v1, Vec4) ? (v1: Vec4).equals(v2) : v1 == v2;
 		case "Not Equal":
-			cond = Std.isOfType(v1, Vec4) ? !v1.equals(v2) : v1 != v2;
+			cond = Std.isOfType(v1, Vec4) ? !(v1: Vec4).equals(v2) : v1 != v2;
 		case "Almost Equal":
-			cond = Std.isOfType(v1, Vec4) ? v1.almostEquals(v2, property1) : Math.abs(v1 - v2) < property1;
+			cond = Std.isOfType(v1, Vec4) ? (v1: Vec4).almostEquals(v2, property1) : Math.abs(v1 - v2) < property1;
 		case "Greater":
 			cond = v1 > v2;
 		case "Greater Equal":


### PR DESCRIPTION
Same issue & fix as https://github.com/armory3d/armory/pull/2398, but this time for the Gate node. Thanks to @ TriVoxel for the report on Discord.