### PR TITLE
Fix apply force and apply impulse at location

### DIFF
--- a/Sources/armory/logicnode/ApplyForceAtLocationNode.hx
+++ b/Sources/armory/logicnode/ApplyForceAtLocationNode.hx
@@ -1,5 +1,6 @@
 package armory.logicnode;
 
+import iron.math.Quat;
 import iron.object.Object;
 import iron.math.Vec4;
 import armory.trait.physics.RigidBody;
@@ -16,7 +17,7 @@ class ApplyForceAtLocationNode extends LogicNode {
 		var object: Object = inputs[1].get();
 		var force: Vec4 = inputs[2].get();
 		var localForce: Bool = inputs.length > 3 ? inputs[3].get() : false;
-        	var location: Vec4 = inputs[4].get();
+		var location: Vec4 = new Vec4().setFrom(inputs[4].get());
 		var localLoc: Bool = inputs.length > 5 ? inputs[5].get() : false;
 
 		if (object == null || force == null || location == null) return;
@@ -24,8 +25,8 @@ class ApplyForceAtLocationNode extends LogicNode {
 #if arm_physics
 		var rb: RigidBody = object.getTrait(RigidBody);
 
-		if (localLoc) {
-			location.applyQuat(object.transform.rot);
+		if (!localLoc) {
+			location.sub(object.transform.world.getLoc());
 		}
 
 		!localForce ? rb.applyForce(force, location) : rb.applyForce(object.transform.worldVecToOrientation(force), location);

--- a/Sources/armory/logicnode/ApplyImpulseAtLocationNode.hx
+++ b/Sources/armory/logicnode/ApplyImpulseAtLocationNode.hx
@@ -16,7 +16,7 @@ class ApplyImpulseAtLocationNode extends LogicNode {
 		var object: Object = inputs[1].get();
 		var impulse: Vec4 = inputs[2].get();
 		var localImpulse: Bool = inputs.length > 3 ? inputs[3].get() : false;
-        	var location: Vec4 = inputs[4].get();
+		var location: Vec4 = new Vec4().setFrom(inputs[4].get());
 		var localLoc: Bool = inputs.length > 5 ? inputs[5].get() : false;
 
 		if (object == null || impulse == null || location == null) return;
@@ -24,8 +24,8 @@ class ApplyImpulseAtLocationNode extends LogicNode {
 #if arm_physics
 		var rb: RigidBody = object.getTrait(RigidBody);
 
-		if (localLoc) {
-			location.applyQuat(object.transform.rot);
+		if (!localLoc) {
+			location.sub(object.transform.world.getLoc());
 		}
 
 		!localImpulse ? rb.applyImpulse(impulse, location) : rb.applyImpulse(object.transform.worldVecToOrientation(impulse), location);

--- a/blender/arm/logicnode/physics/LN_apply_force_at_location.py
+++ b/blender/arm/logicnode/physics/LN_apply_force_at_location.py
@@ -11,7 +11,7 @@ class ApplyForceAtLocationNode(ArmLogicTreeNode):
     @input Force On Local Axis: if `true`, interpret the force vector as in
         object space
     @input Location: the location where to apply the force
-    @input Location On Local Axis: if `true`, use the location relative
+    @input Relative Location: if `true`, use the location relative
         to the objects location, otherwise use world coordinates
     """
     bl_idname = 'LNApplyForceAtLocationNode'
@@ -25,6 +25,6 @@ class ApplyForceAtLocationNode(ArmLogicTreeNode):
         self.add_input('ArmVectorSocket', 'Force')
         self.add_input('ArmBoolSocket', 'Force On Local Axis')
         self.add_input('ArmVectorSocket', 'Location')
-        self.add_input('ArmBoolSocket', 'Location On Local Axis')
+        self.add_input('ArmBoolSocket', 'Relative Location')
 
         self.add_output('ArmNodeSocketAction', 'Out')

--- a/blender/arm/logicnode/physics/LN_apply_impulse_at_location.py
+++ b/blender/arm/logicnode/physics/LN_apply_impulse_at_location.py
@@ -11,7 +11,7 @@ class ApplyImpulseAtLocationNode(ArmLogicTreeNode):
     @input Impulse On Local Axis: if `true`, interpret the impulse vector as in
         object space
     @input Location: the location where to apply the impulse
-    @input Location On Local Axis: if `true`, use the location relative
+    @input Relative Location: if `true`, use the location relative
         to the objects location, otherwise use world coordinates
     """
     bl_idname = 'LNApplyImpulseAtLocationNode'
@@ -25,6 +25,6 @@ class ApplyImpulseAtLocationNode(ArmLogicTreeNode):
         self.add_input('ArmVectorSocket', 'Impulse')
         self.add_input('ArmBoolSocket', 'Impulse On Local Axis')
         self.add_input('ArmVectorSocket', 'Location')
-        self.add_input('ArmBoolSocket', 'Location On Local Axis')
+        self.add_input('ArmBoolSocket', 'Relative Location')
 
         self.add_output('ArmNodeSocketAction', 'Out')


### PR DESCRIPTION
Currently, in these logic nodes, the position at which the force is applied is incorrect. By default, Bullet applies force or impulse relative to Rigid Body position. The rotation of the Rigid Body is not accounted for in Bullet physics. But the logic nodes did not follow this convention, resulting in incorrect application location. 

This PR fixes the above issues. 

References:
1. [Clarifications form creator of Bullet Physics](https://pybullet.org/Bullet/phpBB3/viewtopic.php?p=10849&sid=02a0494883aa9e90879dd0a22603dca3#p10849)
2. [Implementation of apply force at location](https://pybullet.org/Bullet/BulletFull/btRigidBody_8h_source.html#l00318)