### PR TITLE
Fix shader generation for vertex displacement with procedural textures

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -100,7 +100,6 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
     }
     state.sample_bump = False
     state.sample_bump_res = ''
-    state.procedurals_written = False
     wrd = bpy.data.worlds['Arm']
 
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
@@ -577,10 +576,10 @@ def write_result(link: bpy.types.NodeLink) -> Optional[str]:
 
 
 def write_procedurals():
-    if not state.procedurals_written:
+    if state.curshader not in state.procedurals_written:
         state.curshader.add_function(c_functions.str_tex_proc)
-        state.procedurals_written = True
-    return
+        state.procedurals_written.add(state.curshader)
+
 
 def glsl_type(socket_type: str):
     """Socket to glsl type."""

--- a/blender/arm/material/make_depth.py
+++ b/blender/arm/material/make_depth.py
@@ -44,6 +44,7 @@ def make(context_id, rpasses, shadowmap=False):
     tese = None
 
     vert.write_attrib('vec4 spos = vec4(pos.xyz, 1.0);')
+    vert.add_include('compiled.inc')
 
     parse_opacity = 'translucent' in rpasses or mat_state.material.arm_discard
 
@@ -51,7 +52,7 @@ def make(context_id, rpasses, shadowmap=False):
 
     if parse_opacity:
         frag.write('float opacity;')
-    
+
     if(con_depth).is_elem('morph'):
         make_morph_target.morph_pos(vert)
 

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -128,6 +128,7 @@ def make_base(con_mesh, parse_opacity):
         if write_vertex_attribs is not None:
             vattr_written = write_vertex_attribs(vert)
 
+    vert.add_include('compiled.inc')
     frag.add_include('compiled.inc')
 
     attribs_written = False
@@ -295,6 +296,7 @@ def make_forward_mobile(con_mesh):
     vert.write_attrib('vec4 spos = vec4(pos.xyz, 1.0);')
     frag.ins = vert.outs
 
+    vert.add_include('compiled.inc')
     frag.add_include('compiled.inc')
 
     arm_discard = mat_state.material.arm_discard
@@ -460,6 +462,7 @@ def make_forward_solid(con_mesh):
     vert.write_attrib('vec4 spos = vec4(pos.xyz, 1.0);')
     frag.ins = vert.outs
 
+    vert.add_include('compiled.inc')
     frag.add_include('compiled.inc')
 
     arm_discard = mat_state.material.arm_discard

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -52,7 +52,8 @@ class ParserState:
         self.parse_displacement = True
         self.basecol_only = False
 
-        self.procedurals_written = False
+        self.procedurals_written: set[Shader] = set()
+
         # Already exported radiance/irradiance (currently we can only convert
         # an already existing texture as radiance/irradiance)
         self.radiance_written = False


### PR DESCRIPTION
This PR fixes a bunch of shader compilation errors due to missing declarations, caused by two different problems:

- Vertex shaders for mesh or depth contexts didn't include `compiled.inc`, but the wave texture node assumes that this file is included.
- `state.procedurals_written` was set to true when any shader of a material wrote the procedural functions, even if other shader types of the same material were still missing them (and in turn could not find some function declarations). I changed this variable to store per-shader state instead.

Thanks to @ Shakespeare on Discord for the report :)