### PR TITLE
Allow custom naming of lens texture

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -252,12 +252,15 @@ def export_data(fp, sdk_path):
         # Workaround to also export non-material world shaders
         res['shader_datas'] += make_world.shader_datas
 
-        # Point to custom LUT filename if there is any
-        if rpdat.arm_lut == True and rpdat.arm_lut_texture != '' and rpdat.arm_lut_texture != 'luttexture.jpg':
+        if rpdat.arm_lens or rpdat.arm_lut:
             for shader_pass in res["shader_datas"]:
                 for context in shader_pass["contexts"]:
                     for texture_unit in context["texture_units"]:
-                        if "link" in texture_unit and texture_unit["link"] == "$luttexture.jpg":
+                        # Lens Texture
+                        if rpdat.arm_lens_texture != '' and rpdat.arm_lens_texture != 'lenstexture.jpg' and "link" in texture_unit and texture_unit["link"] == "$lenstexture.jpg":
+                            texture_unit["link"] = f"${rpdat.arm_lens_texture}"
+                        # LUT Colorgrading
+                        if rpdat.arm_lut_texture != '' and rpdat.arm_lut_texture != 'luttexture.jpg' and "link" in texture_unit and texture_unit["link"] == "$luttexture.jpg":
                             texture_unit["link"] = f"${rpdat.arm_lut_texture}"
 
         arm.utils.write_arm(shaders_path + '/shader_datas.arm', res)

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -218,11 +218,6 @@ def build():
             if focus_distance > 0.0:
                 wrd.compo_defs += '_CDOF'
                 compo_depth = True
-            if rpdat.arm_lens_texture != '':
-                wrd.compo_defs += '_CLensTex'
-                assets.add_embedded_data('lenstexture.jpg')
-                if rpdat.arm_lens_texture_masking:
-                    wrd.compo_defs += '_CLensTexMasking'
             if rpdat.arm_fisheye:
                 wrd.compo_defs += '_CFishEye'
             if rpdat.arm_vignette:
@@ -230,7 +225,15 @@ def build():
             if rpdat.arm_lensflare:
                 wrd.compo_defs += '_CGlare'
                 compo_depth = True
-            if rpdat.arm_lut == True:
+            if rpdat.arm_lens:
+                if os.path.isfile(project_path + '/Bundled/' + rpdat.arm_lens_texture):
+                    wrd.compo_defs += '_CLensTex'
+                    assets.add_embedded_data(rpdat.arm_lens_texture)
+                    if rpdat.arm_lens_texture_masking:
+                        wrd.compo_defs += '_CLensTexMasking'
+                else:
+                    log.warn('Filepath for Lens texture is invalid.')
+            if rpdat.arm_lut:
                 if os.path.isfile(project_path + '/Bundled/' + rpdat.arm_lut_texture):
                     wrd.compo_defs += '_CLUT'
                     assets.add_embedded_data(rpdat.arm_lut_texture)

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -597,18 +597,19 @@ class ArmRPListItem(bpy.types.PropertyGroup):
                ('Reinhard', 'Reinhard', 'Reinhard'),
                ('Uncharted', 'Uncharted', 'Uncharted')],
         name='Tonemap', description='Tonemapping operator', default='Filmic', update=assets.invalidate_shader_cache)
-    arm_lens_texture: StringProperty(name="Lens Texture", default="")
+    arm_fisheye: BoolProperty(name="Fish Eye", default=False, update=assets.invalidate_shader_cache)
+    arm_vignette: BoolProperty(name="Vignette", default=False, update=assets.invalidate_shader_cache)
+    arm_vignette_strength: FloatProperty(name="Strength", default=0.7, update=assets.invalidate_shader_cache)
+    arm_lensflare: BoolProperty(name="Lens Flare", default=False, update=assets.invalidate_shader_cache)
+    arm_lens: BoolProperty(name="Lens Texture", description="Grime Overlay", default=False, update=assets.invalidate_shader_cache)
+    arm_lens_texture: StringProperty(name="Texture", description="Lens filepath", default="lenstexture.jpg", update=assets.invalidate_shader_cache)
     arm_lens_texture_masking: BoolProperty(name="Luminance Masking", description="Luminance masking", default=False, update=assets.invalidate_shader_cache)
     arm_lens_texture_masking_centerMinClip : FloatProperty(name="Center Min Clip", default=0.5, update=assets.invalidate_shader_cache)
     arm_lens_texture_masking_centerMaxClip : FloatProperty(name="Center Max Clip", default=0.1, update=assets.invalidate_shader_cache)
     arm_lens_texture_masking_luminanceMax : FloatProperty(name="Luminance Min", default=0.1, update=assets.invalidate_shader_cache)
     arm_lens_texture_masking_luminanceMin : FloatProperty(name="Luminance Max", default=2.5, update=assets.invalidate_shader_cache)
     arm_lens_texture_masking_brightnessExp : FloatProperty(name="Brightness Exponent", default=2.0, update=assets.invalidate_shader_cache)
-    arm_fisheye: BoolProperty(name="Fish Eye", default=False, update=assets.invalidate_shader_cache)
-    arm_vignette: BoolProperty(name="Vignette", default=False, update=assets.invalidate_shader_cache)
-    arm_vignette_strength: FloatProperty(name="Strength", default=0.7, update=assets.invalidate_shader_cache)
-    arm_lensflare: BoolProperty(name="Lens Flare", default=False, update=assets.invalidate_shader_cache)
-    arm_lut: BoolProperty(name="LUT Color Grading", description="Color Grading", default=False, update=assets.invalidate_shader_cache)
+    arm_lut: BoolProperty(name="LUT Colorgrading", description="Colorgrading", default=False, update=assets.invalidate_shader_cache)
     arm_lut_texture: StringProperty(name="Texture", description="LUT filepath", default="luttexture.jpg", update=assets.invalidate_shader_cache)
     arm_skin: EnumProperty(
         items=[('On', 'On', 'On'),

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1919,8 +1919,12 @@ class ARM_PT_RenderPathCompositorPanel(bpy.types.Panel):
         col = layout.column()
         col.prop(rpdat, 'arm_fisheye')
         col.prop(rpdat, 'arm_lensflare')
+        layout.separator()
 
         col = layout.column()
+        col.prop(rpdat, 'arm_lens')
+        col = col.column(align=True)
+        col.enabled = rpdat.arm_lens
         col.prop(rpdat, 'arm_lens_texture')
         if rpdat.arm_lens_texture != "":
             col.prop(rpdat, 'arm_lens_texture_masking')
@@ -1933,6 +1937,7 @@ class ARM_PT_RenderPathCompositorPanel(bpy.types.Panel):
                 sub.prop(rpdat, 'arm_lens_texture_masking_luminanceMax')
                 col.prop(rpdat, 'arm_lens_texture_masking_brightnessExp')
                 layout.separator()
+        layout.separator()
 
         col = layout.column()
         col.prop(rpdat, 'arm_lut')


### PR DESCRIPTION
In case anyone wonders:
1. I renamed "Color Grading" to "Colorgrading" to match the manual (it's also logically shorter). (`props_renderpath.py`)
<https://github.com/armory3d/armory/wiki/screen-effects#lut-colorgrading>
2. Removed some unnecessary `true` check conditions. (`make.py`)
3. I also moved some misc code lines so that lens code would be closer to LUT code. This caused some extra diff. (`props_renderpath.py` & `make_renderpath.py`)

# Preview

![image](https://user-images.githubusercontent.com/69180012/215176686-29f74e9c-9a9c-414b-a2fd-02e7f4d4aa33.png)