### PR TITLE
Add Vec4 moveTowards function and a new logic node for it

### DIFF
--- a/Sources/armory/logicnode/VectorMoveTowardsNode.hx
+++ b/Sources/armory/logicnode/VectorMoveTowardsNode.hx
@@ -1,0 +1,46 @@
+package armory.logicnode;
+
+import kha.FastFloat;
+import iron.math.Vec4;
+import iron.system.Time;
+import armory.math.Helper;
+
+class VectorMoveTowardsNode extends LogicNode {
+
+	var reference = new Vec4();
+	var current = new Vec4();
+	var target = new Vec4();
+
+	var endFrame = false;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+
+		tree.notifyOnUpdate(function() {
+			endFrame = false;
+		});
+	}
+
+	override function get(from: Int): Dynamic {
+		if (!endFrame) { // Update once per frame
+			var v1: Vec4 = inputs[0].get();
+			var v2: Vec4 = inputs[1].get();
+			var delta: FastFloat = inputs[2].get();
+	
+			if (v1 == null || v2 == null || delta == null) return null;
+	
+			if (!reference.equals(v1)) {
+				// Current vector changed
+				reference.setFrom(v1);
+				current.setFrom(v1);
+			}
+	
+			target.setFrom(v2);
+			current = Helper.moveTowards(current, target, delta);
+
+			endFrame = true;
+		}
+
+		return current;
+	}
+}

--- a/Sources/armory/math/Helper.hx
+++ b/Sources/armory/math/Helper.hx
@@ -1,5 +1,6 @@
 package armory.math;
 
+import kha.FastFloat;
 import iron.math.Vec4;
 
 class Helper {
@@ -17,6 +18,22 @@ class Helper {
 				  vb.z * vn.y * va.x -
 				  vn.z * va.y * vb.x;
 		return Math.atan2(det, dot);
+	}
+
+	/**
+		Returns a copy of the current vector summed by delta towards the target vector without passing it.
+	**/
+	public static function moveTowards(current: Vec4, target: Vec4, delta: FastFloat): Vec4 {
+		var v1 = current.clone();
+		var v2 = target.clone();
+
+		var diff = v2.clone().sub(v1);
+		var length = diff.length();
+
+		if (length <= delta || length == 0.0) v1.setFrom(v2);
+		else v1.add(diff.mult(1.0 / length * delta));
+
+		return v1;
 	}
 
 	/**

--- a/blender/arm/logicnode/math/LN_vector_move_towards.py
+++ b/blender/arm/logicnode/math/LN_vector_move_towards.py
@@ -1,0 +1,15 @@
+from arm.logicnode.arm_nodes import *
+
+class VectorMoveTowardsNode(ArmLogicTreeNode):
+    """Add a constant value to the given vector until it reach the target vector."""
+    bl_idname = 'LNVectorMoveTowardsNode'
+    bl_label = 'Vector Move Towards'
+    arm_section = 'vector'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmVectorSocket', 'Vector 1', default_value=[0.0, 0.0, 0.0])
+        self.add_input('ArmVectorSocket', 'Vector 2', default_value=[1.0, 1.0, 1.0])
+        self.add_input('ArmFloatSocket', 'Delta', default_value=0.1)
+
+        self.add_output('ArmVectorSocket', 'Result')


### PR DESCRIPTION
To be more easy to use, the node automatically changes the current vector under the hood when it is changed.

I can't see a problem with this behavior yet, except some performance loss because of the comparison. If anyone test other use cases for this and see something that shouldn't happen, please let me know.

Its update is limited by one time per frame, so connecting its output multiple times will not change the speed of the movement.

In the gif, I input the current vector [0, 0, 0] and the target vector [5, 0, 0]. The green cube is positioned at the target position.
![test](https://user-images.githubusercontent.com/63247726/220378142-2105ecfb-d53c-46a0-9924-954b3b6a37a3.gif)