### PR TITLE
Option to disable OpenCL processing in CMFT to avoid driver freeze

### DIFF
--- a/blender/arm/make_world.py
+++ b/blender/arm/make_world.py
@@ -83,6 +83,8 @@ def build():
                             # Set world def, everything else is handled by write_probes()
                             wrd.world_defs += '_Rad'
 
+    write_probes.check_last_cmft_time()
+
 
 def create_world_shaders(world: bpy.types.World):
     """Creates fragment and vertex shaders for the given world."""

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -22,6 +22,7 @@ import arm.nodes_logic
 import arm.ui_icons as ui_icons
 import arm.utils
 import arm.utils_vs
+import arm.write_probes
 
 if arm.is_reload(__name__):
     arm.api = arm.reload_module(arm.api)
@@ -39,6 +40,7 @@ if arm.is_reload(__name__):
     ui_icons = arm.reload_module(ui_icons)
     arm.utils = arm.reload_module(arm.utils)
     arm.utils_vs = arm.reload_module(arm.utils_vs)
+    arm.write_probes = arm.reload_module(arm.write_probes)
 else:
     arm.enable_reload(__name__)
 
@@ -1203,7 +1205,10 @@ class ArmoryStopButton(bpy.types.Operator):
         elif state.proc_build != None:
             state.proc_build.terminate()
             state.proc_build = None
-        return{'FINISHED'}
+
+        arm.write_probes.check_last_cmft_time()
+
+        return {'FINISHED'}
 
 class ArmoryBuildProjectButton(bpy.types.Operator):
     """Build and compile project"""

--- a/blender/arm/write_probes.py
+++ b/blender/arm/write_probes.py
@@ -227,7 +227,7 @@ def write_probes(image_filepath: str, disable_hdr: bool, from_srgb: bool, cached
         mip_count = 7
 
     wrd = bpy.data.worlds['Arm']
-    use_opencl = 'true'
+    use_opencl = 'true' if arm.utils.get_pref_or_default("cmft_use_opencl", True) else 'false'
 
     # cmft doesn't work correctly when passing the number of logical
     # CPUs if there are more logical than physical CPUs on a machine


### PR DESCRIPTION
This PR closes https://github.com/armory3d/armory/issues/2760 and requires https://github.com/armory3d/armsdk/pull/62.

Using CMFT with OpenCL can lead to driver hangs as described in the linked issue. My changes allow to disable OpenCL in the preferences to work around the problem, and additionally display a warning to the console in case CMFT takes an unusually long amount of time (> 20s). I'm not sure whether 20 seconds are a good value and whether this warning is really needed, so please let me know if I should revert that commit.