### PR TITLE
Fix ArrayContains and ArrayIndex Nodes

### DIFF
--- a/Sources/armory/logicnode/ArrayInArrayNode.hx
+++ b/Sources/armory/logicnode/ArrayInArrayNode.hx
@@ -8,8 +8,9 @@ class ArrayInArrayNode extends LogicNode {
 
 	override function get(from: Int): Dynamic {
 		var array: Array<Dynamic> = inputs[0].get();
+		array = array.map(item -> Std.string(item));
 		var value: Dynamic = inputs[1].get();
 
-		return array.indexOf(value) != -1;
+		return array.indexOf(Std.string(value)) != -1;
 	}
 }

--- a/Sources/armory/logicnode/ArrayIndexNode.hx
+++ b/Sources/armory/logicnode/ArrayIndexNode.hx
@@ -8,8 +8,9 @@ class ArrayIndexNode extends LogicNode {
 
 	override function get(from: Int): Dynamic {
 		var array: Array<Dynamic> = inputs[0].get();
+		array = array.map(item -> Std.string(item));
 		var value: Dynamic = inputs[1].get();
 
-		return array.indexOf(value);
+		return array.indexOf(Std.string(value));
 	}
 }


### PR DESCRIPTION
Both nodes returned -1 for vector items or array items (the case when the input array is an array of more than one dimension), even though those items did indeed exist in the array. That's because the indexOf function of  the array class does not handle the comparison properly.

With this fix now the comparison is handled and the correct value is returned for both nodes.