### PR TITLE
Fix material batch

### DIFF
--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -38,6 +38,9 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
 
+    # Texture caching for material batching
+    batch_cached_textures = []
+
     needs_sss = material_needs_sss(material)
     if needs_sss and rpdat.rp_sss_state != 'Off' and '_SSS' not in wrd.world_defs:
         # Must be set before calling make_shader.build()
@@ -123,6 +126,7 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
                             if tex is None:
                                 tex = {'name': tex_name, 'file': ''}
                             c['bind_textures'].append(tex)
+                    batch_cached_textures = c['bind_textures']
 
                 # Set marked inputs as uniforms
                 for node in material.node_tree.nodes:
@@ -133,6 +137,11 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
 
         elif rp == 'translucent':
             c['bind_constants'].append({'name': 'receiveShadow', 'bool': material.arm_receive_shadow})
+        
+        elif rp == 'shadowmap':
+            if wrd.arm_batch_materials:
+                if len(c['bind_textures']) > 0:
+                    c['bind_textures'] = batch_cached_textures
 
     if wrd.arm_single_data_file:
         mat_data['shader'] = shader_data_name

--- a/blender/arm/material/mat_batch.py
+++ b/blender/arm/material/mat_batch.py
@@ -33,8 +33,27 @@ def get_signature(mat):
         sign = traverse_tree(output_node, '')
         # Append flags
         sign += '1' if mat.arm_cast_shadow else '0'
+        sign += '1' if mat.arm_ignore_irradiance else '0'
+        if mat.arm_two_sided:
+            sign += '2'
+        elif mat.arm_cull_mode == 'Clockwise':
+            sign += '1'
+        else:
+            sign += '0'
+        sign += str(mat.arm_material_id)
+        sign += '1' if mat.arm_depth_read else '0'
         sign += '1' if mat.arm_overlay else '0'
-        sign += '1' if mat.arm_cull_mode == 'Clockwise' else '0'
+        sign += '1' if mat.arm_decal else '0'
+        if mat.arm_discard:
+            sign += '1'
+            sign += str(round(mat.arm_discard_opacity, 2))
+            sign += str(round(mat.arm_discard_opacity_shadows, 2))
+        else:
+            sign += '000'
+        sign += mat.arm_custom_material if mat.arm_custom_material != '' else '0'
+        sign += mat.arm_skip_context if mat.arm_skip_context != '' else '0'
+        sign += '1' if mat.arm_particle_fade else '0'
+        sign += mat.arm_billboard
         return sign
 
 def traverse_tree2(node, ar):


### PR DESCRIPTION
The material batch option did not properly separate materials since it missed a few properties. This PR fixes by including those properties in the material signature.

Also, when material batch was enabled, the input textures were not treated as uniforms for shadowmap context. This caused incorrect shadows for meshes. Fixed it by adding these uniforms from the mesh context