### PR TITLE
Fix html anchor in the "Open Node Documentation" operator for some nodes

### DIFF
--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -248,11 +248,11 @@ class ArmOpenNodeWikiEntry(bpy.types.Operator):
             if len(context.selected_nodes) == 1:
                 node = context.selected_nodes[0]
                 if node.bl_idname.startswith('LN') and node.arm_version is not None:
-                    wiki_id = ArmOpenNodeWikiEntry.to_wiki_id(node.__module__.rsplit('.', 2).pop())
+                    anchor = node.bl_label.lower().replace(" ", "-")
 
                     category = arm_nodes.eval_node_category(node)
                     category_section = arm_nodes.get_category(category).category_section
-                    webbrowser.open(f'https://github.com/armory3d/armory/wiki/reference_{category_section}#{wiki_id}')
+                    webbrowser.open(f'https://github.com/armory3d/armory/wiki/reference_{category_section}#{anchor}')
         return{'FINISHED'}
 
 

--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -232,16 +232,9 @@ class ArmOpenNodePythonSource(bpy.types.Operator):
 
 
 class ArmOpenNodeWikiEntry(bpy.types.Operator):
-    """Open the node's documentation in the wiki"""
+    """Open the logic node's documentation in the Armory wiki"""
     bl_idname = 'arm.open_node_documentation'
     bl_label = 'Open Node Documentation'
-
-    @staticmethod
-    def to_wiki_id(node_name):
-        """Convert from the conventional node name to its wiki counterpart's anchor or id.
-        Expected node_name format: LN_[a-z_]+
-        """
-        return node_name.replace('_', '-')[3:]
 
     def execute(self, context):
         if context.selected_nodes is not None:
@@ -252,8 +245,10 @@ class ArmOpenNodeWikiEntry(bpy.types.Operator):
 
                     category = arm_nodes.eval_node_category(node)
                     category_section = arm_nodes.get_category(category).category_section
+
                     webbrowser.open(f'https://github.com/armory3d/armory/wiki/reference_{category_section}#{anchor}')
-        return{'FINISHED'}
+
+        return {'FINISHED'}
 
 
 class ARM_PT_NodeDevelopment(bpy.types.Panel):


### PR DESCRIPTION
For some nodes like _Array Loop_, the previous code would generate a wrong HTML anchor to link to the node reference (e.g. `#array-loop-node` instead of `#array-loop`) because the code didn't match with the script that generates the documentation.

The new code still isn't 100% fail-safe since we depend on GitHub behaviour and we currently don't check for special characters. But to my my knowledge no node's `bl_label` has such characters so we should be safe :)

Thanks to @ BrahRah on Discord for the report.