### PR TITLE
Cleanup deferred light solid

### DIFF
--- a/Shaders/deferred_light_solid/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_solid/deferred_light.frag.glsl
@@ -3,8 +3,6 @@
 #include "compiled.inc"
 #include "std/gbuffer.glsl"
 
-uniform sampler2D gbufferD;
-uniform sampler2D gbuffer0;
 uniform sampler2D gbuffer1;
 
 in vec2 texCoord;


### PR DESCRIPTION
Not sure why these uniforms were even included originally?

Reference: <https://armory3d.github.io/armory_examples_browser/#examples-material_shadeless>

![image](https://user-images.githubusercontent.com/69180012/215305771-22a2f025-5ecf-4a93-a4e5-5769b630d0d9.png)