### PR TITLE
Remove Object Node: remove object from collection

### DIFF
--- a/Sources/armory/logicnode/RemoveObjectNode.hx
+++ b/Sources/armory/logicnode/RemoveObjectNode.hx
@@ -26,6 +26,11 @@ class RemoveObjectNode extends LogicNode {
 				#end
 			}
 		}
+		
+		var raw = iron.Scene.active.raw;
+		for (g in raw.groups) 
+			iron.Scene.active.getGroup(g.name).remove(object);
+		
 		object.remove();
 		runOutput(0);
 	}


### PR DESCRIPTION
The remove object node, removes the object from its collection only when that collection is assigned in blender. But if the collection is assigned within armory, the object remains in the collection despite being removed. This added code removes the object from the armory collection to keep it consistent with the other collection nodes.