### PR TITLE
Case Index node: fix accessing Vec4.equals() when DCE is on + cleanup

### DIFF
--- a/Sources/armory/logicnode/CaseIndexNode.hx
+++ b/Sources/armory/logicnode/CaseIndexNode.hx
@@ -12,7 +12,7 @@ class CaseIndexNode extends LogicNode {
 		var value = inputs[0].get();
 
 		for (index in 0...inputs.length - 1) {
-			if (Std.isOfType(value, Vec4) ? value.equals(inputs[index + 1].get()) : (value == inputs[index + 1].get())) {
+			if (Std.isOfType(value, Vec4) ? (value: Vec4).equals(inputs[index + 1].get()) : (value == inputs[index + 1].get())) {
 				return index;
 			}
 		}

--- a/Sources/armory/logicnode/CaseIndexNode.hx
+++ b/Sources/armory/logicnode/CaseIndexNode.hx
@@ -4,21 +4,18 @@ import iron.math.Vec4;
 
 class CaseIndexNode extends LogicNode {
 
-	var value: Dynamic = null;
-
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 	override function get(from: Dynamic): Int {
+		var value = inputs[0].get();
 
-	var value = inputs[0].get();
-	
-	for(index in 0...inputs.length-1)
-		if(Std.isOfType(value, Vec4) ? value.equals(inputs[index+1].get()) : value == inputs[index+1].get())
-			return index;
-			
-	return null;
-
+		for (index in 0...inputs.length - 1) {
+			if (Std.isOfType(value, Vec4) ? value.equals(inputs[index + 1].get()) : (value == inputs[index + 1].get())) {
+				return index;
+			}
+		}
+		return null;
 	}
 }

--- a/blender/arm/logicnode/logic/LN_case_index.py
+++ b/blender/arm/logicnode/logic/LN_case_index.py
@@ -2,16 +2,16 @@ from arm.logicnode.arm_nodes import *
 
 
 class CaseIndexNode(ArmLogicTreeNode):
-    """Compare the given dynamic value with the other inputs for equality
+    """Compare the given `Compare` value with the other inputs for equality
     and return the first match. This is particularly helpful in combination
     with the `Select` node.
 
     @seeNode Select
 
-    @input Dynamic: the value to be compared
+    @input Compare: the value to be compared
     @input Value: values for the dynamic comparison
 
-    @output Value: the index of the first equal value, or `null` if no
+    @output Index: the index of the first equal value, or `null` if no
         equal value was found.
     """
     bl_idname = 'LNCaseIndexNode'
@@ -26,10 +26,10 @@ class CaseIndexNode(ArmLogicTreeNode):
         array_nodes[str(id(self))] = self
 
     def arm_init(self, context):
-        self.add_input('ArmDynamicSocket', 'Dynamic')
+        self.add_input('ArmDynamicSocket', 'Compare')
         self.add_input_func()
 
-        self.add_output('ArmDynamicSocket', 'Value')
+        self.add_output('ArmIntSocket', 'Index')
 
     def draw_buttons(self, context, layout):
         row = layout.row(align=True)

--- a/blender/arm/logicnode/logic/LN_case_index.py
+++ b/blender/arm/logicnode/logic/LN_case_index.py
@@ -1,38 +1,33 @@
-from bpy.types import NodeSocketInterfaceInt
 from arm.logicnode.arm_nodes import *
 
-class CaseIndexNode(ArmLogicTreeNode):
-    """this node can be used as an input for the select node that takes numeric indixes when cases are dynamic values or as an input for anything that requieres a numeric index.
 
-    @input dynamic: the value to be compared
-    
-    @input value: cases values for the dynamic comparison
-    
-    @output index: Returns the index of the case dynamic comparison
-    
+class CaseIndexNode(ArmLogicTreeNode):
+    """Compare the given dynamic value with the other inputs for equality
+    and return the first match. This is particularly helpful in combination
+    with the `Select` node.
+
+    @seeNode Select
+
+    @input Dynamic: the value to be compared
+    @input Value: values for the dynamic comparison
+
+    @output Value: the index of the first equal value, or `null` if no
+        equal value was found.
     """
-    
     bl_idname = 'LNCaseIndexNode'
     bl_label = 'Case Index'
     arm_version = 1
     min_inputs = 2
 
-    def update_exec_mode(self, context):
-        self.set_mode()
-
-    num_choices: IntProperty(default=1, min=0)
+    num_choices: IntProperty(default=0, min=0)
 
     def __init__(self):
         super().__init__()
         array_nodes[str(id(self))] = self
 
     def arm_init(self, context):
-        self.set_mode()
-
-    def set_mode(self):
-  
         self.add_input('ArmDynamicSocket', 'Dynamic')
-        self.num_choices = 0
+        self.add_input_func()
 
         self.add_output('ArmDynamicSocket', 'Value')
 
@@ -51,7 +46,6 @@ class CaseIndexNode(ArmLogicTreeNode):
 
     def add_input_func(self):
         self.add_input('ArmDynamicSocket', f'Value {self.num_choices}')
-
         self.num_choices += 1
 
     def remove_input_func(self):
@@ -63,10 +57,4 @@ class CaseIndexNode(ArmLogicTreeNode):
         if self.num_choices == 0:
             return self.bl_label
 
-        return f'{self.bl_label}: [{self.num_choices-1}]'
-
-    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
-            raise LookupError()
-            
-        return NodeReplacement.Identity(self)
+        return f'{self.bl_label}: [{self.num_choices}]'


### PR DESCRIPTION
Same fix as https://github.com/armory3d/armory/pull/2740 again, this time for https://github.com/armory3d/armory/pull/2743. While I was on it I also cleaned up the node's sources a bit (whitespace, unused variables/functions etc.) and took the liberty of changing the documentation as well as some socket names to hopefully make its usage a little clearer.

I didn't implement a replacement function for my changes by purpose (in fact, I even removed it since the node's version is still 1 so it is never called) because the node was only implemented a few days ago and isn't yet part of any SDK release.