### PR TITLE
New compositing distort shader

### DIFF
--- a/Shaders/compositor_pass/compositor_pass.frag.glsl
+++ b/Shaders/compositor_pass/compositor_pass.frag.glsl
@@ -62,6 +62,7 @@ uniform vec3 PPComp5;
 uniform vec3 PPComp6;
 uniform vec3 PPComp7;
 uniform vec3 PPComp8;
+uniform vec3 PPComp14;
 #endif
 
 // #ifdef _CPos
@@ -81,8 +82,12 @@ uniform float aspectRatio;
 uniform vec2 texStep;
 #endif
 
+#ifdef _CDistort
+uniform float time;
+#else
 #ifdef _CGrain
 uniform float time;
+#endif
 #endif
 
 #ifdef _DynRes
@@ -238,6 +243,19 @@ void main() {
 	else {
 		texCo = m + normalize(d) * atan(r * -power * 10.0) * bind / atan(-power * bind * 10.0);
 	}
+#endif
+
+#ifdef _CDistort
+	// const float compoDistortStrength = 4.0;
+	#ifdef _CPostprocess
+		float uStrength = PPComp14;
+	#else
+		float uStrength = compoDistortStrength;
+	#endif
+	float uX = time * uStrength;
+	texCo.y = texCo.y + (sin(texCo.x*4.0+uX*2.0)*0.01);
+	texCo.x = texCo.x + (cos(texCo.y*4.0+uX*2.0)*0.01);
+	fragColor.rgb = texture(tex, texCo).rgb;
 #endif
 
 #ifdef _CDepth

--- a/Shaders/compositor_pass/compositor_pass.frag.glsl
+++ b/Shaders/compositor_pass/compositor_pass.frag.glsl
@@ -255,7 +255,6 @@ void main() {
 	float uX = time * uStrength;
 	texCo.y = texCo.y + (sin(texCo.x*4.0+uX*2.0)*0.01);
 	texCo.x = texCo.x + (cos(texCo.y*4.0+uX*2.0)*0.01);
-	fragColor.rgb = texture(tex, texCo).rgb;
 #endif
 
 #ifdef _CDepth

--- a/Shaders/compositor_pass/compositor_pass.json
+++ b/Shaders/compositor_pass/compositor_pass.json
@@ -44,8 +44,8 @@
 				{
 					"name": "time",
 					"link": "_time",
-					"ifdef": ["_CGrain"]
-				},				
+					"ifdef": ["_CDistort", "_CGrain"]		
+				},
 				{
 					"name": "texStep",
 					"link": "_screenSizeInv",
@@ -224,6 +224,11 @@
 				{
 					"name": "PPComp8",
 					"link": "_PPComp8",
+					"ifdef": ["_CPostprocess"]
+				},
+				{
+					"name": "PPComp14",
+					"link": "_PPComp14",
 					"ifdef": ["_CPostprocess"]
 				}
 			],

--- a/Sources/armory/logicnode/CameraGetNode.hx
+++ b/Sources/armory/logicnode/CameraGetNode.hx
@@ -17,6 +17,8 @@ class CameraGetNode extends LogicNode {
 			case 6: armory.renderpath.Postprocess.camera_uniforms[6];
 			case 7: armory.renderpath.Postprocess.camera_uniforms[7];
 			case 8: armory.renderpath.Postprocess.camera_uniforms[8];
+			case 9: armory.renderpath.Postprocess.camera_uniforms[9];
+			case 10: armory.renderpath.Postprocess.camera_uniforms[10];
 			default: 0.0;
 		}
 	}

--- a/Sources/armory/renderpath/Postprocess.hx
+++ b/Sources/armory/renderpath/Postprocess.hx
@@ -52,7 +52,8 @@ class Postprocess {
 		160.0,				//7: DoF Focal Length mm
 		128,				//8: DoF F-Stop
 		0,					//9: Tonemapping Method
-		2.0					//10: Film Grain
+		2.0,				//10: Distort
+		2.0					//11: Film Grain
 	];
 
 	public static var tonemapper_uniforms = [
@@ -259,7 +260,7 @@ class Postprocess {
 		case "_PPComp4":
 			v = iron.object.Uniforms.helpVec;
 			v.x = Std.int(camera_uniforms[9]); //Tonemapping
-			v.y = camera_uniforms[10]; //Film Grain
+			v.y = camera_uniforms[11]; //Film Grain
 			v.z = tonemapper_uniforms[0]; //Slope
 		case "_PPComp5":
 			v = iron.object.Uniforms.helpVec;
@@ -276,11 +277,6 @@ class Postprocess {
 			v.x = lenstexture_uniforms[2]; //Lum min
 			v.y = lenstexture_uniforms[3]; //Lum max
 			v.z = lenstexture_uniforms[4]; //Expo
-		case "_PPComp8":
-			v = iron.object.Uniforms.helpVec;
-			v.x = colorgrading_global_uniforms[7][0]; //LUT R
-			v.y = colorgrading_global_uniforms[7][1]; //LUT G
-			v.z = colorgrading_global_uniforms[7][2]; //LUT B
 		case "_PPComp9":
 			v = iron.object.Uniforms.helpVec;
 			v.x = ssr_uniforms[0]; //Step
@@ -305,6 +301,11 @@ class Postprocess {
 			v = iron.object.Uniforms.helpVec;
 			v.x = chromatic_aberration_uniforms[0]; //CA Strength
 			v.y = chromatic_aberration_uniforms[1]; //CA Samples
+			v.z = 0;
+		case "_PPComp14":
+			v = iron.object.Uniforms.helpVec;
+			v.x = camera_uniforms[10]; //Distort
+			v.y = 0;
 			v.z = 0;
 		}
 

--- a/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
+++ b/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
@@ -4,7 +4,7 @@ class CameraGetNode(ArmLogicTreeNode):
     """Returns the post-processing effects of a camera."""
     bl_idname = 'LNCameraGetNode'
     bl_label = 'Get Camera Post Process'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
         self.add_output('ArmFloatSocket', 'F-Stop')
@@ -16,4 +16,11 @@ class CameraGetNode(ArmLogicTreeNode):
         self.add_output('ArmFloatSocket', 'DOF Distance')
         self.add_output('ArmFloatSocket', 'DOF Length')
         self.add_output('ArmFloatSocket', 'DOF F-Stop')
+        self.add_output('ArmFloatSocket', 'Distort')
         self.add_output('ArmFloatSocket', 'Film Grain')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+            
+        return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
+++ b/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
@@ -4,7 +4,7 @@ class CameraSetNode(ArmLogicTreeNode):
     """Set the post-processing effects of a camera."""
     bl_idname = 'LNCameraSetNode'
     bl_label = 'Set Camera Post Process'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
@@ -17,7 +17,18 @@ class CameraSetNode(ArmLogicTreeNode):
         self.add_input('ArmFloatSocket', 'DoF Distance', default_value=10.0)
         self.add_input('ArmFloatSocket', 'DoF Length', default_value=160.0)
         self.add_input('ArmFloatSocket', 'DoF F-Stop', default_value=128.0)
-        self.add_input('ArmIntSocket', 'Tonemapper', default_value=0)
+        self.add_input('ArmFloatSocket', 'Distort', default_value=2.0)
         self.add_input('ArmFloatSocket', 'Film Grain', default_value=2.0)
 
         self.add_output('ArmNodeSocketAction', 'Out')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        newnode = node_tree.nodes.new('LNCameraSetNode')
+
+        for link in self.inputs[10].links:
+            node_tree.links.new(newnode.inputs[10], link.to_socket)
+
+        return newnode

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -196,6 +196,8 @@ def build():
                 wrd.compo_defs += '_CFXAA'
             if rpdat.arm_letterbox:
                 wrd.compo_defs += '_CLetterbox'
+            if rpdat.arm_distort:
+                wrd.compo_defs += '_CDistort'
             if rpdat.arm_grain:
                 wrd.compo_defs += '_CGrain'
             if rpdat.arm_sharpen:

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -580,6 +580,8 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_letterbox: BoolProperty(name="Letterbox", default=False, update=assets.invalidate_shader_cache)
     arm_letterbox_color: FloatVectorProperty(name="Color", size=3, default=[0, 0, 0], subtype='COLOR', min=0, max=1, update=assets.invalidate_shader_cache)
     arm_letterbox_size: FloatProperty(name="Size", default=0.1, update=assets.invalidate_shader_cache)
+    arm_distort: BoolProperty(name="Distort", default=False, update=assets.invalidate_shader_cache)
+    arm_distort_strength: FloatProperty(name="Strength", default=2.0, update=assets.invalidate_shader_cache)
     arm_grain: BoolProperty(name="Film Grain", default=False, update=assets.invalidate_shader_cache)
     arm_grain_strength: FloatProperty(name="Strength", default=2.0, update=assets.invalidate_shader_cache)
     arm_sharpen: BoolProperty(name="Sharpen", default=False, update=assets.invalidate_shader_cache)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1861,6 +1861,7 @@ class ARM_PT_RenderPathCompositorPanel(bpy.types.Panel):
         col = layout.column()
         draw_conditional_prop(col, 'Sharpen', rpdat, 'arm_sharpen', 'arm_sharpen_strength')
         draw_conditional_prop(col, 'Vignette', rpdat, 'arm_vignette', 'arm_vignette_strength')
+        draw_conditional_prop(col, 'Distort', rpdat, 'arm_distort', 'arm_distort_strength')
         draw_conditional_prop(col, 'Film Grain', rpdat, 'arm_grain', 'arm_grain_strength')
         layout.separator()
 
@@ -1882,9 +1883,8 @@ class ARM_PT_RenderPathCompositorPanel(bpy.types.Panel):
         layout.separator()
 
         col = layout.column()
-        col.prop(rpdat, 'arm_lensflare')
         col.prop(rpdat, 'arm_fisheye')
-        layout.separator()
+        col.prop(rpdat, 'arm_lensflare')
 
         col = layout.column()
         col.prop(rpdat, 'arm_lens_texture')

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -677,6 +677,11 @@ const float autoExposureSpeed = """ + str(rpdat.arm_autoexposure_speed) + """;
 const vec3 compoLetterboxColor = vec3(""" + str(round(rpdat.arm_letterbox_color[0] * 100) / 100) + """, """ + str(round(rpdat.arm_letterbox_color[1] * 100) / 100) + """, """ + str(round(rpdat.arm_letterbox_color[2] * 100) / 100) + """);
 """)
 
+        if rpdat.arm_distort:
+            f.write(
+"""const float compoDistortStrength = """ + str(round(rpdat.arm_distort_strength * 100) / 100) + """;
+""")
+
         if rpdat.arm_grain:
             f.write(
 """const float compoGrainStrength = """ + str(round(rpdat.arm_grain_strength * 100) / 100) + """;


### PR DESCRIPTION
Originally requested [here](https://forums.armory3d.org/t/underwater-effect/5093). Combined with fog and a LUT texture or a colored overlay, a convincing underwater effect can be achieved.

<hr />

# Preview

https://user-images.githubusercontent.com/69180012/210872628-1601ad40-53ad-46b1-a891-3fd3962e3caf.mp4

# Changelog

## Add-on

`props_renderpath.py` - New distort data.

`props_ui.py` - New distort UI. [Unrelated] Moved lensflare UI closer to one another (team decision).

`make_renderpath.py` - New distort data.

`write_data.py` - New distort data.

## Logic Nodes

`LN_get_camera_post_process.py` - New distort output.

`LN_set_camera_post_process.py` - Fixed incorrect type statement (additionally reported on Discord). Renamed input to distort.

`CameraGetNode.hx` - New distort data. Implemented missing input return.

## Shader

`Postprocess.hx` - New distort data.

`compositor_pass.json` - New distort data.

`compositor_pass.frag` - New distort shader.

<hr />

Super big thanks to @MoritzBrueckner for review, pointers, and suggestions.