### PR TITLE
Updated tilesheet UI to support Sparrow atlas files.

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -14,6 +14,7 @@ http://creativecommons.org/licenses/by-sa/3.0/deed.en_US
 from enum import Enum, unique
 import math
 import os
+import pathlib
 import time
 from typing import Any, Dict, List, Tuple, Union, Optional
 
@@ -2244,9 +2245,11 @@ Make sure the mesh only has tris/quads.""")
         for ts in wrd.arm_tilesheetlist:
             o = {}
             o['name'] = ts.name
+            o['format'] = ts.format_prop
             o['tilesx'] = ts.tilesx_prop
             o['tilesy'] = ts.tilesy_prop
             o['framerate'] = ts.framerate_prop
+            o['atlas_data'] = self.read_file(ts.atlas_file_prop)
             o['actions'] = []
             for tsa in ts.arm_tilesheetactionlist:
                 ao = {}
@@ -2254,8 +2257,17 @@ Make sure the mesh only has tris/quads.""")
                 ao['start'] = tsa.start_prop
                 ao['end'] = tsa.end_prop
                 ao['loop'] = tsa.loop_prop
+                ao['prefix'] = tsa.prefix_prop
                 o['actions'].append(ao)
             self.output['tilesheet_datas'].append(o)
+
+    def read_file(self, path):
+        f = pathlib.Path(bpy.path.abspath(path))
+
+        if f.exists():
+            return f.read_text()
+        else:
+            return ''
 
     def export_world(self):
         """Exports the world of the current scene."""

--- a/blender/arm/props_tilesheet.py
+++ b/blender/arm/props_tilesheet.py
@@ -4,23 +4,31 @@ from bpy.props import *
 class ArmTilesheetActionListItem(bpy.types.PropertyGroup):
     name: StringProperty(
         name="Name",
-        description="A name for this item",
+        description="A name for this action",
         default="Untitled")
+
+    # GRID action properties
 
     start_prop: IntProperty(
         name="Start",
-        description="A name for this item",
+        description="The start frame index for this action",
         default=0)
 
     end_prop: IntProperty(
         name="End",
-        description="A name for this item",
+        description="The end frame index for this action",
         default=0)
 
     loop_prop: BoolProperty(
         name="Loop",
-        description="A name for this item",
+        description="Whether this action loops or not",
         default=True)
+
+    # SPARROW action properties
+
+    prefix_prop: StringProperty(
+        name="Prefix",
+        description="An animation prefix for this action")
 
 class ARM_UL_TilesheetActionList(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
@@ -136,20 +144,38 @@ class ArmTilesheetListItem(bpy.types.PropertyGroup):
         description="A name for this item",
         default="Untitled")
 
+    format_prop: EnumProperty(
+        name="Format",
+        description="The format to use for the tilesheet",
+        items=(
+            ('GRID', 'Grid', ""),
+            ('SPARROW', 'Sparrow', "")
+        ),
+        default="GRID")
+
+    # GRID format
+
     tilesx_prop: IntProperty(
         name="Tiles X",
-        description="A name for this item",
+        description="The grid width of the tilesheet in tiles",
         default=0)
 
     tilesy_prop: IntProperty(
         name="Tiles Y",
-        description="A name for this item",
+        description="The grid height of the tilesheet in tiles",
         default=0)
 
     framerate_prop: FloatProperty(
         name="Frame Rate",
-        description="A name for this item",
+        description="The framerate of the tilesheet",
         default=4.0)
+
+    # SPARROW format
+
+    atlas_file_prop: StringProperty(
+        name = "Atlas File",
+        description = "A path to an XML file describing the Sparrow spritesheet",
+        subtype = "FILE_PATH")
 
     arm_tilesheetactionlist: CollectionProperty(type=ArmTilesheetActionListItem)
     arm_tilesheetactionlist_index: IntProperty(name="Index for arm_tilesheetactionlist", default=0)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -2175,8 +2175,15 @@ class ARM_PT_TilesheetPanel(bpy.types.Panel):
 
         if wrd.arm_tilesheetlist_index >= 0 and len(wrd.arm_tilesheetlist) > 0:
             dat = wrd.arm_tilesheetlist[wrd.arm_tilesheetlist_index]
-            layout.prop(dat, "tilesx_prop")
-            layout.prop(dat, "tilesy_prop")
+            layout.prop(dat, "format_prop")
+
+            # Provide different properties for different tile formats
+            if dat.format_prop == "GRID":
+                layout.prop(dat, "tilesx_prop")
+                layout.prop(dat, "tilesy_prop")
+            elif dat.format_prop == "SPARROW":
+                layout.prop(dat, "atlas_file_prop")
+
             layout.prop(dat, "framerate_prop")
 
             layout.label(text='Actions')
@@ -2198,8 +2205,11 @@ class ARM_PT_TilesheetPanel(bpy.types.Panel):
 
             if dat.arm_tilesheetactionlist_index >= 0 and len(dat.arm_tilesheetactionlist) > 0:
                 adat = dat.arm_tilesheetactionlist[dat.arm_tilesheetactionlist_index]
-                layout.prop(adat, "start_prop")
-                layout.prop(adat, "end_prop")
+                if (dat.format_prop == "GRID"):
+                    layout.prop(adat, "start_prop")
+                    layout.prop(adat, "end_prop")
+                elif (dat.format_prop == "SPARROW"):
+                    layout.prop(adat, "prefix_prop")
                 layout.prop(adat, "loop_prop")
 
 class ArmPrintTraitsButton(bpy.types.Operator):


### PR DESCRIPTION
The current implementation of Tilesheets in Armory is very limited. It only provides support for grids of square sprites, and playing a range of frames from the grid in order. This is highly inefficient, as it does not allow the spritesheet to be optimized or frames to be reused.

This pull request implements user interface support for the Sparrow sprite format, which associates an XML file with the spritesheet, which looks like so:

```
<TextureAtlas imagePath="atlas.png">
 <SubTexture name="idle001" x="0" y="0" width="30" height="30"/>;
 <SubTexture name="idle002" x="30" y="0" width="65" height="78"/>;
 <SubTexture name="walk001" x="30" y="80" width="65" height="78"/>;
 <SubTexture name="walk002" x="30" y="80" width="65" height="78"/>;
 ...
</TextureAtlas>;
```

These spritesheets can be generated by programs such as TexturePacker or Adobe Animate.

Developers can then specify frames by prefix, for example the Walk animation will use the frames with the name `walk`, in order.

Care was taken to ensure only relevant options to the current atlas format display to the user, so the user is not prompted for a file when in Grid mode.

There is also room to add additional file formats as users request them.

## TODO

- [ ] Add additional options for Actions.
  - [ ] Make frame rate action-specific
  - [ ] Add the ability to specify an array of frame indices to use rather than a range.
  - [ ] Add the ability to horizontally or vertically flip the action.

## Note

This pull request is associated with armory3d/iron#182, and will not function as intended without it.