### PR TITLE
Add component-wise mode to Vector Clamp node

### DIFF
--- a/Sources/armory/logicnode/VectorClampToSizeNode.hx
+++ b/Sources/armory/logicnode/VectorClampToSizeNode.hx
@@ -15,7 +15,7 @@ class VectorClampToSizeNode extends LogicNode {
 	}
 
 	override function get(from: Int): Dynamic {
-		v = inputs[0].get().clone();
+		v = (inputs[0].get(): Vec4).clone();
 		var fmin: kha.FastFloat = inputs[1].get();
 		var fmax: kha.FastFloat = inputs[2].get();
 

--- a/Sources/armory/logicnode/VectorClampToSizeNode.hx
+++ b/Sources/armory/logicnode/VectorClampToSizeNode.hx
@@ -1,21 +1,32 @@
 package armory.logicnode;
 
 import iron.math.Vec4;
+import armory.math.Helper;
 
 class VectorClampToSizeNode extends LogicNode {
 
-	var v = new Vec4();
+	/** Clamping mode ("length" or "components"). **/
+	public var property0: String;
+
+	var v: Vec4;
 
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 	override function get(from: Int): Dynamic {
-		v = inputs[0].get();
+		v = inputs[0].get().clone();
 		var fmin: kha.FastFloat = inputs[1].get();
 		var fmax: kha.FastFloat = inputs[2].get();
 
-		v.clamp(fmin, fmax);
+		if (property0 == "length") {
+			v.clamp(fmin, fmax);
+		}
+		else if (property0 == "components") {
+			v.x = Helper.clamp(v.x, fmin, fmax);
+			v.y = Helper.clamp(v.y, fmin, fmax);
+			v.z = Helper.clamp(v.z, fmin, fmax);
+		}
 
 		return v;
 	}

--- a/blender/arm/logicnode/math/LN_vector_clamp.py
+++ b/blender/arm/logicnode/math/LN_vector_clamp.py
@@ -15,6 +15,7 @@ class VectorClampToSizeNode(ArmLogicTreeNode):
     property0: HaxeEnumProperty(
         'property0',
         name='Clamping Mode', default='length',
+        description='Whether to clamp the length of the vector or the value of each individual component',
         items=[
             ('length', 'Length', 'Clamp the length (magnitude) of the vector'),
             ('components', 'Components', 'Clamp the individual components of the vector'),

--- a/blender/arm/logicnode/math/LN_vector_clamp.py
+++ b/blender/arm/logicnode/math/LN_vector_clamp.py
@@ -1,11 +1,30 @@
 from arm.logicnode.arm_nodes import *
 
+
 class VectorClampToSizeNode(ArmLogicTreeNode):
-    """Keeps the vector value inside the given range."""
+    """Clamp the vector's value inside the given range and return the result as a new vector.
+
+    @option Clamping Mode: Whether to clamp the length of the vector
+        or the value of each individual component.
+    """
     bl_idname = 'LNVectorClampToSizeNode'
     bl_label = 'Vector Clamp'
     arm_section = 'vector'
-    arm_version = 1
+    arm_version = 2
+
+    property0: HaxeEnumProperty(
+        'property0',
+        name='Clamping Mode', default='length',
+        items=[
+            ('length', 'Length', 'Clamp the length (magnitude) of the vector'),
+            ('components', 'Components', 'Clamp the individual components of the vector'),
+        ]
+    )
+
+    def draw_buttons(self, context, layout):
+        col = layout.column()
+        col.label(text="Clamping Mode:")
+        col.prop(self, 'property0', expand=True)
 
     def arm_init(self, context):
         self.add_input('ArmVectorSocket', 'Vector In', default_value=[0.0, 0.0, 0.0])
@@ -13,3 +32,9 @@ class VectorClampToSizeNode(ArmLogicTreeNode):
         self.add_input('ArmFloatSocket', 'Max')
 
         self.add_output('ArmVectorSocket', 'Vector Out')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement.Identity(self)


### PR DESCRIPTION
![Node screenshot](https://user-images.githubusercontent.com/17685000/231173993-4b06f231-9363-44d7-b983-2cb76fa4500f.png)

Previously, the Vector Clamp node only clamped the length of the vector, this PR makes it possible to alternatively clamp the elements of the vector instead.
