### PR TITLE
Cleanup volumetric light

### DIFF
--- a/Shaders/volumetric_light/volumetric_light.frag.glsl
+++ b/Shaders/volumetric_light/volumetric_light.frag.glsl
@@ -44,8 +44,6 @@ uniform vec2 cameraPlane;
 #endif
 
 #ifdef _Sun
-uniform vec3 sunDir;
-uniform vec3 sunCol;
 	#ifdef _ShadowMap
 	#ifdef _ShadowMapAtlas
 	#ifndef _SingleAtlas


### PR DESCRIPTION
Reference: <https://armory3d.github.io/armory_examples_browser/#examples-light_volumetric>

(Please note, the lamp that is in the scene _is_ of type `Sun`, yet the uniforms are still never used.)

![image](https://user-images.githubusercontent.com/69180012/215353913-225f34ed-6747-4679-954e-28f7a01968b7.png)