### PR TITLE
Logic Nodes: Get/Set Camera Start End Node

### DIFF
--- a/Sources/armory/logicnode/GetCameraStartEndNode.hx
+++ b/Sources/armory/logicnode/GetCameraStartEndNode.hx
@@ -1,0 +1,18 @@
+package armory.logicnode;
+
+import iron.object.CameraObject;
+
+class GetCameraStartEndNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var camera: CameraObject = inputs[0].get();
+
+		if (camera == null) return null;
+		
+		return from == 0 ? camera.data.raw.near_plane : camera.data.raw.far_plane;
+	}
+}

--- a/Sources/armory/logicnode/GetCameraStartEndNode.hx
+++ b/Sources/armory/logicnode/GetCameraStartEndNode.hx
@@ -2,17 +2,38 @@ package armory.logicnode;
 
 import iron.object.CameraObject;
 
-class GetCameraStartEndNode extends LogicNode {
+class SetCameraStartEndNode extends LogicNode {
+
+	public var property0: String;
 
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
-	override function get(from: Int): Dynamic {
-		var camera: CameraObject = inputs[0].get();
-
-		if (camera == null) return null;
+	override function run(from: Int) {
+		var camera: CameraObject = inputs[1].get();
 		
-		return from == 0 ? camera.data.raw.near_plane : camera.data.raw.far_plane;
+		if (camera == null) return;
+		
+		if (property0 == 'Start'){
+			var start: Float = inputs[2].get();
+			camera.data.raw.near_plane = start;
+		}
+		else if (property0 == 'End' ){
+			var end: Float = inputs[2].get();
+			camera.data.raw.far_plane = end;
+		}
+		else {
+		
+		var start: Float = inputs[2].get();
+		camera.data.raw.near_plane = start;
+		var end: Float = inputs[3].get();
+		camera.data.raw.far_plane = end;
+		
+		}
+				
+		camera.buildProjection();
+
+		runOutput(0);
 	}
 }

--- a/Sources/armory/logicnode/GetCameraStartEndNode.hx
+++ b/Sources/armory/logicnode/GetCameraStartEndNode.hx
@@ -2,38 +2,17 @@ package armory.logicnode;
 
 import iron.object.CameraObject;
 
-class SetCameraStartEndNode extends LogicNode {
-
-	public var property0: String;
+class GetCameraStartEndNode extends LogicNode {
 
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
-	override function run(from: Int) {
-		var camera: CameraObject = inputs[1].get();
-		
-		if (camera == null) return;
-		
-		if (property0 == 'Start'){
-			var start: Float = inputs[2].get();
-			camera.data.raw.near_plane = start;
-		}
-		else if (property0 == 'End' ){
-			var end: Float = inputs[2].get();
-			camera.data.raw.far_plane = end;
-		}
-		else {
-		
-		var start: Float = inputs[2].get();
-		camera.data.raw.near_plane = start;
-		var end: Float = inputs[3].get();
-		camera.data.raw.far_plane = end;
-		
-		}
-				
-		camera.buildProjection();
+	override function get(from: Int): Dynamic {
+		var camera: CameraObject = inputs[0].get();
 
-		runOutput(0);
+		if (camera == null) return null;
+		
+		return from == 0 ? camera.data.raw.near_plane : camera.data.raw.far_plane;
 	}
 }

--- a/Sources/armory/logicnode/SetCameraStartEndNode.hx
+++ b/Sources/armory/logicnode/SetCameraStartEndNode.hx
@@ -1,0 +1,25 @@
+package armory.logicnode;
+
+import iron.object.CameraObject;
+
+class SetCameraStartEndNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var camera: CameraObject = inputs[1].get();
+		var start: Float = inputs[2].get();
+		var end: Float = inputs[3].get();
+
+		if (camera == null) return;
+
+		camera.data.raw.near_plane = start;
+		camera.data.raw.far_plane = end;
+		
+		camera.buildProjection();
+
+		runOutput(0);
+	}
+}

--- a/Sources/armory/logicnode/SetCameraStartEndNode.hx
+++ b/Sources/armory/logicnode/SetCameraStartEndNode.hx
@@ -4,20 +4,34 @@ import iron.object.CameraObject;
 
 class SetCameraStartEndNode extends LogicNode {
 
+	public var property0: String;
+
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 	override function run(from: Int) {
 		var camera: CameraObject = inputs[1].get();
-		var start: Float = inputs[2].get();
-		var end: Float = inputs[3].get();
-
-		if (camera == null) return;
-
-		camera.data.raw.near_plane = start;
-		camera.data.raw.far_plane = end;
 		
+		assert(Error, Std.isOfType(camera, CameraObject), "Camera must be a camera object!");
+		
+		if (camera == null) return;
+		
+		if (property0 == 'Start'){
+			var start: Float = inputs[2].get();
+			camera.data.raw.near_plane = start;
+		}
+		else if (property0 == 'End' ){
+			var end: Float = inputs[2].get();
+			camera.data.raw.far_plane = end;
+		}
+		else {
+		var start: Float = inputs[2].get();
+		camera.data.raw.near_plane = start;
+		var end: Float = inputs[3].get();
+		camera.data.raw.far_plane = end;
+		}
+				
 		camera.buildProjection();
 
 		runOutput(0);

--- a/blender/arm/logicnode/camera/LN_get_camera_start_end.py
+++ b/blender/arm/logicnode/camera/LN_get_camera_start_end.py
@@ -1,0 +1,15 @@
+from arm.logicnode.arm_nodes import *
+
+class GetCameraStartEndNode(ArmLogicTreeNode):
+    """Returns the Start & End of the given camera.
+
+    @seeNode Set Camera Start & End"""
+    bl_idname = 'LNGetCameraStartEndNode'
+    bl_label = 'Get Camera Start End'
+    arm_version = 1
+    
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketObject', 'Camera')
+
+        self.add_output('ArmFloatSocket', 'Start')
+        self.add_output('ArmFloatSocket', 'End')

--- a/blender/arm/logicnode/camera/LN_set_camera_start_end.py
+++ b/blender/arm/logicnode/camera/LN_set_camera_start_end.py
@@ -1,0 +1,39 @@
+from arm.logicnode.arm_nodes import *
+
+class SetCameraStartEndNode(ArmLogicTreeNode):
+    """Sets the Start & End of the given camera.
+
+    @seeNode Get Camera Start & End"""
+    bl_idname = 'LNSetCameraStartEndNode'
+    bl_label = 'Set Camera Start End'
+    arm_version = 1
+    
+    def remove_extra_inputs(self, context):
+        while len(self.inputs) > 2:
+                self.inputs.remove(self.inputs[-1])
+        if self.property0 == 'Start':
+            self.add_input('ArmFloatSocket', 'Start')
+        if self.property0 == 'End':
+            self.add_input('ArmFloatSocket', 'End')
+        if self.property0 == 'Start&End':
+            self.add_input('ArmFloatSocket', 'Start')
+            self.add_input('ArmFloatSocket', 'End')
+       
+    property0: HaxeEnumProperty(
+    'property0',
+    items = [('Start&End', 'Start&End', 'Start&End'),
+             ('Start', 'Start', 'Start'),
+             ('End', 'End', 'End')],
+    name='', default='Start&End', update=remove_extra_inputs)
+    
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Camera')
+        self.add_input('ArmFloatSocket', 'Start')
+        self.add_input('ArmFloatSocket', 'End')
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+        
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')


### PR DESCRIPTION
These nodes allows to modify the initial  start end plane of a given camera. Very useful for effects or camera draws (according to object position)

![image](https://user-images.githubusercontent.com/32546729/215387474-2d8f45a4-ac54-46dd-ba83-de3a3cfa6ea7.png)
