### PR TITLE
Use panels for watch nodes in Debug Console

### DIFF
--- a/Sources/armory/trait/internal/DebugConsole.hx
+++ b/Sources/armory/trait/internal/DebugConsole.hx
@@ -879,8 +879,17 @@ class DebugConsole extends Trait {
 			}
 
 			if (watchNodes.length > 0 && ui.tab(htab, "Watch")) {
+				var lineCounter = 0;
 				for (n in watchNodes) {
-					ui.text(n.tree.object.name + "." + n.tree.name + "." + n.name + " = " + n.get(0));
+					if (ui.panel(Id.handle({selected: true}).nest(lineCounter), n.tree.object.name + "." + n.tree.name + "." + n.name + " : ")){
+						ui.indent();
+						ui.g.color = ui.t.SEPARATOR_COL;
+						ui.g.fillRect(0, ui._y, ui._windowW, ui.ELEMENT_H());
+						ui.g.color = 0xffffffff;
+						ui.text(Std.string(n.get(0)));
+						ui.unindent();
+					}
+					lineCounter++;
 				}
 			}
 


### PR DESCRIPTION
The values displayed by the watch nodes were not in full due to the name and the value displayed in the same line. Additionally, all the outputs were displayed at the same time, making it difficult to decipher. This PR uses collapsible panels to display the values of the watch nodes. Another advantage is that the value of the node is retrieved only when panel is expanded, reducing some overhead.

before:
![image](https://user-images.githubusercontent.com/55564981/224178191-e9df200e-349e-420f-8867-9486add409cc.png)

now:
![image](https://user-images.githubusercontent.com/55564981/224177497-cd620020-dfe6-4f4b-9fed-954a05dafe18.png)


**Edit:** Also thanks to @ BrahRah for bringing up this issue on Discord.