### PR TITLE
Fix realtime postprocessing

### DIFF
--- a/Shaders/compositor_pass/compositor_pass.frag.glsl
+++ b/Shaders/compositor_pass/compositor_pass.frag.glsl
@@ -248,7 +248,7 @@ void main() {
 #ifdef _CDistort
 	// const float compoDistortStrength = 4.0;
 	#ifdef _CPostprocess
-		float uStrength = PPComp14;
+		float uStrength = PPComp14.x;
 	#else
 		float uStrength = compoDistortStrength;
 	#endif

--- a/Sources/armory/logicnode/CameraGetNode.hx
+++ b/Sources/armory/logicnode/CameraGetNode.hx
@@ -8,17 +8,18 @@ class CameraGetNode extends LogicNode {
 
 	override function get(from:Int):Dynamic {
 		return switch (from) {
-			case 0: armory.renderpath.Postprocess.camera_uniforms[0];
-			case 1: armory.renderpath.Postprocess.camera_uniforms[1];
-			case 2: armory.renderpath.Postprocess.camera_uniforms[2];
-			case 3: armory.renderpath.Postprocess.camera_uniforms[3];
-			case 4: armory.renderpath.Postprocess.camera_uniforms[4];
-			case 5: armory.renderpath.Postprocess.camera_uniforms[5];
-			case 6: armory.renderpath.Postprocess.camera_uniforms[6];
-			case 7: armory.renderpath.Postprocess.camera_uniforms[7];
-			case 8: armory.renderpath.Postprocess.camera_uniforms[8];
-			case 9: armory.renderpath.Postprocess.camera_uniforms[9];
-			case 10: armory.renderpath.Postprocess.camera_uniforms[10];
+			case 0: armory.renderpath.Postprocess.camera_uniforms[0];//Camera: F-Number
+			case 1: armory.renderpath.Postprocess.camera_uniforms[1];//Camera: Shutter time
+			case 2: armory.renderpath.Postprocess.camera_uniforms[2];//Camera: ISO
+			case 3: armory.renderpath.Postprocess.camera_uniforms[3];//Camera: Exposure Compensation
+			case 4: armory.renderpath.Postprocess.camera_uniforms[4];//Fisheye Distortion
+			case 5: armory.renderpath.Postprocess.camera_uniforms[5];//DoF AutoFocus §§ If true, it ignores the DoF Distance setting
+			case 6: armory.renderpath.Postprocess.camera_uniforms[6];//DoF Distance
+			case 7: armory.renderpath.Postprocess.camera_uniforms[7];//DoF Focal Length mm
+			case 8: armory.renderpath.Postprocess.camera_uniforms[8];//DoF F-Stop
+			case 9: armory.renderpath.Postprocess.camera_uniforms[9];//Tonemapping Method
+			case 10: armory.renderpath.Postprocess.camera_uniforms[10];//Distort
+			case 11: armory.renderpath.Postprocess.camera_uniforms[11];//Film Grain
 			default: 0.0;
 		}
 	}

--- a/Sources/armory/logicnode/CameraSetNode.hx
+++ b/Sources/armory/logicnode/CameraSetNode.hx
@@ -7,17 +7,18 @@ class CameraSetNode extends LogicNode {
 	}
 
 	override function run(from:Int) {
-		armory.renderpath.Postprocess.camera_uniforms[0] = inputs[1].get();
-		armory.renderpath.Postprocess.camera_uniforms[1] = inputs[2].get();
-		armory.renderpath.Postprocess.camera_uniforms[2] = inputs[3].get();
-		armory.renderpath.Postprocess.camera_uniforms[3] = inputs[4].get();
-		armory.renderpath.Postprocess.camera_uniforms[4] = inputs[5].get();
-		armory.renderpath.Postprocess.camera_uniforms[5] = inputs[6].get();
-		armory.renderpath.Postprocess.camera_uniforms[6] = inputs[7].get();
-		armory.renderpath.Postprocess.camera_uniforms[7] = inputs[8].get();
-		armory.renderpath.Postprocess.camera_uniforms[8] = inputs[9].get();
-		armory.renderpath.Postprocess.camera_uniforms[9] = inputs[10].get();
-		armory.renderpath.Postprocess.camera_uniforms[10] = inputs[11].get();
+		armory.renderpath.Postprocess.camera_uniforms[0] = inputs[1].get();//Camera: F-Number
+		armory.renderpath.Postprocess.camera_uniforms[1] = inputs[2].get();//Camera: Shutter time
+		armory.renderpath.Postprocess.camera_uniforms[2] = inputs[3].get();//Camera: ISO
+		armory.renderpath.Postprocess.camera_uniforms[3] = inputs[4].get();//Camera: Exposure Compensation
+		armory.renderpath.Postprocess.camera_uniforms[4] = inputs[5].get();//Fisheye Distortion
+		armory.renderpath.Postprocess.camera_uniforms[5] = inputs[6].get();//DoF AutoFocus §§ If true, it ignores the DoF Distance setting
+		armory.renderpath.Postprocess.camera_uniforms[6] = inputs[7].get();//DoF Distance
+		armory.renderpath.Postprocess.camera_uniforms[7] = inputs[8].get();//DoF Focal Length mm
+		armory.renderpath.Postprocess.camera_uniforms[8] = inputs[9].get();//DoF F-Stop
+		armory.renderpath.Postprocess.camera_uniforms[9] = inputs[10].get();//Tonemapping Method
+		armory.renderpath.Postprocess.camera_uniforms[10] = inputs[11].get();//Distort
+		armory.renderpath.Postprocess.camera_uniforms[11] = inputs[12].get();//Film Grain
 
 		runOutput(0);
 	}

--- a/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
+++ b/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
@@ -4,23 +4,24 @@ class CameraGetNode(ArmLogicTreeNode):
     """Returns the post-processing effects of a camera."""
     bl_idname = 'LNCameraGetNode'
     bl_label = 'Get Camera Post Process'
-    arm_version = 2
+    arm_version = 3
 
     def arm_init(self, context):
-        self.add_output('ArmFloatSocket', 'F-Stop')
-        self.add_output('ArmFloatSocket', 'Shutter Time')
-        self.add_output('ArmFloatSocket', 'ISO')
-        self.add_output('ArmFloatSocket', 'Exposure Compensation')
-        self.add_output('ArmFloatSocket', 'Fisheye Distortion')
-        self.add_output('ArmBoolSocket', 'Auto Focus')
-        self.add_output('ArmFloatSocket', 'DOF Distance')
-        self.add_output('ArmFloatSocket', 'DOF Length')
-        self.add_output('ArmFloatSocket', 'DOF F-Stop')
-        self.add_output('ArmFloatSocket', 'Distort')
-        self.add_output('ArmFloatSocket', 'Film Grain')
+        self.add_output('ArmFloatSocket', 'F-Stop')#0
+        self.add_output('ArmFloatSocket', 'Shutter Time')#1
+        self.add_output('ArmFloatSocket', 'ISO')#2
+        self.add_output('ArmFloatSocket', 'Exposure Compensation')#3
+        self.add_output('ArmFloatSocket', 'Fisheye Distortion')#4
+        self.add_output('ArmBoolSocket', 'Auto Focus')#5
+        self.add_output('ArmFloatSocket', 'DOF Distance')#6
+        self.add_output('ArmFloatSocket', 'DOF Length')#7
+        self.add_output('ArmFloatSocket', 'DOF F-Stop')#8
+        self.add_output('ArmBoolSocket', 'Tonemapping')#9
+        self.add_output('ArmFloatSocket', 'Distort')#10
+        self.add_output('ArmFloatSocket', 'Film Grain')#11
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
+++ b/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
@@ -4,26 +4,27 @@ class CameraSetNode(ArmLogicTreeNode):
     """Set the post-processing effects of a camera."""
     bl_idname = 'LNCameraSetNode'
     bl_label = 'Set Camera Post Process'
-    arm_version = 2
+    arm_version = 3
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmFloatSocket', 'F-stop', default_value=2.0)
-        self.add_input('ArmFloatSocket', 'Shutter Time', default_value=1.0)
-        self.add_input('ArmFloatSocket', 'ISO', default_value=100.0)
-        self.add_input('ArmFloatSocket', 'Exposure Compensation', default_value=0.0)
-        self.add_input('ArmFloatSocket', 'Fisheye Distortion', default_value=0.01)
-        self.add_input('ArmBoolSocket', 'Auto Focus', default_value=True)
-        self.add_input('ArmFloatSocket', 'DoF Distance', default_value=10.0)
-        self.add_input('ArmFloatSocket', 'DoF Length', default_value=160.0)
-        self.add_input('ArmFloatSocket', 'DoF F-Stop', default_value=128.0)
-        self.add_input('ArmFloatSocket', 'Distort', default_value=2.0)
-        self.add_input('ArmFloatSocket', 'Film Grain', default_value=2.0)
+        self.add_input('ArmFloatSocket', 'F-stop', default_value=1.0)#0
+        self.add_input('ArmFloatSocket', 'Shutter Time', default_value=2.8333)#1
+        self.add_input('ArmFloatSocket', 'ISO', default_value=100.0)#2
+        self.add_input('ArmFloatSocket', 'Exposure Compensation', default_value=0.0)#3
+        self.add_input('ArmFloatSocket', 'Fisheye Distortion', default_value=0.01)#4
+        self.add_input('ArmBoolSocket', 'Auto Focus', default_value=True)#5
+        self.add_input('ArmFloatSocket', 'DoF Distance', default_value=10.0)#6
+        self.add_input('ArmFloatSocket', 'DoF Length', default_value=160.0)#7
+        self.add_input('ArmFloatSocket', 'DoF F-Stop', default_value=128.0)#8
+        self.add_input('ArmBoolSocket', 'Tonemapping', default_value=False)#9
+        self.add_input('ArmFloatSocket', 'Distort', default_value=2.0)#10
+        self.add_input('ArmFloatSocket', 'Film Grain', default_value=2.0)#11
 
         self.add_output('ArmNodeSocketAction', 'Out')
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 1):
+        if self.arm_version not in (0, 2):
             raise LookupError()
 
         newnode = node_tree.nodes.new('LNCameraSetNode')


### PR DESCRIPTION
Issues caused by me in #2751..

# Changelog

`compositor_pass.frag.glsl` - Special thanks to @ Armory-Community-Channel for reporting this issue on Discord.

`CameraGetNode.hx` - Added comments; fixed outputs order and added missing output.

`CameraSetNode.hx` - Added comments; fixed inputs order and added missing input.

`LN_get_camera_post_process.py` - Added comments; fixed return order and added missing return.

`LN_set_camera_post_process.py` - Added comments; fixed return order and added missing return; match default values with [Postprocess.hx](https://github.com/armory3d/armory/blob/main/Sources/armory/renderpath/Postprocess.hx). (Original defaults weren't implemented by me.)