### PR TITLE
PlayActionFrom: add boolean for Reverse Action

### DIFF
--- a/Sources/armory/logicnode/PlayActionFromNode.hx
+++ b/Sources/armory/logicnode/PlayActionFromNode.hx
@@ -4,6 +4,7 @@ import iron.object.Animation;
 import iron.object.Object;
 import iron.Scene;
 import kha.arrays.Float32Array;
+import iron.object.ObjectAnimation;
 
 class PlayActionFromNode extends LogicNode {
 
@@ -91,7 +92,7 @@ class PlayActionFromNode extends LogicNode {
 				var oaction = null;
 				var tracks = [];
 
-				var oactions = animation.getOactions();
+				var oactions = cast(animation, ObjectAnimation).oactions;
 
 				for (a in oactions)
 					if (a.objects[0].name == actionR) isnew = false;

--- a/Sources/armory/logicnode/PlayActionFromNode.hx
+++ b/Sources/armory/logicnode/PlayActionFromNode.hx
@@ -3,6 +3,7 @@ package armory.logicnode;
 import iron.object.Animation;
 import iron.object.Object;
 import iron.Scene;
+import kha.arrays.Float32Array;
 
 class PlayActionFromNode extends LogicNode {
 
@@ -10,6 +11,8 @@ class PlayActionFromNode extends LogicNode {
 	var startFrame: Int;
 	var endFrame: Int = -1;
 	var loop: Bool;
+	var reverse: Bool;
+	var actionR: String;
 
 	public function new(tree: LogicTree) {
 		super(tree);
@@ -38,16 +41,95 @@ class PlayActionFromNode extends LogicNode {
 		var blendTime: Float = inputs[5].get();
 		var speed: Float = inputs[6].get();
 		loop = inputs[7].get();
-		
+		reverse = inputs[8].get();
+
 		if (object == null) return;
 		animation = object.animation;
 		if (animation == null) animation = object.getParentArmature(object.name);
 
-		animation.play(action, function() {
+		if (reverse){
+			var isnew = true;
+			actionR = action+'Reverse';
+
+			if (animation.isSkinned){
+				for(a in animation.armature.actions)
+					if (a.name == actionR) isnew = false;
+
+				if (isnew){
+					for(a in animation.armature.actions)
+						if(a.name == action)
+							animation.armature.actions.push({
+								name: actionR,
+								bones: a.bones,
+								mats: null});
+
+					for(a in animation.armature.actions)
+						if(a.name == actionR){
+							for(bone in a.bones){
+								var val: Array<Float> = [];
+								var v = bone.anim.tracks[0];
+								var len: Int = v.values.length;
+								var l = Std.int(len/16);
+								for(i in 0...l)
+									for(j in 0...16)
+										val.push(v.values[(l-i)*16+j-16]);
+								for(i in 0...v.values.length)
+									v.values[i] = val[i];
+							}
+
+						var castBoneAnim = cast(animation, iron.object.BoneAnimation);
+						castBoneAnim.data.geom.actions.set(actionR, a.bones);
+						castBoneAnim.data.geom.mats.set(actionR, castBoneAnim.data.geom.mats.get(action));
+
+						for(o in iron.Scene.active.raw.objects)
+							if (o.name == object.name) o.bone_actions.push('action_'+o.bone_actions[0].split('_')[1]+'_'+actionR);
+						}
+				}
+			}
+			else {
+				
+				var oaction = null;
+				var tracks = [];
+
+				var oactions = animation.getOactions();
+
+				for (a in oactions)
+					if (a.objects[0].name == actionR) isnew = false;
+
+				if (isnew){
+					for (a in oactions){
+						if (a.objects[0].name == action){
+							oaction = a.objects[0];
+							for(b in a.objects[0].anim.tracks){
+								var val: Array<Float> = [];
+								for(c in b.values) val.push(c);
+								val.reverse();
+								var vali = new Float32Array(val.length);
+								for(i in 0...val.length) vali[i] = val[i];
+								tracks.push({target: b.target, frames: b.frames, values: vali});
+							}
+
+						oactions.push({
+			                objects: [{name: actionR,
+			                anim: {begin: oaction.anim.begin, end: oaction.anim.end, tracks: tracks},
+			                type: 'object',
+			                data_ref: '',
+			                transform: null}]});
+
+						for(o in iron.Scene.active.raw.objects)
+							if (o.name == object.name) o.object_actions.push('action_'+actionR);
+						}
+					}
+				}
+			}
+		}
+
+		animation.play(reverse ? actionR : action, function() {
 			runOutput(1);
 		}, blendTime, speed, loop);
 		animation.update(startFrame * Scene.active.raw.frame_time);
 
 		runOutput(0);
+
 	}
 }

--- a/blender/arm/logicnode/animation/LN_play_action_from.py
+++ b/blender/arm/logicnode/animation/LN_play_action_from.py
@@ -19,7 +19,7 @@ class PlayActionFromNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNPlayActionFromNode'
     bl_label = 'Play Action From'
-    arm_version = 4
+    arm_version = 3
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')

--- a/blender/arm/logicnode/animation/LN_play_action_from.py
+++ b/blender/arm/logicnode/animation/LN_play_action_from.py
@@ -19,7 +19,7 @@ class PlayActionFromNode(ArmLogicTreeNode):
     """
     bl_idname = 'LNPlayActionFromNode'
     bl_label = 'Play Action From'
-    arm_version = 3
+    arm_version = 4
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
@@ -30,6 +30,7 @@ class PlayActionFromNode(ArmLogicTreeNode):
         self.add_input('ArmFloatSocket', 'Blend', default_value = 0.25)
         self.add_input('ArmFloatSocket', 'Speed', default_value = 1.0)
         self.add_input('ArmBoolSocket', 'Loop', default_value = False)
+        self.add_input('ArmBoolSocket', 'Reverse', default_value = False)
 
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmNodeSocketAction', 'Done')


### PR DESCRIPTION
Requires: [iron:187](https://github.com/armory3d/iron/pull/187)

This modification allows the node to play the action backwards for both Object and Bone Animations. The functionality clones the action as actionReverse and reverses the frames. In that way the animation class works as usual.

![image](https://user-images.githubusercontent.com/32546729/220211296-8264c48e-b3f5-4fcc-ac59-95ac16856d7c.png)