### PR TITLE
Fix roughness artifacts in specularBRDF()

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -335,9 +335,9 @@ void main() {
 
 #ifdef _Sun
 	vec3 sh = normalize(v + sunDir);
-	float sdotNH = dot(n, sh);
-	float sdotVH = dot(v, sh);
-	float sdotNL = dot(n, sunDir);
+	float sdotNH = max(0.0, dot(n, sh));
+	float sdotVH = max(0.0, dot(v, sh));
+	float sdotNL = max(0.0, dot(n, sunDir));
 	float svisibility = 1.0;
 	vec3 sdirect = lambertDiffuseBRDF(albedo, sdotNL) +
 				   specularBRDF(f0, roughness, sdotNL, sdotNH, dotNV, sdotVH) * occspec.y;

--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -340,7 +340,7 @@ void main() {
 	float sdotNL = max(0.0, dot(n, sunDir));
 	float svisibility = 1.0;
 	vec3 sdirect = lambertDiffuseBRDF(albedo, sdotNL) +
-				   specularBRDF(f0, roughness, sdotNL, sdotNH, dotNV, sdotVH) * occspec.y;
+	               specularBRDF(f0, roughness, sdotNL, sdotNH, dotNV, sdotVH) * occspec.y;
 
 	#ifdef _ShadowMap
 		#ifdef _CSM

--- a/Shaders/deferred_light_mobile/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_mobile/deferred_light.frag.glsl
@@ -190,7 +190,7 @@ void main() {
 	float sdotNL = max(0.0, dot(n, sunDir));
 	float svisibility = 1.0;
 	vec3 sdirect = lambertDiffuseBRDF(albedo, sdotNL) +
-				   specularBRDF(f0, roughness, sdotNL, sdotNH, dotNV, sdotVH) * occspec.y;
+	               specularBRDF(f0, roughness, sdotNL, sdotNH, dotNV, sdotVH) * occspec.y;
 
 	#ifdef _ShadowMap
 		#ifdef _CSM

--- a/Shaders/deferred_light_mobile/deferred_light.frag.glsl
+++ b/Shaders/deferred_light_mobile/deferred_light.frag.glsl
@@ -185,9 +185,9 @@ void main() {
 
 #ifdef _Sun
 	vec3 sh = normalize(v + sunDir);
-	float sdotNH = dot(n, sh);
-	float sdotVH = dot(v, sh);
-	float sdotNL = dot(n, sunDir);
+	float sdotNH = max(0.0, dot(n, sh));
+	float sdotVH = max(0.0, dot(v, sh));
+	float sdotNL = max(0.0, dot(n, sunDir));
 	float svisibility = 1.0;
 	vec3 sdirect = lambertDiffuseBRDF(albedo, sdotNL) +
 				   specularBRDF(f0, roughness, sdotNL, sdotNH, dotNV, sdotVH) * occspec.y;

--- a/Shaders/std/brdf.glsl
+++ b/Shaders/std/brdf.glsl
@@ -77,7 +77,7 @@ vec3 orenNayarDiffuseBRDF(const vec3 albedo, const float roughness, const float 
 }
 
 vec3 lambertDiffuseBRDF(const vec3 albedo, const float nl) {
-	return albedo * max(0.0, nl);
+	return albedo * nl;
 }
 
 vec3 surfaceAlbedo(const vec3 baseColor, const float metalness) {

--- a/Shaders/std/brdf.glsl
+++ b/Shaders/std/brdf.glsl
@@ -100,13 +100,13 @@ float wardSpecular(vec3 N, vec3 H, float dotNL, float dotNV, float dotNH, vec3 f
 	// fiberDirection - parse from rotation
 	// shinyParallel - roughness
 	// shinyPerpendicular - anisotropy
-	
+
 	vec3 fiberParallel = normalize(fiberDirection);
 	vec3 fiberPerpendicular = normalize(cross(N, fiberDirection));
 	float dotXH = dot(fiberParallel, H);
 	float dotYH = dot(fiberPerpendicular, H);
 	const float PI = 3.1415926535;
-	float coeff = sqrt(dotNL/dotNV) / (4.0 * PI * shinyParallel * shinyPerpendicular); 
+	float coeff = sqrt(dotNL/dotNV) / (4.0 * PI * shinyParallel * shinyPerpendicular);
 	float theta = (pow(dotXH/shinyParallel, 2.0) + pow(dotYH/shinyPerpendicular, 2.0)) / (1.0 + dotNH);
 	return clamp(coeff * exp(-2.0 * theta), 0.0, 1.0);
 }

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -104,9 +104,9 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	vec3 ld = lp - p;
 	vec3 l = normalize(ld);
 	vec3 h = normalize(v + l);
-	float dotNH = dot(n, h);
-	float dotVH = dot(v, h);
-	float dotNL = dot(n, l);
+	float dotNH = max(0.0, dot(n, h));
+	float dotVH = max(0.0, dot(v, h));
+	float dotNL = max(0.0, dot(n, l));
 
 	#ifdef _LTC
 	float theta = acos(dotNV);

--- a/Shaders/std/light_mobile.glsl
+++ b/Shaders/std/light_mobile.glsl
@@ -57,11 +57,11 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	vec3 ld = lp - p;
 	vec3 l = normalize(ld);
 	vec3 h = normalize(v + l);
-	float dotNH = dot(n, h);
-	float dotVH = dot(v, h);
-	float dotNL = dot(n, l);
+	float dotNH = max(0.0, dot(n, h));
+	float dotVH = max(0.0, dot(v, h));
+	float dotNL = max(0.0, dot(n, l));
 
-	vec3 direct = albedo * max(dotNL, 0.0) +
+	vec3 direct = lambertDiffuseBRDF(albedo, dotNL) +
 				  specularBRDF(f0, rough, dotNL, dotNH, dotNV, dotVH) * spec;
 
 	direct *= lightCol;


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/2792 (see the issue for an example).

Some dot products weren't clamped correctly and caused some mathematical mayhem when calculating the microfacet BRDF in `specularBRDF()`. Thanks @ LVutner for the help!