### PR TITLE
Fix incorrect node replacements

### DIFF
--- a/blender/arm/logicnode/logic/LN_gate.py
+++ b/blender/arm/logicnode/logic/LN_gate.py
@@ -71,10 +71,8 @@ class GateNode(ArmLogicTreeNode):
         if self.arm_version not in (0, 2):
             raise LookupError()
             
-        if self.arm_version == 1:
+        if self.arm_version == 1 or self.arm_version == 2:
             return NodeReplacement(
                 'LNGateNode', self.arm_version, 'LNGateNode', 2,
                 in_socket_mapping={0:0, 1:1, 2:2}, out_socket_mapping={0:0, 1:1}
             )
-        elif self.arm_version == 2:
-            return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/logic/LN_merge.py
+++ b/blender/arm/logicnode/logic/LN_merge.py
@@ -72,7 +72,7 @@ class MergeNode(ArmLogicTreeNode):
         if self.arm_version not in (0, 2):
             raise LookupError()
             
-        if self.arm_version == 1:
+        if self.arm_version == 1 or self.arm_version == 2:
             newnode = node_tree.nodes.new('LNMergeNode')
             newnode.property0 = self.property0
 
@@ -89,5 +89,3 @@ class MergeNode(ArmLogicTreeNode):
                 node_tree.links.new(newnode.outputs[0], link.to_socket)
 
             return newnode
-        elif self.arm_version == 2:
-            return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/math/LN_compare.py
+++ b/blender/arm/logicnode/math/LN_compare.py
@@ -60,10 +60,8 @@ class CompareNode(ArmLogicTreeNode):
         if self.arm_version not in (0, 2):
             raise LookupError()
 
-        if self.arm_version == 1:
+        if self.arm_version == 1 or self.arm_version == 2:
             return NodeReplacement(
                 'LNGateNode', self.arm_version, 'LNGateNode', 2,
                 in_socket_mapping={0:0, 1:1, 2:2}, out_socket_mapping={0:0, 1:1}
             )
-        elif self.arm_version == 2:
-            return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/math/LN_quaternion_math.py
+++ b/blender/arm/logicnode/math/LN_quaternion_math.py
@@ -193,7 +193,7 @@ class QuaternionMathNode(ArmLogicTreeNode):
         if self.arm_version not in (0, 2):
             raise LookupError()
             
-        if self.arm_version == 1:
+        if self.arm_version == 1 or self.arm_version == 2:
             ret=[]
             if self.property0 == 'GetEuler':
                 newself = node_tree.nodes.new('LNSeparateRotationNode')
@@ -364,8 +364,6 @@ class QuaternionMathNode(ArmLogicTreeNode):
                 elif node.bl_idname == 'LNQuaternionMathNode':
                     node.set_enum(node.get_enum())
             return ret
-        elif self.arm_version == 2:
-            return NodeReplacement.Identity(self)
 
     # note: keep property1, so that it is actually readable for node conversion.
     property1: BoolProperty(name='DEPRECATED', default=False)

--- a/blender/arm/logicnode/native/LN_call_haxe_static.py
+++ b/blender/arm/logicnode/native/LN_call_haxe_static.py
@@ -40,10 +40,8 @@ class CallHaxeStaticNode(ArmLogicTreeNode):
         if self.arm_version not in (0, 2):
             raise LookupError()
             
-        if self.arm_version == 1:
+        if self.arm_version == 1 or self.arm_version == 2:
             return NodeReplacement(
                 'LNCallHaxeStaticNode', self.arm_version, 'LNCallHaxeStaticNode', 2,
                 in_socket_mapping={0:0, 1:1}, out_socket_mapping={0:0, 1:1}
             )
-        elif self.arm_version == 2:
-            return NodeReplacement.Identity(self)


### PR DESCRIPTION
Reported by @ MoritzBrueckner on Discord. Past commit of mine: https://github.com/armory3d/armory/commit/94902e5a59e01eaee1093c82974327c75551f13e, is the culprit. Apparently, I implemented incorrect replacement checks, which causes errors with outdated nodes, such as those in online demo blends.

For example with the [archery](https://github.com/armory3d/armory_templates/tree/master/archery) demo, the merged node would throw the error:

```
A node of type LNMergeNode in tree "NodeTree" failed to be updated, because there is no (longer?) an update routine for this version of the node. Original exception:
Traceback (most recent call last):
  File "[...]\armory\blender\arm\logicnode\replacement.py", line 237, in replace_all
    replace(tree, node)
  File "[...]armory\blender\arm\logicnode\replacement.py", line 192, in replace
    dest_socket = newnode.inputs[dest_socket_id]
IndexError: bpy_prop_collection[index]: index 0 out of range, size 0
```