### PR TITLE
Logic Node: Array get Previous Next

### DIFF
--- a/Sources/armory/logicnode/ArrayGetPreviousNextNode.hx
+++ b/Sources/armory/logicnode/ArrayGetPreviousNextNode.hx
@@ -1,0 +1,33 @@
+package armory.logicnode;
+
+class ArrayGetPreviousNextNode extends LogicNode {
+
+	var i = 0;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var ar: Array<Dynamic> = inputs[0].get();
+		var direction: Bool = inputs[1].get();
+
+		if (ar == null) return null;
+		
+		if(direction)
+			if (i < ar.length - 1)
+				i++;
+			else 
+				i = 0;
+		else
+			if (i <= 0)
+				i = ar.length-1;
+			else 
+				i--;
+
+		var value = ar[i];
+		
+		return value;
+		
+	}
+}

--- a/blender/arm/logicnode/array/LN_array_get_PreviousNext.py
+++ b/blender/arm/logicnode/array/LN_array_get_PreviousNext.py
@@ -1,0 +1,13 @@
+from arm.logicnode.arm_nodes import *
+
+class ArrayGetPreviousNextNode(ArmLogicTreeNode):
+    """Returns the previous or next value to be retrieve by looping the array according to the boolean condition."""
+    bl_idname = 'LNArrayGetPreviousNextNode'
+    bl_label = 'Array Get Previous/Next'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketArray', 'Array')
+        self.add_input('ArmBoolSocket', 'Previous: 0 / Next: 1')
+
+        self.add_output('ArmDynamicSocket', 'Value')


### PR DESCRIPTION
As we have the array get next, I thought to make the array get previous. But then i realized that in order to change the direction between them is needed the index, so i end up only uploading the previous/next that has the boolean condition to establish the direction of the item to be retrieved, as is shown in the video containing a collection arrays of objects as a path to follow. 

![image](https://user-images.githubusercontent.com/32546729/216962266-35d7d82c-4694-4678-830a-fd89e63247dc.png)

https://user-images.githubusercontent.com/32546729/216962298-50502400-7b75-4b11-91b5-bb30215b5472.mp4

