### PR TITLE
Various micro shadowing fixes and improvements

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -391,7 +391,8 @@ void main() {
 	#endif
 
 	#ifdef _MicroShadowing
-	svisibility *= sdotNL + 2.0 * occspec.x * occspec.x - 1.0;
+	// See https://advances.realtimerendering.com/other/2016/naughty_dog/NaughtyDog_TechArt_Final.pdf
+	svisibility *= clamp(sdotNL + 2.0 * occspec.x * occspec.x - 1.0, 0.0, 1.0);
 	#endif
 
 	fragColor.rgb += sdirect * svisibility * sunCol;

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -129,7 +129,7 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	direct *= lightCol;
 
 	#ifdef _MicroShadowing
-	direct *= dotNL + 2.0 * occ * occ - 1.0;
+	direct *= clamp(dotNL + 2.0 * occ * occ - 1.0, 0.0, 1.0);
 	#endif
 
 	#ifdef _SSRS

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -1,14 +1,16 @@
 import bpy
 
+import arm.material.shader as shader
 import arm.utils
 
 if arm.is_reload(__name__):
+    shader = arm.reload_module(shader)
     arm.utils = arm.reload_module(arm.utils)
 else:
     arm.enable_reload(__name__)
 
 
-def write(vert, frag):
+def write(vert: shader.Shader, frag: shader.Shader):
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
     is_mobile = rpdat.arm_material_model == 'Mobile'

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -1,7 +1,17 @@
 import bpy
 
+import arm.utils
+
+if arm.is_reload(__name__):
+    arm.utils = arm.reload_module(arm.utils)
+else:
+    arm.enable_reload(__name__)
+
+
 def write(vert, frag):
     wrd = bpy.data.worlds['Arm']
+    rpdat = arm.utils.get_rp()
+    is_mobile = rpdat.arm_material_model == 'Mobile'
     is_shadows = '_ShadowMap' in wrd.world_defs
     is_shadows_atlas = '_ShadowMapAtlas' in wrd.world_defs
     is_single_atlas = '_SingleAtlas' in wrd.world_defs
@@ -72,7 +82,9 @@ def write(vert, frag):
         frag.write('\t, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w)') # scale
         frag.write('\t, lightsArraySpot[li * 2 + 1].xyz') # right
     if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:
-        frag.write('  , voxels, voxpos')
+        frag.write('\t, voxels, voxpos')
+    if '_MicroShadowing' in wrd.world_defs and not is_mobile:
+        frag.write('\t, occlusion')
     frag.write(');')
 
     frag.write('}') # for numLights

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -709,6 +709,8 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
             frag.write('  , true, spotData.x, spotData.y, spotDir, spotData.zw, spotRight')
         if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:
             frag.write('  , voxels, voxpos')
+        if '_MicroShadowing' in wrd.world_defs:
+            frag.write('  , occlusion')
         frag.write(');')
 
     if '_Clusters' in wrd.world_defs:

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -201,8 +201,8 @@ class ShaderContext:
         self.tese = Shader(self, 'tese')
         return self.tese
 
-class Shader:
 
+class Shader:
     def __init__(self, context, shader_type):
         self.context = context
         self.shader_type = shader_type

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -150,7 +150,7 @@ def update_preset(self, context):
         rpdat.rp_volumetriclight = False
         rpdat.rp_ssgi = 'RTAO'
         rpdat.arm_ssrs = False
-        rpdat.arm_micro_shadowing = False
+        rpdat.arm_micro_shadowing = True
         rpdat.rp_ssr = True
         rpdat.arm_ssr_half_res = False
         rpdat.rp_bloom = True
@@ -461,7 +461,7 @@ class ArmRPListItem(bpy.types.PropertyGroup):
         name="Resolution Z", description="3D texture z resolution multiplier", default='1.0', update=update_renderpath)
     arm_clouds: BoolProperty(name="Clouds", description="Enable clouds pass", default=False, update=assets.invalidate_shader_cache)
     arm_ssrs: BoolProperty(name="SSRS", description="Screen-space ray-traced shadows", default=False, update=assets.invalidate_shader_cache)
-    arm_micro_shadowing: BoolProperty(name="Micro Shadowing", description="Micro shadowing based on ambient occlusion", default=False, update=assets.invalidate_shader_cache)
+    arm_micro_shadowing: BoolProperty(name="Micro Shadowing", description="Use the shaders' occlusion parameter to compute micro shadowing for the scene's sun lamp. This option is not available for render paths using mobile or solid material models", default=False, update=assets.invalidate_shader_cache)
     arm_texture_filter: EnumProperty(
         items=[('Anisotropic', 'Anisotropic', 'Anisotropic'),
                ('Linear', 'Linear', 'Linear'),

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1798,9 +1798,11 @@ class ARM_PT_RenderPathPostProcessPanel(bpy.types.Panel):
         sub.prop(rpdat, 'arm_ssgi_radius')
         sub.prop(rpdat, 'arm_ssgi_strength')
         sub.prop(rpdat, 'arm_ssgi_max_steps')
-        layout.separator(factor=0.5)
+        layout.separator()
 
-        layout.prop(rpdat, 'arm_micro_shadowing')
+        row = layout.row()
+        row.enabled = rpdat.arm_material_model == 'Full'
+        row.prop(rpdat, 'arm_micro_shadowing')
         layout.separator()
 
         col = layout.column()


### PR DESCRIPTION
- Fixed shader generation and compilation when using micro shadowing (`sampleLight()` did not receive the correct amount of arguments)
- Fixed the value range of the micro shadow factor (following the [original paper](https://advances.realtimerendering.com/other/2016/naughty_dog/index.html)). Previousl,y values could be both negative or greater than 1. The original implementation does not use a `dotNL` value clamped to [0, 1] but instead uses its absolute value, but since the mesh will be in shadow for negative values I think we can keep it as is.
- Added a more precise UI tooltip to the micro shadowing property
- Disable the micro shadowing property if the selected material model doesn't support it (mobile, solid/baked)
- Enable micro shadowing by default for the "Max" render path preset