### PR TITLE
Add missing checks for bundled traits

### DIFF
--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -869,6 +869,7 @@ def draw_traits_panel(layout: bpy.types.UILayout, obj: Union[bpy.types.Object, b
                 if item.class_name_prop == 'NavMesh':
                     row.operator("arm.generate_navmesh", icon="UV_VERTEXSEL")
                 else:
+                    row.enabled = item.class_name_prop != ''
                     row.operator("arm.edit_bundled_script", icon_value=ICON_HAXE).is_object = is_object
 
             refresh_op = "arm.refresh_object_scripts" if is_object else "arm.refresh_scripts"
@@ -936,8 +937,7 @@ def draw_traits_panel(layout: bpy.types.UILayout, obj: Union[bpy.types.Object, b
 
         # =====================
         # Draw trait properties
-        if item.type_prop == 'Haxe Script' or item.type_prop == 'Bundled Script':
-
+        if (item.type_prop == 'Haxe Script' or item.type_prop == 'Bundled Script') and item.class_name_prop != '':
             if item.arm_traitpropslist:
                 layout.label(text="Trait Properties:")
                 if item.arm_traitpropswarnings:


### PR DESCRIPTION
Fixed issue 1: The <kbd>Edit Script</kbd> button was still enabled even when the active trait property was empty, which caused errors if the button was clicked because no trait property was selected.

Fixed issue 2: Trait properties panel was still visible even when the active trait property was empty, which shouldn't happen.