### PR TITLE
ArrayAdd Node: comparison for other type of values

### DIFF
--- a/Sources/armory/logicnode/ArrayAddNode.hx
+++ b/Sources/armory/logicnode/ArrayAddNode.hx
@@ -3,6 +3,7 @@ package armory.logicnode;
 class ArrayAddNode extends LogicNode {
 
 	var ar: Array<Dynamic>;
+	var array: Array<Dynamic>;
 
 	public function new(tree: LogicTree) {
 		super(tree);
@@ -10,12 +11,15 @@ class ArrayAddNode extends LogicNode {
 
 	override function run(from: Int) {
 		ar = inputs[1].get();
+		
 		if (ar == null) return;
 
 		// "Modify Original" == `false` -> Copy the input array
 		if (!inputs[2].get()) {
 			ar = ar.copy();
 		}
+
+		array = ar.map(item -> Std.string(item));
 
 		if (inputs.length > 4) {
 			for (i in 4...inputs.length) {
@@ -24,7 +28,11 @@ class ArrayAddNode extends LogicNode {
 				// "Unique Values" options only supports primitive data types
 				// for now, a custom indexOf() or contains() method would be
 				// required to compare values of other types
-				if (!inputs[3].get() || ar.indexOf(value) == -1) {
+
+				//meanwhile an efficient comparison method is defined, it can be compared as a string representation.
+				var type: Bool = value is Bool || value is Float || value is Int || value is String;
+
+				if (!inputs[3].get() || (type ? ar.indexOf(value) : array.indexOf(Std.string(value))) == -1) {
 					ar.push(value);
 				}
 			}


### PR DESCRIPTION
Meanwhile an efficient comparison method is defined, the array unique values can be compared as a string representation for values like arrays or vector, which at the moment are not working.

In that case I added a condition to only do that for cases that are not: Bool, Float, Int or String (if there is a better way to check the value types please update this code or leave a comment so i can modify it)

![image](https://user-images.githubusercontent.com/32546729/217051715-1858c064-5784-463e-b313-b2857fe8468f.png)

When the time comes this code can be discarded for the definitive solution.