### PR TITLE
Export deform only option

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -241,7 +241,12 @@ class ArmoryExporter:
         return []
 
     def export_bone(self, armature, bone: bpy.types.Bone, o, action: bpy.types.Action):
+        rpdat = arm.utils.get_rp()
         bobject_ref = self.bobject_bone_array.get(bone)
+
+        if rpdat.arm_use_armature_deform_only:
+            if not bone.use_deform:
+                return
 
         if bobject_ref:
             o['type'] = STRUCT_IDENTIFIER[bobject_ref["objectType"].value]

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -613,6 +613,7 @@ class ArmRPListItem(bpy.types.PropertyGroup):
         items=[('On', 'On', 'On'),
                ('Off', 'Off', 'Off')],
         name='Skinning', description='Enable skinning', default='On', update=assets.invalidate_shader_cache)
+    arm_use_armature_deform_only: BoolProperty(name="Only Deform Bones", description="Only write deforming bones (and non-deforming ones when they have deforming children)", default=False, update=assets.invalidate_compiled_data)
     arm_skin_max_bones_auto: BoolProperty(name="Auto Bones", description="Calculate amount of maximum bones based on armatures", default=True, update=assets.invalidate_compiled_data)
     arm_skin_max_bones: IntProperty(name="Max Bones", default=50, min=1, max=3000, update=assets.invalidate_shader_cache)
     arm_morph_target: EnumProperty(

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1454,6 +1454,7 @@ class ARM_PT_RenderPathRendererPanel(bpy.types.Panel):
         col.prop(rpdat, 'arm_skin')
         col = col.column()
         col.enabled = rpdat.arm_skin == 'On'
+        col.prop(rpdat, 'arm_use_armature_deform_only')
         col.prop(rpdat, 'arm_skin_max_bones_auto')
         row = col.row()
         row.enabled = not rpdat.arm_skin_max_bones_auto


### PR DESCRIPTION
Closes #842

Test blend: https://github.com/rpaladin/armory3d-export-deform-only-test
**NOTE:** Test blend uses code from: https://github.com/armory3d/iron/pull/184

For those curious, if the new `Only Deform Bones` option is enabled, any parent bone that is marked as non-deformed, their children will not be exported along with the parent bone (this is expected behavior and not a bug).

<hr />

Special thanks to @MoritzBrueckner and @QuantumCoderQC for review and suggestions.