### PR TITLE
Fix export of delta transform animations

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -360,6 +360,9 @@ class ArmoryExporter:
                         # Missing target entry for array_index or something else
                         raise
 
+                    if data_path.startswith('delta_'):
+                        out_anim['has_delta'] = True
+
                     out_anim['tracks'].append(out_track)
 
                 if len(unresolved_data_paths) > 0:


### PR DESCRIPTION
Iron expects `TAnimation.has_delta` for delta transform animations in order to initialize some transform attributes ([source](https://github.com/armory3d/iron/blob/0f28228090ebc452da3c21bab8bea64f7414ec88/Sources/iron/object/ObjectAnimation.hx#L85-L95)), but Armory did not set `has_delta`  during export, leading to the following runtime exception:
```
Trace: TypeError: Cannot set properties of null (setting 'x')
    at iron_object_ObjectAnimation.updateTransformAnim (<anonymous>:17492:22)
    at iron_object_ObjectAnimation.updateObjectAnim (<anonymous>:17388:8)
    at iron_object_ObjectAnimation.update (<anonymous>:17384:9)
    at iron_Scene.updateFrame (<anonymous>:4550:9)
    at update (<anonymous>:3418:21)
    at kha_TimeTask.task (<anonymous>:25557:4)
    at kha_Scheduler.executeTimeTasks (<anonymous>:25440:76)
    at kha_Scheduler.executeFrame (<anonymous>:25390:18)
    at renderCallback (<anonymous>:26202:17)
```