### PR TITLE
Camera Logic Nodes: Get/Set Camera Aspect, Scale and Type

### DIFF
--- a/Sources/armory/logicnode/GetCameraAspectNode.hx
+++ b/Sources/armory/logicnode/GetCameraAspectNode.hx
@@ -1,0 +1,18 @@
+package armory.logicnode;
+
+import iron.object.CameraObject;
+
+class GetCameraAspectNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var camera: CameraObject = inputs[0].get();
+
+		if (camera == null) return null;
+
+		return camera.data.raw.aspect != null ? camera.data.raw.aspect : iron.App.w() / iron.App.h();
+	}
+}

--- a/Sources/armory/logicnode/GetCameraScaleNode.hx
+++ b/Sources/armory/logicnode/GetCameraScaleNode.hx
@@ -1,0 +1,18 @@
+package armory.logicnode;
+
+import iron.object.CameraObject;
+
+class GetCameraScaleNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var camera: CameraObject = inputs[0].get();
+
+		if (camera == null) return null;
+
+		return camera.data.raw.ortho[1]*2;
+	}
+}

--- a/Sources/armory/logicnode/GetCameraTypeNode.hx
+++ b/Sources/armory/logicnode/GetCameraTypeNode.hx
@@ -1,0 +1,18 @@
+package armory.logicnode;
+
+import iron.object.CameraObject;
+
+class GetCameraTypeNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var camera: CameraObject = inputs[0].get();
+
+		if (camera == null) return null;
+
+		return camera.data.raw.ortho != null ? 1 : 0;
+	}
+}

--- a/Sources/armory/logicnode/SetCameraAspectNode.hx
+++ b/Sources/armory/logicnode/SetCameraAspectNode.hx
@@ -1,0 +1,22 @@
+package armory.logicnode;
+
+import iron.object.CameraObject;
+
+class SetCameraAspectNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var camera: CameraObject = inputs[1].get();
+		var aspect: Float = inputs[2].get();
+
+		if (camera == null) return;
+
+		camera.data.raw.aspect = aspect;
+		camera.buildProjection();
+
+		runOutput(0);
+	}
+}

--- a/Sources/armory/logicnode/SetCameraScaleNode.hx
+++ b/Sources/armory/logicnode/SetCameraScaleNode.hx
@@ -1,0 +1,30 @@
+package armory.logicnode;
+
+import iron.object.CameraObject;
+import kha.arrays.Float32Array;
+
+class SetCameraScaleNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var camera: CameraObject = inputs[1].get();
+		var scale: Float = inputs[2].get();
+
+		if (camera == null) return;
+
+		var aspect = camera.data.raw.aspect != null ? camera.data.raw.aspect : iron.App.w() / iron.App.h();
+		var ortho = new Float32Array(4);
+		ortho[0] = - scale / 2;
+		ortho[1] = scale / 2;
+		ortho[2] = - scale / (2 * aspect);
+		ortho[3] = scale / (2 * aspect);
+		camera.data.raw.ortho = ortho;
+
+		camera.buildProjection();
+
+		runOutput(0);
+	}
+}

--- a/Sources/armory/logicnode/SetCameraTypeNode.hx
+++ b/Sources/armory/logicnode/SetCameraTypeNode.hx
@@ -1,0 +1,42 @@
+package armory.logicnode;
+
+import iron.object.CameraObject;
+import kha.arrays.Float32Array;
+
+class SetCameraTypeNode extends LogicNode {
+
+	public var property0: String;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var camera: CameraObject = inputs[1].get();
+		var prop: Float = inputs[2].get();
+
+		if (camera == null) return;
+
+		if (property0 == 'Perspective'){
+			camera.data.raw.ortho = null;
+			camera.data.raw.fov = prop;
+			camera.data.raw.near_plane = inputs[3].get();
+			camera.data.raw.far_plane = inputs[4].get();
+		}
+		else {
+			var aspect = camera.data.raw.aspect != null ? camera.data.raw.aspect : iron.App.w() / iron.App.h();
+			camera.data.raw.fov = null;
+			var ortho = new Float32Array(4);
+			ortho[0] = - prop / 2;
+			ortho[1] = prop / 2;
+			ortho[2] = - prop / (2 * aspect);
+			ortho[3] = prop / (2 * aspect);
+			camera.data.raw.ortho = ortho;
+			camera.data.raw.near_plane = - camera.data.raw.far_plane;
+		}
+
+		camera.buildProjection();
+
+		runOutput(0);
+	}
+}

--- a/blender/arm/logicnode/camera/LN_get_camera_aspect.py
+++ b/blender/arm/logicnode/camera/LN_get_camera_aspect.py
@@ -1,0 +1,12 @@
+from arm.logicnode.arm_nodes import *
+
+class GetCameraAspectNode(ArmLogicTreeNode):
+    """Returns the aspect of the given camera."""
+    bl_idname = 'LNGetCameraAspectNode'
+    bl_label = 'Get Camera Aspect'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketObject', 'Camera')
+
+        self.add_output('ArmFloatSocket', 'Aspect')

--- a/blender/arm/logicnode/camera/LN_get_camera_scale.py
+++ b/blender/arm/logicnode/camera/LN_get_camera_scale.py
@@ -1,0 +1,13 @@
+from arm.logicnode.arm_nodes import *
+
+class GetCameraScaleNode(ArmLogicTreeNode):
+    """Returns the scale of the given camera."""
+    bl_idname = 'LNGetCameraScaleNode'
+    bl_label = 'Get Camera Ortho Scale'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketObject', 'Camera')
+
+        self.add_output('ArmFloatSocket', 'Ortho Scale')
+2

--- a/blender/arm/logicnode/camera/LN_get_camera_type.py
+++ b/blender/arm/logicnode/camera/LN_get_camera_type.py
@@ -1,0 +1,15 @@
+from arm.logicnode.arm_nodes import *
+
+class GetCameraTypeNode(ArmLogicTreeNode):
+    """Returns the camera Type:
+        0 : Perspective
+        1 : Ortographic
+    ."""
+    bl_idname = 'LNGetCameraTypeNode'
+    bl_label = 'Get Camera Type'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketObject', 'Camera')
+        
+        self.add_output('ArmBoolSocket', 'Type')

--- a/blender/arm/logicnode/camera/LN_set_camera_aspect.py
+++ b/blender/arm/logicnode/camera/LN_set_camera_aspect.py
@@ -1,0 +1,14 @@
+from arm.logicnode.arm_nodes import *
+
+class SetCameraAspectNode(ArmLogicTreeNode):
+    """Sets the aspect of the given camera."""
+    bl_idname = 'LNSetCameraAspectNode'
+    bl_label = 'Set Camera Aspect'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Camera')
+        self.add_input('ArmFloatSocket', 'Aspect', default_value=1.7)
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/blender/arm/logicnode/camera/LN_set_camera_scale.py
+++ b/blender/arm/logicnode/camera/LN_set_camera_scale.py
@@ -1,0 +1,14 @@
+from arm.logicnode.arm_nodes import *
+
+class SetCameraScaleNode(ArmLogicTreeNode):
+    """Sets the aspect of the given camera."""
+    bl_idname = 'LNSetCameraScaleNode'
+    bl_label = 'Set Camera Ortho Scale'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Camera')
+        self.add_input('ArmFloatSocket', 'Ortho Scale', default_value=1.7)
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/blender/arm/logicnode/camera/LN_set_camera_type.py
+++ b/blender/arm/logicnode/camera/LN_set_camera_type.py
@@ -1,0 +1,33 @@
+from arm.logicnode.arm_nodes import *
+
+class SetCameraTypeNode(ArmLogicTreeNode):
+    """Sets the camera type."""
+    bl_idname = 'LNSetCameraTypeNode'
+    bl_label = 'Set Camera Type'
+    arm_version = 1
+    
+    def remove_extra_inputs(self, context):
+        while len(self.inputs) > 2:
+            self.inputs.remove(self.inputs[-1])
+        if self.property0 == 'Perspective':
+            self.add_input('ArmFloatSocket', 'Fov')
+            self.add_input('ArmFloatSocket', 'Start')
+            self.add_input('ArmFloatSocket', 'End')
+        if self.property0 == 'Orthographic':
+            self.add_input('ArmFloatSocket', 'Scale')
+    
+    property0: HaxeEnumProperty(
+    'property0',
+    items = [('Perspective', 'Perspective', 'Perspective'),
+             ('Orthographic', 'Orthographic', 'Orthographic')],
+    name='', default='Perspective', update=remove_extra_inputs)
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Camera')
+        self.add_input('ArmFloatSocket', 'Fov')
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')


### PR DESCRIPTION
A lot of nodes for handling Camera modifications, the camera type allows to switch between perspective and orthographic camera settings.

![image](https://user-images.githubusercontent.com/32546729/216784776-cc4c2e0a-0da4-4215-9bda-6b283403c7aa.png)
