### PR TITLE
Ray Cast On and Convex Cast On nodes

### DIFF
--- a/Sources/armory/logicnode/CastPhysicsRayOnNode.hx
+++ b/Sources/armory/logicnode/CastPhysicsRayOnNode.hx
@@ -1,0 +1,56 @@
+package armory.logicnode;
+
+import iron.object.Object;
+import iron.math.Vec4;
+
+class CastPhysicsRayOnNode extends LogicNode {
+
+	var v = new Vec4();
+	var hitRb: Object = null;
+	var hitPos: Vec4 = null;
+	var hitNormal: Vec4 = null;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	function reset() {
+		hitRb = null;
+		hitPos = null;
+		hitNormal = null;
+	}
+
+	override function run(from:Int) {
+		reset();
+
+		var vfrom: Vec4 = inputs[1].get();
+		var vto: Vec4 = inputs[2].get();
+		var mask: Int = inputs[3].get();
+
+#if arm_physics
+		if (vfrom != null && vto != null) {
+			var physics = armory.trait.physics.PhysicsWorld.active;
+			var hit = physics.rayCast(vfrom, vto, mask);
+			if(hit != null) {
+				hitRb = hit.rb;
+				hitPos.setFrom(physics.hitPointWorld);
+				hitNormal.setFrom(physics.hitNormalWorld);
+			}
+		}
+#end
+		runOutput(0);
+	}
+
+	override function get(from: Int): Dynamic {
+		if (from == 1) { // Object
+			return hitRb;
+		}
+		else if (from == 2) { // Hit
+			return hitPos;
+		}
+		else { // Normal
+			return hitNormal;
+		}
+		return null;
+	}
+}

--- a/Sources/armory/logicnode/CastPhysicsRayOnNode.hx
+++ b/Sources/armory/logicnode/CastPhysicsRayOnNode.hx
@@ -32,9 +32,9 @@ class CastPhysicsRayOnNode extends LogicNode {
 			var physics = armory.trait.physics.PhysicsWorld.active;
 			var hit = physics.rayCast(vfrom, vto, mask);
 			if(hit != null) {
-				hitRb = hit.rb;
-				hitPos.setFrom(physics.hitPointWorld);
-				hitNormal.setFrom(physics.hitNormalWorld);
+				hitRb = hit.rb.object;
+				hitPos = new Vec4().setFrom(physics.hitPointWorld);
+				hitNormal = new Vec4().setFrom(physics.hitNormalWorld);
 			}
 		}
 #end

--- a/Sources/armory/logicnode/PhysicsConvexCastOnNode.hx
+++ b/Sources/armory/logicnode/PhysicsConvexCastOnNode.hx
@@ -1,0 +1,68 @@
+package armory.logicnode;
+
+#if arm_physics
+import armory.trait.physics.RigidBody;
+#end
+import iron.object.Object;
+import iron.math.Vec4;
+import iron.math.Quat;
+
+class PhysicsConvexCastOnNode extends LogicNode {
+
+	var hitPos: Vec4 = null;
+	var convexPos: Vec4 = null;
+	var hitNormal: Vec4 = null;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	function reset() {
+		hitPos = null;
+		convexPos = null;
+		hitNormal = null;
+	}
+
+	override function run(from:Int) {
+		reset();
+
+		var convex: Object = inputs[1].get();
+		var vfrom: Vec4 = inputs[2].get();
+		var vto: Vec4 = inputs[3].get();
+		var rot: Quat = inputs[4].get();
+		var mask: Int = inputs[5].get();
+
+#if arm_physics
+		if (vfrom != null && vto != null) {
+			var physics = armory.trait.physics.PhysicsWorld.active;
+			var hit = physics.convexSweepTest(rb, vfrom, vto, rot, mask);
+			if(hit != null) {
+				hitPos.setFrom(hit.pos);
+
+				var d = Vec4.distance(vfrom, vto);
+				var v = new Vec4();
+				v.subvecs(vto, vfrom).normalize();
+				v.mult(d * hit.hitFraction);
+				v.add(vfrom);
+				convexPos.setFrom(v)
+
+				hitNormal.setFrom(physics.hitNormalWorld);
+			}
+		}
+#end
+		runOutput(0);
+	}
+
+	override function get(from: Int): Dynamic {
+		if (from == 1) { // Hit Position
+			return hitPos;
+		}
+		else if (from == 2) { // RB Position
+			return convexPos;
+		}
+		else { // Normal
+			return hitNormal;
+		}
+		return null;
+	}
+}

--- a/Sources/armory/logicnode/PhysicsConvexCastOnNode.hx
+++ b/Sources/armory/logicnode/PhysicsConvexCastOnNode.hx
@@ -34,19 +34,19 @@ class PhysicsConvexCastOnNode extends LogicNode {
 
 #if arm_physics
 		if (vfrom != null && vto != null) {
+			var rb = convex.getTrait(RigidBody);
 			var physics = armory.trait.physics.PhysicsWorld.active;
 			var hit = physics.convexSweepTest(rb, vfrom, vto, rot, mask);
 			if(hit != null) {
-				hitPos.setFrom(hit.pos);
-
+				hitPos = new Vec4().setFrom(hit.pos);
 				var d = Vec4.distance(vfrom, vto);
 				var v = new Vec4();
 				v.subvecs(vto, vfrom).normalize();
 				v.mult(d * hit.hitFraction);
 				v.add(vfrom);
-				convexPos.setFrom(v)
+				convexPos = new Vec4().setFrom(v);
 
-				hitNormal.setFrom(physics.hitNormalWorld);
+				hitNormal = new Vec4().setFrom(physics.hitNormalWorld);
 			}
 		}
 #end

--- a/blender/arm/logicnode/physics/LN_convex_cast_on.py
+++ b/blender/arm/logicnode/physics/LN_convex_cast_on.py
@@ -1,0 +1,38 @@
+from arm.logicnode.arm_nodes import *
+
+class ConvexCastOnNode(ArmLogicTreeNode):
+    """Casts a convex rigid body and get the closest hit point. Also called Convex Sweep Test.
+
+    @seeNode Mask
+
+    @input In: Input trigger
+    @input Convex RB: A convex Rigid Body object to be used for the sweep test.
+    @input From: The initial location of the convex object.
+    @input To: The final location of the convex object.
+    @input Rotation: Rotation of the Convex RB during sweep test.
+    @input Mask: A bit mask value to specify which
+        objects are considered
+
+    @output Out: Output after hit
+    @output Hit Position: The hit position in world coordinates
+    @output Convex Position: Position of the convex RB at the time of collision.
+    @output Normal: The surface normal of the hit position relative to
+        the world.
+    """
+    bl_idname = 'LNPhysicsConvexCastOnNode'
+    bl_label = 'Convex Cast On'
+    arm_section = 'ray'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Convex RB')
+        self.add_input('ArmVectorSocket', 'From')
+        self.add_input('ArmVectorSocket', 'To')
+        self.add_input('ArmRotationSocket', 'Rotation')
+        self.add_input('ArmIntSocket', 'Mask', default_value=1)
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('ArmVectorSocket', 'Hit Position')
+        self.add_output('ArmVectorSocket', 'Convex Position')
+        self.add_output('ArmVectorSocket', 'Normal')

--- a/blender/arm/logicnode/physics/LN_ray_cast_on.py
+++ b/blender/arm/logicnode/physics/LN_ray_cast_on.py
@@ -1,0 +1,36 @@
+from arm.logicnode.arm_nodes import *
+
+class RayCastOnNode(ArmLogicTreeNode):
+    """Casts a physics ray and returns the first object that is hit by
+    this ray.
+
+    @seeNode Mask
+
+    @input In: Input trigger
+    @input From: the location from where to start the ray, in world
+        coordinates
+    @input To: the target location of the ray, in world coordinates
+    @input Mask: a bit mask value to specify which
+        objects are considered
+
+    @output Out: Output after hit
+    @output RB: the object that was hit
+    @output Hit: the hit position in world coordinates
+    @output Normal: the surface normal of the hit position relative to
+        the world
+    """
+    bl_idname = 'LNCastPhysicsRayOnNode'
+    bl_label = 'Ray Cast On'
+    arm_section = 'ray'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmVectorSocket', 'From')
+        self.add_input('ArmVectorSocket', 'To')
+        self.add_input('ArmIntSocket', 'Mask', default_value=1)
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('ArmNodeSocketObject', 'RB')
+        self.add_output('ArmVectorSocket', 'Hit')
+        self.add_output('ArmVectorSocket', 'Normal')


### PR DESCRIPTION
The `Ray Cast` and `Convex Cast` nodes have multiple outputs. Each time an output is accessed, the physics collision operation is performed causing unnecessary overhead. To reduce this overhead and only perform the physics operations when needed, the new nodes will have an `In` and `Out` socket.

The current Ray Cast and Convex Cast may be deprecated once the new nodes become a norm.

Preview of new nodes:
![image](https://user-images.githubusercontent.com/55564981/228820640-c194debe-f725-4c73-a843-c17afb0e6064.png)
