### PR TITLE
Node group improvements

### DIFF
--- a/blender/arm/keymap.py
+++ b/blender/arm/keymap.py
@@ -28,6 +28,24 @@ def register():
     km.keymap_items.new("tlm.clean_lightmaps", type='F7', value='PRESS')
     arm_keymaps.append(km)
 
+    km = addon_keyconfig.keymaps.new(name='Node Editor', space_type='NODE_EDITOR')
+
+    # shift+G: Create a new node call group node
+    km.keymap_items.new('arm.add_call_group_node', 'G', 'PRESS', shift=True)
+
+    # ctrl+G: make node group from selected
+    km.keymap_items.new('arm.add_group_tree_from_selected', 'G', 'PRESS', ctrl=True)
+
+    # TAB: enter node groups depending on selection
+    km.keymap_items.new('arm.edit_group_tree', 'TAB', 'PRESS')
+
+    # ctrl+TAB: exit node groups depending on selectio
+    km.keymap_items.new('node.tree_path_parent', 'TAB', 'PRESS', ctrl=True)
+
+    # alt+G: ungroup node tree
+    km.keymap_items.new('arm.ungroup_group_tree', 'G', 'PRESS', alt=True)
+    arm_keymaps.append(km)
+
 
 def unregister():
     wm = bpy.context.window_manager

--- a/blender/arm/logicnode/arm_node_group.py
+++ b/blender/arm/logicnode/arm_node_group.py
@@ -333,15 +333,30 @@ class ArmAddCallGroupNode(bpy.types.Operator):
     bl_idname = 'arm.add_call_group_node'
     bl_label = "Add call group node"
 
+    node_ref = None
+
     @classmethod
     def poll(cls, context):
         if context.space_data.type == 'NODE_EDITOR':
             return context.space_data.edit_tree and context.space_data.tree_type == 'ArmLogicTreeType'
         return False
 
+    def invoke(self, context, event):
+        context.window_manager.modal_handler_add(self)
+        self.execute(context)
+        return {'RUNNING_MODAL'}
+
+    def modal(self, context, event):
+        if event.type == 'MOUSEMOVE':
+            self.node_ref.location = context.space_data.cursor_location
+        elif event.type == 'LEFTMOUSE':  # Confirm
+            return {'FINISHED'}
+        return {'RUNNING_MODAL'}
+
     def execute(self, context):
         tree = context.space_data.path[-1].node_tree
-        tree.nodes.new('LNCallGroupNode')
+        self.node_ref = tree.nodes.new('LNCallGroupNode')
+        self.node_ref.location = context.space_data.cursor_location
         return {'FINISHED'}
 
 class ARM_PT_LogicGroupPanel(bpy.types.Panel):

--- a/blender/arm/logicnode/arm_node_group.py
+++ b/blender/arm/logicnode/arm_node_group.py
@@ -164,7 +164,9 @@ class ArmAddGroupTree(bpy.types.Operator):
         group_node.group_tree = sub_tree  # link sub tree to group node
         sub_tree.nodes.new('LNGroupInputsNode').location = (-250, 0)  # create node for putting data into sub tree
         sub_tree.nodes.new('LNGroupOutputsNode').location = (250, 0)  # create node for getting data from sub tree
-        return bpy.ops.arm.edit_group_tree(node_index=self.node_index)
+        context.space_data.path.append(sub_tree, node=group_node)
+        sub_tree.group_node_name = group_node.name
+        return {'FINISHED'}
 
 class ArmAddGroupTreeFromSelected(bpy.types.Operator):
     """Select nodes group node and placing them into sub tree"""

--- a/blender/arm/logicnode/arm_node_group.py
+++ b/blender/arm/logicnode/arm_node_group.py
@@ -76,13 +76,28 @@ class ArmEditGroupTree(bpy.types.Operator):
     bl_label = 'Edit group tree'
     node_index: StringProperty(name='Node Index', default='')
 
+    def custom_poll(self, context):
+        if not self.node_index == '':
+            return True
+        if context.space_data.type == 'NODE_EDITOR':
+            if context.active_node and hasattr(context.active_node, 'group_tree'):
+                if context.active_node.group_tree is not None:
+                    return True
+        return False
+
     def execute(self, context):
-        global array_nodes
-        group_node = array_nodes[self.node_index]
-        sub_tree: ArmLogicTree = group_node.group_tree
-        context.space_data.path.append(sub_tree, node=group_node)
-        sub_tree.group_node_name = group_node.name
-        return {'FINISHED'}
+        if self.custom_poll(context):
+            global array_nodes
+            if not self.node_index == '':
+                group_node = array_nodes[self.node_index]
+            else:
+                group_node = context.active_node
+            sub_tree: ArmLogicTree = group_node.group_tree
+            context.space_data.path.append(sub_tree, node=group_node)
+            sub_tree.group_node_name = group_node.name
+            self.node_index = ''
+            return {'FINISHED'}
+        return {'CANCELLED'}
 
 class ArmCopyGroupTree(bpy.types.Operator):
     """Create a copy of this group tree and use it"""

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -305,12 +305,15 @@ class ArmLogicTreeNode(bpy.types.Node):
         SetVariable node).
         """
 
-        links = self.inputs[socket_index].links
+        old_socket = self.inputs[socket_index]
+        links = old_socket.links
         from_sockets = []
         for link in links:
             from_sockets.append(link.from_socket)
-        self.inputs.remove(self.inputs[socket_index])
         current_socket = self.insert_input(socket_type, socket_index, socket_name, default_value, is_var)
+        if default_value is None:
+            old_socket.copy_defaults(current_socket)
+        self.inputs.remove(old_socket)
         tree = self.get_tree()
         for from_socket in from_sockets:
             tree.links.new(from_socket, current_socket)

--- a/blender/arm/logicnode/arm_sockets.py
+++ b/blender/arm/logicnode/arm_sockets.py
@@ -59,6 +59,10 @@ class ArmCustomSocket(NodeSocket):
         """Called when the update() method of the corresponding node is called."""
         pass
 
+    def copy_defaults(self, socket):
+        """Called when this socket default values are to be copied to the given socket"""
+        pass
+
 
 class ArmActionSocket(ArmCustomSocket):
     bl_idname = 'ArmNodeSocketAction'
@@ -104,6 +108,10 @@ class ArmAnimActionSocket(ArmCustomSocket):
 
     def draw_color(self, context, node):
         return socket_colors[self.bl_idname]
+
+    def copy_defaults(self, socket):
+        if socket.bl_idname == self.bl_idname:
+            socket.default_value_raw = self.default_value_raw
 
 
 class ArmRotationSocket(ArmCustomSocket):
@@ -288,6 +296,17 @@ class ArmRotationSocket(ArmCustomSocket):
         update = _on_update_socket
     )
 
+    def copy_defaults(self, socket):
+        if socket.bl_idname == self.bl_idname:
+            socket.default_value_mode = self.default_value_mode
+            socket.default_value_unit = self.default_value_unit
+            socket.default_value_order = self.default_value_order
+            socket.default_value_s0 = self.default_value_s0
+            socket.default_value_s1 = self.default_value_s1
+            socket.default_value_s2 = self.default_value_s2
+            socket.default_value_s3 = self.default_value_s3
+            socket.default_value_raw = self.default_value_raw
+
 
 class ArmArraySocket(ArmCustomSocket):
     bl_idname = 'ArmNodeSocketArray'
@@ -321,6 +340,10 @@ class ArmBoolSocket(ArmCustomSocket):
     def get_default_value(self):
         return self.default_value_raw
 
+    def copy_defaults(self, socket):
+        if socket.bl_idname == self.bl_idname:
+            socket.default_value_raw = self.default_value_raw
+
 
 class ArmColorSocket(ArmCustomSocket):
     bl_idname = 'ArmColorSocket'
@@ -346,6 +369,10 @@ class ArmColorSocket(ArmCustomSocket):
 
     def get_default_value(self):
         return self.default_value_raw
+
+    def copy_defaults(self, socket):
+        if socket.bl_idname == self.bl_idname:
+            socket.default_value_raw = self.default_value_raw
 
 
 class ArmDynamicSocket(ArmCustomSocket):
@@ -430,6 +457,9 @@ class ArmFloatSocket(ArmCustomSocket):
     def get_default_value(self):
         return self.default_value_raw
 
+    def copy_defaults(self, socket):
+        if socket.bl_idname == self.bl_idname:
+            socket.default_value_raw = self.default_value_raw
 
 class ArmIntSocket(ArmCustomSocket):
     bl_idname = 'ArmIntSocket'
@@ -451,6 +481,9 @@ class ArmIntSocket(ArmCustomSocket):
     def get_default_value(self):
         return self.default_value_raw
 
+    def copy_defaults(self, socket):
+        if socket.bl_idname == self.bl_idname:
+            socket.default_value_raw = self.default_value_raw
 
 class ArmObjectSocket(ArmCustomSocket):
     bl_idname = 'ArmNodeSocketObject'
@@ -485,7 +518,9 @@ class ArmObjectSocket(ArmCustomSocket):
     def draw_color(self, context, node):
         return socket_colors[self.bl_idname]
 
-
+    def copy_defaults(self, socket):
+        if socket.bl_idname == self.bl_idname:
+            socket.default_value_raw = self.default_value_raw
 
 class ArmStringSocket(ArmCustomSocket):
     bl_idname = 'ArmStringSocket'
@@ -507,6 +542,9 @@ class ArmStringSocket(ArmCustomSocket):
     def get_default_value(self):
         return self.default_value_raw
 
+    def copy_defaults(self, socket):
+        if socket.bl_idname == self.bl_idname:
+            socket.default_value_raw = self.default_value_raw
 
 class ArmVectorSocket(ArmCustomSocket):
     bl_idname = 'ArmVectorSocket'
@@ -535,6 +573,9 @@ class ArmVectorSocket(ArmCustomSocket):
     def get_default_value(self):
         return self.default_value_raw
 
+    def copy_defaults(self, socket):
+        if socket.bl_idname == self.bl_idname:
+            socket.default_value_raw = self.default_value_raw
 
 def draw_socket_layout(socket: bpy.types.NodeSocket, layout: bpy.types.UILayout, prop_name='default_value_raw'):
     if not socket.is_output and not socket.is_linked:

--- a/blender/arm/logicnode/miscellaneous/LN_call_group.py
+++ b/blender/arm/logicnode/miscellaneous/LN_call_group.py
@@ -130,9 +130,8 @@ class CallGroupNode(ArmLogicTreeNode):
             op = row_copy.operator('arm.copy_group_tree', text=str(self.group_tree.users - fake_user))
             op.node_index = self.get_id_str()
             row_name.prop(self.group_tree, 'use_fake_user', text='')
-            op = row_name.operator('arm.node_call_func', icon='X', text='')
+            op = row_name.operator('arm.unlink_group_tree', icon='X', text='')
             op.node_index = self.get_id_str()
-            op.callback_name = 'remove_tree'
         row_ops.enabled = not self.group_tree is None
         op = row_ops.operator('arm.edit_group_tree', icon='FULLSCREEN_ENTER', text='Edit tree')
         op.node_index = self.get_id_str()

--- a/blender/arm/logicnode/miscellaneous/LN_call_group.py
+++ b/blender/arm/logicnode/miscellaneous/LN_call_group.py
@@ -102,18 +102,29 @@ class CallGroupNode(ArmLogicTreeNode):
     # Prperty to store group tree pointer
     group_tree: PointerProperty(name='Group', type=bpy.types.NodeTree, update=update_sockets)
 
+    def draw_label(self) -> str:
+        if self.group_tree is not None:
+            return f'Group: {self.group_tree.name}'
+        return self.bl_label
+
     # Draw node UI
     def draw_buttons(self, context, layout):
         col = layout.column()
         row_name = col.row(align=True)
         row_add = col.row(align=True)
         row_ops = col.row()
-        op = row_add.operator('arm.add_group_tree', icon='PLUS', text='New Group')
-        op.node_index = self.get_id_str()
+        if self.group_tree is None:
+            op = row_add.operator('arm.add_group_tree', icon='PLUS', text='New Group')
+            op.node_index = self.get_id_str()
         op = row_name.operator('arm.search_group_tree', text='', icon='VIEWZOOM')
         op.node_index = self.get_id_str()
         if self.group_tree:
             row_name.prop(self.group_tree, 'name', text='')
+            row_copy = row_name.split(align=True)
+            row_copy.alignment = 'CENTER'
+            fake_user = 1 if self.group_tree.use_fake_user else 0
+            op = row_copy.operator('arm.copy_group_tree', text=str(self.group_tree.users - fake_user))
+            op.node_index = self.get_id_str()
             row_name.prop(self.group_tree, 'use_fake_user', text='')
             op = row_name.operator('arm.node_call_func', icon='X', text='')
             op.node_index = self.get_id_str()

--- a/blender/arm/logicnode/miscellaneous/LN_group_input.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_input.py
@@ -22,6 +22,9 @@ class GroupInputsNode(ArmLogicTreeNode):
     # Flag to store invalid links
     invalid_link: BoolProperty(name='invalid_link', description='', default=False)
 
+    # Override copy prevention in certain situations such as copying entire group
+    copy_override: BoolProperty(name='copy override', description='', default=False)
+
     def init(self, context):
         tree = bpy.context.space_data.edit_tree
         node_count = 0
@@ -36,8 +39,10 @@ class GroupInputsNode(ArmLogicTreeNode):
 
     # Prevent copying of group node
     def copy(self, node):
-        self.mute = True
-        self.outputs.clear()
+        if not self.copy_override:
+            self.mute = True
+            self.outputs.clear()
+        self.copy_override = False
 
     def arm_init(self, context):
         if not self.mute:

--- a/blender/arm/logicnode/miscellaneous/LN_group_input.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_input.py
@@ -164,6 +164,12 @@ class GroupInputsNode(ArmLogicTreeNode):
         if self.active_output > len(self.outputs) - 1:
             self.active_output = len(self.outputs) - 1
 
+    # Handle deletion of group input node
+    def free(self):
+        call_group_nodes = self.get_call_group_nodes()
+        for node in call_group_nodes:
+            node.inputs.clear()
+
     # Draw node UI
     def draw_buttons(self, context, layout):
         if self.mute:

--- a/blender/arm/logicnode/miscellaneous/LN_group_output.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_output.py
@@ -22,7 +22,10 @@ class GroupOutputsNode(ArmLogicTreeNode):
     # Flag to store invalid links
     invalid_link: BoolProperty(name='invalid_link', description='', default=False)
 
-    def arm_init(self, context):
+    # Override copy prevention in certain situations such as copying entire group
+    copy_override: BoolProperty(name='copy override', description='', default=False)
+
+    def init(self, context):
         tree = bpy.context.space_data.edit_tree
         node_count = 0
         for node in tree.nodes:
@@ -36,8 +39,10 @@ class GroupOutputsNode(ArmLogicTreeNode):
 
     # Prevent copying of group node
     def copy(self, node):
-        self.mute = True
-        self.inputs.clear()
+        if not self.copy_override:
+            self.mute = True
+            self.inputs.clear()
+        self.copy_override = False
 
     def arm_init(self, context):
         if not self.mute:

--- a/blender/arm/logicnode/miscellaneous/LN_group_output.py
+++ b/blender/arm/logicnode/miscellaneous/LN_group_output.py
@@ -164,6 +164,12 @@ class GroupOutputsNode(ArmLogicTreeNode):
         if self.active_input > len(self.inputs) - 1:
             self.active_input = len(self.inputs) - 1
 
+    # Handle deletion of group input node
+    def free(self):
+        call_group_nodes = self.get_call_group_nodes()
+        for node in call_group_nodes:
+            node.outputs.clear()
+
     # Draw node UI
     def draw_buttons(self, context, layout):
         if self.mute:


### PR DESCRIPTION
This PR adds many QOL improvements to the node groups.

1. Better UI for group nodes, indicating the number of users, fake user and a button to create a copy of current group:
![image](https://user-images.githubusercontent.com/55564981/227634576-4c4be3f7-d68a-4546-82f7-d1862a31864a.png)
Also removed the `New Group` button when there is an existing node group in use. It was sometimes accidentally clicked making it annoying.



2. Add shortcuts to the node group operations:
![image](https://user-images.githubusercontent.com/55564981/227637205-0a6b1334-4076-4ca7-a900-a83f2685b3c5.png)



3. `Add call group node` operator now follows cursor location and adds the node there:
![LNG Add](https://user-images.githubusercontent.com/55564981/227637762-da1ffc33-d6c4-4a8b-a819-0e495acf0ca1.gif)


4. More improvements with the overall behavior of sockets when connecting/ disconnecting.

