### PR TITLE
Make Bump node work with arbitrary height inputs

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -16,7 +16,7 @@
 #
 import os
 import shutil
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import bpy
 
@@ -24,10 +24,11 @@ import arm.assets
 import arm.log as log
 import arm.make_state
 import arm.material.cycles_functions as c_functions
-from arm.material.cycles_nodes import *
+import arm.material.node_meta as node_meta
 import arm.material.mat_state as mat_state
-from arm.material.parser_state import ParserState, ParserContext
+from arm.material.parser_state import ParserState, ParserContext, ParserPass
 from arm.material.shader import Shader, ShaderContext, floatstr, vec3str
+import arm.node_utils
 import arm.utils
 
 if arm.is_reload(__name__):
@@ -36,12 +37,14 @@ if arm.is_reload(__name__):
     arm.make_state = arm.reload_module(arm.make_state)
     c_functions = arm.reload_module(c_functions)
     arm.material.cycles_nodes = arm.reload_module(arm.material.cycles_nodes)
+    node_meta = arm.reload_module(node_meta)
     from arm.material.cycles_nodes import *
     mat_state = arm.reload_module(mat_state)
     arm.material.parser_state = arm.reload_module(arm.material.parser_state)
-    from arm.material.parser_state import ParserState, ParserContext
+    from arm.material.parser_state import ParserState, ParserContext, ParserPass
     arm.material.shader = arm.reload_module(arm.material.shader)
     from arm.material.shader import Shader, ShaderContext, floatstr, vec3str
+    arm.node_utils = arm.reload_module(arm.node_utils)
     arm.utils = arm.reload_module(arm.utils)
 else:
     arm.enable_reload(__name__)
@@ -98,8 +101,6 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
         'velocity': False,
         'angular_velocity': False
     }
-    state.sample_bump = False
-    state.sample_bump_res = ''
     wrd = bpy.data.worlds['Arm']
 
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
@@ -209,30 +210,27 @@ def parse_shader_input(inp: bpy.types.NodeSocket) -> Tuple[str, ...]:
 
 
 def parse_shader(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> Tuple[str, ...]:
-    # Use switch-like lookup via dictionary
-    # (better performance, better code readability)
-    # 'NODE_TYPE': parser_function
-    node_parser_funcs: Dict[str, Callable] = {
-        'MIX_SHADER': nodes_shader.parse_mixshader,
-        'ADD_SHADER': nodes_shader.parse_addshader,
-        'BSDF_PRINCIPLED': nodes_shader.parse_bsdfprincipled,
-        'BSDF_DIFFUSE': nodes_shader.parse_bsdfdiffuse,
-        'BSDF_GLOSSY': nodes_shader.parse_bsdfglossy,
-        'AMBIENT_OCCLUSION': nodes_shader.parse_ambientocclusion,
-        'BSDF_ANISOTROPIC': nodes_shader.parse_bsdfanisotropic,
-        'EMISSION': nodes_shader.parse_emission,
-        'BSDF_GLASS': nodes_shader.parse_bsdfglass,
-        'HOLDOUT': nodes_shader.parse_holdout,
-        'SUBSURFACE_SCATTERING': nodes_shader.parse_subsurfacescattering,
-        'BSDF_TRANSLUCENT': nodes_shader.parse_bsdftranslucent,
-        'BSDF_TRANSPARENT': nodes_shader.parse_bsdftransparent,
-        'BSDF_VELVET': nodes_shader.parse_bsdfvelvet,
-    }
+    supported_node_types = (
+        'MIX_SHADER',
+        'ADD_SHADER',
+        'BSDF_PRINCIPLED',
+        'BSDF_DIFFUSE',
+        'BSDF_GLOSSY',
+        'AMBIENT_OCCLUSION',
+        'BSDF_ANISOTROPIC',
+        'EMISSION',
+        'BSDF_GLASS',
+        'HOLDOUT',
+        'SUBSURFACE_SCATTERING',
+        'BSDF_TRANSLUCENT',
+        'BSDF_TRANSPARENT',
+        'BSDF_VELVET',
+    )
 
     state.reset_outs()
 
-    if node.type in node_parser_funcs:
-        node_parser_funcs[node.type](node, socket, state)
+    if node.type in supported_node_types:
+        node_meta.get_node_meta(node).parse_func(node, socket, state)
 
     elif node.type == 'GROUP':
         if node.node_tree.name.startswith('Armory PBR'):
@@ -268,7 +266,7 @@ def parse_shader(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> Tuple[st
 
     elif node.type == 'CUSTOM':
         if node.bl_idname == 'ArmShaderDataNode':
-            return node.parse(state.frag, state.vert)
+            node_meta.get_node_meta(node).parse_func(node, socket, state)
 
     else:
         log.warn(f'Node tree "{tree_name()}": material node type {node.type} not supported')
@@ -317,60 +315,60 @@ def parse_vector_input(inp: bpy.types.NodeSocket) -> vec3str:
 
 def parse_vector(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> str:
     """Parses the vector/color output value from the given node and socket."""
-    node_parser_funcs: Dict[str, Callable] = {
-        'ATTRIBUTE': nodes_input.parse_attribute,
+    supported_node_types = (
+        'ATTRIBUTE',
 
         # RGB outputs
-        'RGB': nodes_input.parse_rgb,
-        'TEX_BRICK': nodes_texture.parse_tex_brick,
-        'TEX_CHECKER': nodes_texture.parse_tex_checker,
-        'TEX_ENVIRONMENT': nodes_texture.parse_tex_environment,
-        'TEX_GRADIENT': nodes_texture.parse_tex_gradient,
-        'TEX_IMAGE': nodes_texture.parse_tex_image,
-        'TEX_MAGIC': nodes_texture.parse_tex_magic,
-        'TEX_MUSGRAVE': nodes_texture.parse_tex_musgrave,
-        'TEX_NOISE': nodes_texture.parse_tex_noise,
-        'TEX_POINTDENSITY': nodes_texture.parse_tex_pointdensity,
-        'TEX_SKY': nodes_texture.parse_tex_sky,
-        'TEX_VORONOI': nodes_texture.parse_tex_voronoi,
-        'TEX_WAVE': nodes_texture.parse_tex_wave,
-        'VERTEX_COLOR': nodes_input.parse_vertex_color,
-        'BRIGHTCONTRAST': nodes_color.parse_brightcontrast,
-        'GAMMA': nodes_color.parse_gamma,
-        'HUE_SAT': nodes_color.parse_huesat,
-        'INVERT': nodes_color.parse_invert,
-        'MIX_RGB': nodes_color.parse_mixrgb,
-        'BLACKBODY': nodes_converter.parse_blackbody,
-        'VALTORGB': nodes_converter.parse_valtorgb,  # ColorRamp
-        'CURVE_VEC': nodes_vector.parse_curvevec,  # Vector Curves
-        'CURVE_RGB': nodes_color.parse_curvergb,
-        'COMBINE_COLOR': nodes_converter.parse_combine_color,
-        'COMBHSV': nodes_converter.parse_combhsv,
-        'COMBRGB': nodes_converter.parse_combrgb,
-        'WAVELENGTH': nodes_converter.parse_wavelength,
+        'RGB',
+        'TEX_BRICK',
+        'TEX_CHECKER',
+        'TEX_ENVIRONMENT',
+        'TEX_GRADIENT',
+        'TEX_IMAGE',
+        'TEX_MAGIC',
+        'TEX_MUSGRAVE',
+        'TEX_NOISE',
+        'TEX_POINTDENSITY',
+        'TEX_SKY',
+        'TEX_VORONOI',
+        'TEX_WAVE',
+        'VERTEX_COLOR',
+        'BRIGHTCONTRAST',
+        'GAMMA',
+        'HUE_SAT',
+        'INVERT',
+        'MIX_RGB',
+        'BLACKBODY',
+        'VALTORGB',
+        'CURVE_VEC',
+        'CURVE_RGB',
+        'COMBINE_COLOR',
+        'COMBHSV',
+        'COMBRGB',
+        'WAVELENGTH',
 
         # Vector outputs
-        'CAMERA': nodes_input.parse_camera,
-        'NEW_GEOMETRY': nodes_input.parse_geometry,
-        'HAIR_INFO': nodes_input.parse_hairinfo,
-        'OBJECT_INFO': nodes_input.parse_objectinfo,
-        'PARTICLE_INFO': nodes_input.parse_particleinfo,
-        'TANGENT': nodes_input.parse_tangent,
-        'TEX_COORD': nodes_input.parse_texcoord,
-        'UVMAP': nodes_input.parse_uvmap,
-        'BUMP': nodes_vector.parse_bump,
-        'MAPPING': nodes_vector.parse_mapping,
-        'NORMAL': nodes_vector.parse_normal,
-        'NORMAL_MAP': nodes_vector.parse_normalmap,
-        'VECT_TRANSFORM': nodes_vector.parse_vectortransform,
-        'COMBXYZ': nodes_converter.parse_combxyz,
-        'VECT_MATH': nodes_converter.parse_vectormath,
-        'DISPLACEMENT': nodes_vector.parse_displacement,
-        'VECTOR_ROTATE': nodes_vector.parse_vectorrotate,
-    }
+        'CAMERA',
+        'NEW_GEOMETRY',
+        'HAIR_INFO',
+        'OBJECT_INFO',
+        'PARTICLE_INFO',
+        'TANGENT',
+        'TEX_COORD',
+        'UVMAP',
+        'BUMP',
+        'MAPPING',
+        'NORMAL',
+        'NORMAL_MAP',
+        'VECT_TRANSFORM',
+        'COMBXYZ',
+        'VECT_MATH',
+        'DISPLACEMENT',
+        'VECTOR_ROTATE',
+    )
 
-    if node.type in node_parser_funcs:
-        return node_parser_funcs[node.type](node, socket, state)
+    if node.type in supported_node_types:
+        return node_meta.get_node_meta(node).parse_func(node, socket, state)
 
     elif node.type == 'GROUP':
         return parse_group(node, socket)
@@ -380,7 +378,7 @@ def parse_vector(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> str:
 
     elif node.type == 'CUSTOM':
         if node.bl_idname == 'ArmShaderDataNode':
-            return node.parse(state.frag, state.vert)
+            node_meta.get_node_meta(node).parse_func(node, socket, state)
 
     log.warn(f'Node tree "{tree_name()}": material node type {node.type} not supported')
     return "vec3(0, 0, 0)"
@@ -439,44 +437,44 @@ def parse_value_input(inp: bpy.types.NodeSocket) -> floatstr:
 
 
 def parse_value(node, socket):
-    node_parser_funcs: Dict[str, Callable] = {
-        'ATTRIBUTE': nodes_input.parse_attribute,
-        'CAMERA': nodes_input.parse_camera,
-        'FRESNEL': nodes_input.parse_fresnel,
-        'NEW_GEOMETRY': nodes_input.parse_geometry,
-        'HAIR_INFO': nodes_input.parse_hairinfo,
-        'LAYER_WEIGHT': nodes_input.parse_layerweight,
-        'LIGHT_PATH': nodes_input.parse_lightpath,
-        'OBJECT_INFO': nodes_input.parse_objectinfo,
-        'PARTICLE_INFO': nodes_input.parse_particleinfo,
-        'VALUE': nodes_input.parse_value,
-        'WIREFRAME': nodes_input.parse_wireframe,
-        'TEX_BRICK': nodes_texture.parse_tex_brick,
-        'TEX_CHECKER': nodes_texture.parse_tex_checker,
-        'TEX_GRADIENT': nodes_texture.parse_tex_gradient,
-        'TEX_IMAGE': nodes_texture.parse_tex_image,
-        'TEX_MAGIC': nodes_texture.parse_tex_magic,
-        'TEX_MUSGRAVE': nodes_texture.parse_tex_musgrave,
-        'TEX_NOISE': nodes_texture.parse_tex_noise,
-        'TEX_POINTDENSITY': nodes_texture.parse_tex_pointdensity,
-        'TEX_VORONOI': nodes_texture.parse_tex_voronoi,
-        'TEX_WAVE': nodes_texture.parse_tex_wave,
-        'LIGHT_FALLOFF': nodes_color.parse_lightfalloff,
-        'NORMAL': nodes_vector.parse_normal,
-        'CLAMP': nodes_converter.parse_clamp,
-        'VALTORGB': nodes_converter.parse_valtorgb,
-        'MATH': nodes_converter.parse_math,
-        'RGBTOBW': nodes_converter.parse_rgbtobw,
-        'SEPARATE_COLOR': nodes_converter.parse_separate_color,
-        'SEPHSV': nodes_converter.parse_sephsv,
-        'SEPRGB': nodes_converter.parse_seprgb,
-        'SEPXYZ': nodes_converter.parse_sepxyz,
-        'VECT_MATH': nodes_converter.parse_vectormath,
-        'MAP_RANGE': nodes_converter.parse_maprange,
-    }
+    supported_node_types = (
+        'ATTRIBUTE',
+        'CAMERA',
+        'FRESNEL',
+        'NEW_GEOMETRY',
+        'HAIR_INFO',
+        'LAYER_WEIGHT',
+        'LIGHT_PATH',
+        'OBJECT_INFO',
+        'PARTICLE_INFO',
+        'VALUE',
+        'WIREFRAME',
+        'TEX_BRICK',
+        'TEX_CHECKER',
+        'TEX_GRADIENT',
+        'TEX_IMAGE',
+        'TEX_MAGIC',
+        'TEX_MUSGRAVE',
+        'TEX_NOISE',
+        'TEX_POINTDENSITY',
+        'TEX_VORONOI',
+        'TEX_WAVE',
+        'LIGHT_FALLOFF',
+        'NORMAL',
+        'CLAMP',
+        'VALTORGB',
+        'MATH',
+        'RGBTOBW',
+        'SEPARATE_COLOR',
+        'SEPHSV',
+        'SEPRGB',
+        'SEPXYZ',
+        'VECT_MATH',
+        'MAP_RANGE',
+    )
 
-    if node.type in node_parser_funcs:
-        return node_parser_funcs[node.type](node, socket, state)
+    if node.type in supported_node_types:
+        return node_meta.get_node_meta(node).parse_func(node, socket, state)
 
     elif node.type == 'GROUP':
         if node.node_tree.name.startswith('Armory PBR'):
@@ -493,7 +491,7 @@ def parse_value(node, socket):
 
     elif node.type == 'CUSTOM':
         if node.bl_idname == 'ArmShaderDataNode':
-            return node.parse(state.frag, state.vert)
+            node_meta.get_node_meta(node).parse_func(node, socket, state)
 
     log.warn(f'Node tree "{tree_name()}": material node type {node.type} not supported')
     return '0.0'
@@ -503,22 +501,22 @@ def vector_curve(name, fac, points):
     curshader = state.curshader
 
     # Write Ys array
-    ys_var = name + '_ys'
+    ys_var = name + '_ys' + state.get_parser_pass_suffix()
     curshader.write('float {0}[{1}];'.format(ys_var, len(points))) # TODO: Make const
     for i in range(0, len(points)):
         curshader.write('{0}[{1}] = {2};'.format(ys_var, i, points[i].location[1]))
     # Get index
-    fac_var = name + '_fac'
+    fac_var = name + '_fac' + state.get_parser_pass_suffix()
     curshader.write('float {0} = {1};'.format(fac_var, fac))
     index = '0'
     for i in range(1, len(points)):
         index += ' + ({0} > {1} ? 1 : 0)'.format(fac_var, points[i].location[0])
     # Write index
-    index_var = name + '_i'
+    index_var = name + '_i' + state.get_parser_pass_suffix()
     curshader.write('int {0} = {1};'.format(index_var, index))
     # Linear
     # Write Xs array
-    facs_var = name + '_xs'
+    facs_var = name + '_xs' + state.get_parser_pass_suffix()
     curshader.write('float {0}[{1}];'.format(facs_var, len(points))) # TODO: Make const
     for i in range(0, len(points)):
         curshader.write('{0}[{1}] = {2};'.format(facs_var, i, points[i].location[0]))
@@ -546,6 +544,10 @@ def write_result(link: bpy.types.NodeLink) -> Optional[str]:
     """Write the parsed result of the given node link to the shader."""
     res_var = res_var_name(link.from_node, link.from_socket)
 
+    need_dxdy_offset = node_need_reevaluation_for_screenspace_derivative(link.from_node)
+    if need_dxdy_offset:
+        res_var += state.get_parser_pass_suffix()
+
     # Unparsed node
     if not is_parsed(res_var):
         state.parsed.add(res_var)
@@ -567,6 +569,10 @@ def write_result(link: bpy.types.NodeLink) -> Optional[str]:
                 state.curshader.add_const('float', res_var, res)
             else:
                 state.curshader.write(f'float {res_var} = {res};')
+
+        if state.dxdy_varying_input_value:
+            state.curshader.write(f'{res_var} = {apply_screenspace_derivative_offset_if_required(res_var)};')
+            state.dxdy_varying_input_value = False
 
     # Normal map already parsed, return
     elif link.from_node.type == 'NORMAL_MAP':
@@ -596,13 +602,19 @@ def to_uniform(inp: bpy.types.NodeSocket):
 def store_var_name(node: bpy.types.Node):
     return node_name(node.name) + '_store'
 
+
 def texture_store(node, tex, tex_name, to_linear=False, tex_link=None, default_value=None, is_arm_mat_param=None):
     curshader = state.curshader
 
     tex_store = store_var_name(node)
+
+    if node_need_reevaluation_for_screenspace_derivative(node):
+        tex_store += state.get_parser_pass_suffix()
+
     if is_parsed(tex_store):
         return tex_store
     state.parsed.add(tex_store)
+
     if is_arm_mat_param is None:
         mat_bind_texture(tex)
     state.con.add_elem('tex', 'short2norm')
@@ -629,52 +641,58 @@ def texture_store(node, tex, tex_name, to_linear=False, tex_link=None, default_v
             curshader.write('vec4 {0} = textureGrad({1}, {2}.xy, g2.xy, g2.zw);'.format(tex_store, tex_name, uv_name))
         else:
             curshader.write('vec4 {0} = texture({1}, {2}.xy);'.format(tex_store, tex_name, uv_name))
-    if state.sample_bump:
-        state.sample_bump_res = tex_store
-        curshader.write('float {0}_1 = textureOffset({1}, {2}.xy, ivec2(-2, 0)).r;'.format(tex_store, tex_name, uv_name))
-        curshader.write('float {0}_2 = textureOffset({1}, {2}.xy, ivec2(2, 0)).r;'.format(tex_store, tex_name, uv_name))
-        curshader.write('float {0}_3 = textureOffset({1}, {2}.xy, ivec2(0, -2)).r;'.format(tex_store, tex_name, uv_name))
-        curshader.write('float {0}_4 = textureOffset({1}, {2}.xy, ivec2(0, 2)).r;'.format(tex_store, tex_name, uv_name))
-        state.sample_bump = False
+
     if to_linear:
         curshader.write('{0}.rgb = pow({0}.rgb, vec3(2.2));'.format(tex_store))
+
     return tex_store
 
 
-def write_bump(node: bpy.types.Node, out_socket: bpy.types.NodeSocket, res: str, scl=0.001):
-    """Sample texture values around the current texture coordinate for bump mapping. The result of the sampling is
-    stored in 4 variables named after state.sample_bump_res with _[0-3] appended."""
-    state.sample_bump_res = store_var_name(node) + '_bump'
+def apply_screenspace_derivative_offset_if_required(coords: str) -> str:
+    """Apply screen-space derivative offsets to the given coordinates,
+    if required by the current ParserPass.
+    """
+    # Derivative functions are only available in fragment shaders
+    if state.curshader.shader_type == 'frag':
+        if state.current_pass == ParserPass.DX_SCREEN_SPACE:
+            coords = f'({coords}) + {dfdx_fine(coords)}'
+        elif state.current_pass == ParserPass.DY_SCREEN_SPACE:
+            coords = f'({coords}) + {dfdy_fine(coords)}'
 
-    # Testing.. get function parts..
-    ar = res.split('(', 1)
-    pre = ar[0] + '('
-    if ',' in ar[1]:
-        ar2 = ar[1].split(',', 1)
-        co = ar2[0]
-        post = ',' + ar2[1]
-    else:
-        co = ar[1][:-1]
-        post = ')'
+    return '(' + coords + ')'
 
-    coordinate_offsets = (
-        f'vec3(-{scl}, 0.0, 0.0)',
-        f'vec3({scl}, 0.0, {scl})',
-        f'vec3(0.0, -{scl}, 0.0)',
-        f'vec3(0.0, {scl}, -{scl})'
-    )
 
-    needs_conversion_bw = glsl_type(out_socket.type) == "vec3"
-    curshader = state.curshader
-    for i in range(1, 5):
-        if needs_conversion_bw:
-            vec_var = f'{state.sample_bump_res}_vec{i}'
-            curshader.write(f'vec3 {vec_var} = {pre}{co} + {coordinate_offsets[i - 1]}{post};')
-            curshader.write(f'float {state.sample_bump_res}_{i} = {rgb_to_bw(vec_var)};')
-        else:
-            curshader.write(f'float {state.sample_bump_res}_{i} = {pre}{co} + {coordinate_offsets[i - 1]}{post};')
+def node_need_reevaluation_for_screenspace_derivative(node: bpy.types.Node) -> bool:
+    if state.current_pass not in (ParserPass.DX_SCREEN_SPACE, ParserPass.DY_SCREEN_SPACE):
+        return False
 
-    state.sample_bump = False
+    should_compute_offset = node_meta.get_node_meta(node).compute_dxdy_offset
+
+    if should_compute_offset == node_meta.ComputeDXDYVariant.ALWAYS:
+        return True
+    elif should_compute_offset == node_meta.ComputeDXDYVariant.NEVER:
+        return False
+
+    # ComputeDXDYVariant.DYNAMIC
+    needs_reevaluation = False
+    for inp in node.inputs:
+        c_node, _ = arm.node_utils.input_get_connected_node(inp)
+        if c_node is None:
+            continue
+
+        needs_reevaluation |= node_need_reevaluation_for_screenspace_derivative(c_node)
+
+    return needs_reevaluation
+
+
+def dfdx_fine(val: str) -> str:
+    # GL_ARB_derivative_control is unavailable in OpenGL ES (= no fine/coarse variants),
+    # OES_standard_derivatives is automatically enabled in kha.SystemImpl
+    return f'dFdx({val})' if arm.utils.is_gapi_gl_es() else f'dFdxFine({val})'
+
+
+def dfdy_fine(val: str) -> str:
+    return f'dFdy({val})' if arm.utils.is_gapi_gl_es() else f'dFdyFine({val})'
 
 
 def to_vec1(v):

--- a/blender/arm/material/cycles_nodes/nodes_color.py
+++ b/blender/arm/material/cycles_nodes/nodes_color.py
@@ -60,7 +60,7 @@ def parse_mixrgb(node: bpy.types.ShaderNodeMixRGB, out_socket: bpy.types.NodeSoc
 
     # Store factor in variable for linked factor input
     if node.inputs[0].is_linked:
-        fac = c.node_name(node.name) + '_fac'
+        fac = c.node_name(node.name) + '_fac' + state.get_parser_pass_suffix()
         state.curshader.write('float {0} = {1};'.format(fac, c.parse_value_input(node.inputs[0])))
     else:
         fac = c.parse_value_input(node.inputs[0])

--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -57,16 +57,19 @@ def parse_attribute(node: bpy.types.ShaderNodeAttribute, out_socket: bpy.types.N
                 # First UV map referenced
                 if len(lays) > 0 and node.attribute_name == lays[0].name:
                     state.con.add_elem('tex', 'short2norm')
+                    state.dxdy_varying_input_value = True
                     return c.cast_value('vec3(texCoord.x, 1.0 - texCoord.y, 0.0)', from_type='vec3', to_type=out_type)
 
                 # Second UV map referenced
                 elif len(lays) > 1 and node.attribute_name == lays[1].name:
                     state.con.add_elem('tex1', 'short2norm')
+                    state.dxdy_varying_input_value = True
                     return c.cast_value('vec3(texCoord1.x, 1.0 - texCoord1.y, 0.0)', from_type='vec3', to_type=out_type)
 
         # Vertex colors
         # TODO: support multiple vertex color sets
         state.con.add_elem('col', 'short4norm')
+        state.dxdy_varying_input_value = True
         return c.cast_value('vcolor', from_type='vec3', to_type=out_type)
 
     # Check object properties
@@ -107,12 +110,8 @@ def parse_rgb(node: bpy.types.ShaderNodeRGB, out_socket: bpy.types.NodeSocket, s
     if node.arm_material_param:
         nn = 'param_' + c.node_name(node.name)
         v = out_socket.default_value
-        value = []
-        value.append(float(v[0]))
-        value.append(float(v[1]))
-        value.append(float(v[2]))
-        is_arm_mat_param = True
-        state.curshader.add_uniform(f'vec3 {nn}', link=f'{node.name}', default_value = value, is_arm_mat_param = is_arm_mat_param)
+        value = [float(v[0]), float(v[1]), float(v[2])]
+        state.curshader.add_uniform(f'vec3 {nn}', link=f'{node.name}', default_value=value, is_arm_mat_param=True)
         return nn
     else:
         return c.to_vec3(out_socket.default_value)
@@ -126,38 +125,47 @@ def parse_vertex_color(node: bpy.types.ShaderNodeVertexColor, out_socket: bpy.ty
 def parse_camera(node: bpy.types.ShaderNodeCameraData, out_socket: bpy.types.NodeSocket, state: ParserState) -> Union[floatstr, vec3str]:
     # View Vector in camera space
     if out_socket == node.outputs[0]:
+        state.dxdy_varying_input_value = True
         return 'vVecCam'
 
     # View Z Depth
     elif out_socket == node.outputs[1]:
         state.curshader.add_include('std/math.glsl')
         state.curshader.add_uniform('vec2 cameraProj', link='_cameraPlaneProj')
+        state.dxdy_varying_input_value = True
         return 'linearize(gl_FragCoord.z, cameraProj)'
 
     # View Distance
     else:
         state.curshader.add_uniform('vec3 eye', link='_cameraPosition')
+        state.dxdy_varying_input_value = True
         return 'distance(eye, wposition)'
 
 
 def parse_geometry(node: bpy.types.ShaderNodeNewGeometry, out_socket: bpy.types.NodeSocket, state: ParserState) -> Union[floatstr, vec3str]:
     # Position
     if out_socket == node.outputs[0]:
+        state.dxdy_varying_input_value = True
         return 'wposition'
     # Normal
     elif out_socket == node.outputs[1]:
+        state.dxdy_varying_input_value = True
         return 'n' if state.curshader.shader_type == 'frag' else 'wnormal'
     # Tangent
     elif out_socket == node.outputs[2]:
+        state.dxdy_varying_input_value = True
         return 'wtangent'
     # True Normal
     elif out_socket == node.outputs[3]:
+        state.dxdy_varying_input_value = True
         return 'n' if state.curshader.shader_type == 'frag' else 'wnormal'
     # Incoming
     elif out_socket == node.outputs[4]:
+        state.dxdy_varying_input_value = True
         return 'vVec'
     # Parametric
     elif out_socket == node.outputs[5]:
+        state.dxdy_varying_input_value = True
         return 'mposition'
     # Backfacing
     elif out_socket == node.outputs[6]:
@@ -282,6 +290,7 @@ def parse_particleinfo(node: bpy.types.ShaderNodeParticleInfo, out_socket: bpy.t
 
 
 def parse_tangent(node: bpy.types.ShaderNodeTangent, out_socket: bpy.types.NodeSocket, state: ParserState) -> vec3str:
+    state.dxdy_varying_input_value = True
     return 'wtangent'
 
 
@@ -289,24 +298,30 @@ def parse_texcoord(node: bpy.types.ShaderNodeTexCoord, out_socket: bpy.types.Nod
     #obj = node.object
     #instance = node.from_instance
     if out_socket == node.outputs[0]: # Generated - bounds
+        state.dxdy_varying_input_value = True
         return 'bposition'
     elif out_socket == node.outputs[1]: # Normal
+        state.dxdy_varying_input_value = True
         return 'n'
     elif out_socket == node.outputs[2]: # UV
         if state.context == ParserContext.WORLD:
             return 'vec3(0.0)'
         state.con.add_elem('tex', 'short2norm')
+        state.dxdy_varying_input_value = True
         return 'vec3(texCoord.x, 1.0 - texCoord.y, 0.0)'
     elif out_socket == node.outputs[3]: # Object
+        state.dxdy_varying_input_value = True
         return 'mposition'
     elif out_socket == node.outputs[4]: # Camera
         return 'vec3(0.0)' # 'vposition'
     elif out_socket == node.outputs[5]: # Window
         # TODO: Don't use gl_FragCoord here, it uses different axes on different graphics APIs
         state.frag.add_uniform('vec2 screenSize', link='_screenSize')
+        state.dxdy_varying_input_value = True
         return f'vec3(gl_FragCoord.xy / screenSize, 0.0)'
     elif out_socket == node.outputs[6]: # Reflection
         if state.context == ParserContext.WORLD:
+            state.dxdy_varying_input_value = True
             return 'n'
         return 'vec3(0.0)'
 
@@ -316,14 +331,18 @@ def parse_uvmap(node: bpy.types.ShaderNodeUVMap, out_socket: bpy.types.NodeSocke
     state.con.add_elem('tex', 'short2norm')
     mat = c.mat_get_material()
     mat_users = c.mat_get_material_users()
-    if mat_users != None and mat in mat_users:
+
+    state.dxdy_varying_input_value = True
+
+    if mat_users is not None and mat in mat_users:
         mat_user = mat_users[mat][0]
         if hasattr(mat_user.data, 'uv_layers'):
-            lays = mat_user.data.uv_layers
-            # Second uvmap referenced
-            if len(lays) > 1 and node.uv_map == lays[1].name:
+            layers = mat_user.data.uv_layers
+            # Second UV map referenced
+            if len(layers) > 1 and node.uv_map == layers[1].name:
                 state.con.add_elem('tex1', 'short2norm')
                 return 'vec3(texCoord1.x, 1.0 - texCoord1.y, 0.0)'
+
     return 'vec3(texCoord.x, 1.0 - texCoord.y, 0.0)'
 
 
@@ -334,6 +353,8 @@ def parse_fresnel(node: bpy.types.ShaderNodeFresnel, out_socket: bpy.types.NodeS
         dotnv = 'dot({0}, vVec)'.format(c.parse_vector_input(node.inputs[1]))
     else:
         dotnv = 'dotNV'
+
+    state.dxdy_varying_input_value = True
     return 'fresnel({0}, {1})'.format(ior, dotnv)
 
 
@@ -343,6 +364,8 @@ def parse_layerweight(node: bpy.types.ShaderNodeLayerWeight, out_socket: bpy.typ
         dotnv = 'dot({0}, vVec)'.format(c.parse_vector_input(node.inputs[1]))
     else:
         dotnv = 'dotNV'
+
+    state.dxdy_varying_input_value = True
 
     # Fresnel
     if out_socket == node.outputs[0]:

--- a/blender/arm/material/cycles_nodes/nodes_shader.py
+++ b/blender/arm/material/cycles_nodes/nodes_shader.py
@@ -29,7 +29,7 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
 
     prefix = '' if node.inputs[0].is_linked else 'const '
     fac = c.parse_value_input(node.inputs[0])
-    fac_var = c.node_name(node.name) + '_fac'
+    fac_var = c.node_name(node.name) + '_fac' + state.get_parser_pass_suffix()
     fac_inv_var = c.node_name(node.name) + '_fac_inv'
     state.curshader.write('{0}float {1} = clamp({2}, 0.0, 1.0);'.format(prefix, fac_var, fac))
     state.curshader.write('{0}float {1} = 1.0 - {2};'.format(prefix, fac_inv_var, fac_var))

--- a/blender/arm/material/node_meta.py
+++ b/blender/arm/material/node_meta.py
@@ -1,6 +1,6 @@
 """
-This module contains a list of all Blender nodes that Armory supports,
-including Armory-related metadata.
+This module contains a list of all material nodes that Armory supports
+(excluding output nodes), as well as Armory-related metadata.
 """
 from enum import IntEnum, unique
 from dataclasses import dataclass

--- a/blender/arm/material/node_meta.py
+++ b/blender/arm/material/node_meta.py
@@ -1,0 +1,209 @@
+"""
+This module contains a list of all Blender nodes that Armory supports,
+including Armory-related metadata.
+"""
+from enum import IntEnum, unique
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+import bpy
+
+import arm.material.arm_nodes.shader_data_node as shader_data_node
+import arm.material.cycles_nodes.nodes_color as nodes_color
+import arm.material.cycles_nodes.nodes_converter as nodes_converter
+import arm.material.cycles_nodes.nodes_input as nodes_input
+import arm.material.cycles_nodes.nodes_shader as nodes_shader
+import arm.material.cycles_nodes.nodes_texture as nodes_texture
+import arm.material.cycles_nodes.nodes_vector as nodes_vector
+import arm.material.parser_state
+
+if arm.is_reload(__name__):
+    shader_data_node = arm.reload_module(shader_data_node)
+    nodes_color = arm.reload_module(nodes_color)
+    nodes_converter = arm.reload_module(nodes_converter)
+    nodes_input = arm.reload_module(nodes_input)
+    nodes_shader = arm.reload_module(nodes_shader)
+    nodes_texture = arm.reload_module(nodes_texture)
+    nodes_vector = arm.reload_module(nodes_vector)
+    arm.material.parser_state = arm.reload_module(arm.material.parser_state)
+else:
+    arm.enable_reload(__name__)
+
+
+@unique
+class ComputeDXDYVariant(IntEnum):
+    ALWAYS = 0
+    """Always compute dx/dy variants of the corresponding node.
+    Use this for input nodes that represent leafs of the node graph
+    if some of their output values vary between fragments.
+    """
+
+    NEVER = 1
+    """Never compute dx/dy variants of the corresponding node.
+    Use this for nodes whose output values do not change with respect
+    to fragment positions.
+    """
+
+    DYNAMIC = 2
+    """Compute dx/dy variants if any input socket of the corresponding node
+    is connected to a node that requires dx/dy variants.
+    """
+
+
+@dataclass
+class MaterialNodeMeta:
+    # Use Any here due to contravariance
+    parse_func: Callable[[Any, bpy.types.NodeSocket, arm.material.parser_state.ParserState], Optional[str]]
+    """The function used to parse this node and to translate it to GLSL output code."""
+
+    compute_dxdy_offset: ComputeDXDYVariant = ComputeDXDYVariant.DYNAMIC
+    """Specifies when this node should compute dx/dy variants
+    if the ParserState is in the dx/dy offset pass.
+    """
+
+
+ALL_NODES: dict[str, MaterialNodeMeta] = {
+    # --- nodes_color
+    'BRIGHTCONTRAST': MaterialNodeMeta(parse_func=nodes_color.parse_brightcontrast),
+    'CURVE_RGB': MaterialNodeMeta(parse_func=nodes_color.parse_curvergb),
+    'GAMMA': MaterialNodeMeta(parse_func=nodes_color.parse_gamma),
+    'HUE_SAT': MaterialNodeMeta(parse_func=nodes_color.parse_huesat),
+    'INVERT': MaterialNodeMeta(parse_func=nodes_color.parse_invert),
+    'LIGHT_FALLOFF': MaterialNodeMeta(parse_func=nodes_color.parse_lightfalloff),
+    'MIX_RGB': MaterialNodeMeta(parse_func=nodes_color.parse_mixrgb),
+
+    # --- nodes_converter
+    'BLACKBODY': MaterialNodeMeta(parse_func=nodes_converter.parse_blackbody),
+    'CLAMP': MaterialNodeMeta(parse_func=nodes_converter.parse_clamp),
+    'COMBHSV': MaterialNodeMeta(parse_func=nodes_converter.parse_combhsv),
+    'COMBINE_COLOR': MaterialNodeMeta(parse_func=nodes_converter.parse_combine_color),
+    'COMBRGB': MaterialNodeMeta(parse_func=nodes_converter.parse_combrgb),
+    'COMBXYZ': MaterialNodeMeta(parse_func=nodes_converter.parse_combxyz),
+    'MAP_RANGE': MaterialNodeMeta(parse_func=nodes_converter.parse_maprange),
+    'MATH': MaterialNodeMeta(parse_func=nodes_converter.parse_math),
+    'RGBTOBW': MaterialNodeMeta(parse_func=nodes_converter.parse_rgbtobw),
+    'SEPARATE_COLOR': MaterialNodeMeta(parse_func=nodes_converter.parse_separate_color),
+    'SEPHSV': MaterialNodeMeta(parse_func=nodes_converter.parse_sephsv),
+    'SEPRGB': MaterialNodeMeta(parse_func=nodes_converter.parse_seprgb),
+    'SEPXYZ': MaterialNodeMeta(parse_func=nodes_converter.parse_sepxyz),
+    'VALTORGB': MaterialNodeMeta(parse_func=nodes_converter.parse_valtorgb),  # ColorRamp
+    'VECT_MATH': MaterialNodeMeta(parse_func=nodes_converter.parse_vectormath),
+    'WAVELENGTH': MaterialNodeMeta(parse_func=nodes_converter.parse_wavelength),
+
+    # --- nodes_input
+    'ATTRIBUTE': MaterialNodeMeta(
+        parse_func=nodes_input.parse_attribute,
+        compute_dxdy_offset=ComputeDXDYVariant.ALWAYS
+    ),
+    'CAMERA': MaterialNodeMeta(
+        parse_func=nodes_input.parse_camera,
+        compute_dxdy_offset=ComputeDXDYVariant.ALWAYS
+    ),
+    'FRESNEL': MaterialNodeMeta(
+        parse_func=nodes_input.parse_fresnel,
+        compute_dxdy_offset=ComputeDXDYVariant.ALWAYS
+    ),
+    'HAIR_INFO': MaterialNodeMeta(parse_func=nodes_input.parse_hairinfo),
+    'LAYER_WEIGHT': MaterialNodeMeta(
+        parse_func=nodes_input.parse_layerweight,
+        compute_dxdy_offset=ComputeDXDYVariant.ALWAYS
+    ),
+    'LIGHT_PATH': MaterialNodeMeta(
+        parse_func=nodes_input.parse_lightpath,
+        compute_dxdy_offset=ComputeDXDYVariant.NEVER
+    ),
+    'NEW_GEOMETRY': MaterialNodeMeta(
+        parse_func=nodes_input.parse_geometry,
+        compute_dxdy_offset=ComputeDXDYVariant.ALWAYS
+    ),
+    'OBJECT_INFO': MaterialNodeMeta(
+        parse_func=nodes_input.parse_objectinfo,
+        compute_dxdy_offset=ComputeDXDYVariant.NEVER
+    ),
+    'PARTICLE_INFO': MaterialNodeMeta(
+        parse_func=nodes_input.parse_particleinfo,
+        compute_dxdy_offset=ComputeDXDYVariant.NEVER
+    ),
+    'RGB': MaterialNodeMeta(
+        parse_func=nodes_input.parse_rgb,
+        compute_dxdy_offset=ComputeDXDYVariant.NEVER
+    ),
+    'TANGENT': MaterialNodeMeta(
+        parse_func=nodes_input.parse_tangent,
+        compute_dxdy_offset=ComputeDXDYVariant.ALWAYS
+    ),
+    'TEX_COORD': MaterialNodeMeta(
+        parse_func=nodes_input.parse_texcoord,
+        compute_dxdy_offset=ComputeDXDYVariant.ALWAYS
+    ),
+    'UVMAP': MaterialNodeMeta(
+        parse_func=nodes_input.parse_uvmap,
+        compute_dxdy_offset=ComputeDXDYVariant.ALWAYS
+    ),
+    'VALUE': MaterialNodeMeta(
+        parse_func=nodes_input.parse_value,
+        compute_dxdy_offset=ComputeDXDYVariant.NEVER
+    ),
+    'VERTEX_COLOR': MaterialNodeMeta(parse_func=nodes_input.parse_vertex_color),
+    'WIREFRAME': MaterialNodeMeta(
+        parse_func=nodes_input.parse_wireframe,
+        compute_dxdy_offset=ComputeDXDYVariant.NEVER
+    ),
+
+    # --- nodes_shader
+    'ADD_SHADER': MaterialNodeMeta(parse_func=nodes_shader.parse_addshader),
+    'AMBIENT_OCCLUSION': MaterialNodeMeta(parse_func=nodes_shader.parse_ambientocclusion),
+    'BSDF_ANISOTROPIC': MaterialNodeMeta(parse_func=nodes_shader.parse_bsdfanisotropic),
+    'BSDF_DIFFUSE': MaterialNodeMeta(parse_func=nodes_shader.parse_bsdfdiffuse),
+    'BSDF_GLASS': MaterialNodeMeta(parse_func=nodes_shader.parse_bsdfglass),
+    'BSDF_GLOSSY': MaterialNodeMeta(parse_func=nodes_shader.parse_bsdfglossy),
+    'BSDF_PRINCIPLED': MaterialNodeMeta(parse_func=nodes_shader.parse_bsdfprincipled),
+    'BSDF_TRANSLUCENT': MaterialNodeMeta(parse_func=nodes_shader.parse_bsdftranslucent),
+    'BSDF_TRANSPARENT': MaterialNodeMeta(parse_func=nodes_shader.parse_bsdftransparent),
+    'BSDF_VELVET': MaterialNodeMeta(parse_func=nodes_shader.parse_bsdfvelvet),
+    'EMISSION': MaterialNodeMeta(parse_func=nodes_shader.parse_emission),
+    'HOLDOUT': MaterialNodeMeta(
+        parse_func=nodes_shader.parse_holdout,
+        compute_dxdy_offset=ComputeDXDYVariant.NEVER
+    ),
+    'MIX_SHADER': MaterialNodeMeta(parse_func=nodes_shader.parse_mixshader),
+    'SUBSURFACE_SCATTERING': MaterialNodeMeta(parse_func=nodes_shader.parse_subsurfacescattering),
+
+    # --- nodes_texture
+    'TEX_BRICK': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_brick),
+    'TEX_CHECKER': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_checker),
+    'TEX_ENVIRONMENT': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_environment),
+    'TEX_GRADIENT': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_gradient),
+    'TEX_IMAGE': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_image),
+    'TEX_MAGIC': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_magic),
+    'TEX_MUSGRAVE': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_musgrave),
+    'TEX_NOISE': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_noise),
+    'TEX_POINTDENSITY': MaterialNodeMeta(
+        parse_func=nodes_texture.parse_tex_pointdensity,
+        compute_dxdy_offset=ComputeDXDYVariant.NEVER
+    ),
+    'TEX_SKY': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_sky),
+    'TEX_VORONOI': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_voronoi),
+    'TEX_WAVE': MaterialNodeMeta(parse_func=nodes_texture.parse_tex_wave),
+
+    # --- nodes_vector
+    'BUMP': MaterialNodeMeta(parse_func=nodes_vector.parse_bump),
+    'CURVE_VEC': MaterialNodeMeta(parse_func=nodes_vector.parse_curvevec),
+    'DISPLACEMENT': MaterialNodeMeta(parse_func=nodes_vector.parse_displacement),
+    'MAPPING': MaterialNodeMeta(parse_func=nodes_vector.parse_mapping),
+    'NORMAL': MaterialNodeMeta(parse_func=nodes_vector.parse_normal),
+    'NORMAL_MAP': MaterialNodeMeta(parse_func=nodes_vector.parse_normalmap),
+    'VECTOR_ROTATE': MaterialNodeMeta(parse_func=nodes_vector.parse_vectorrotate),
+    'VECT_TRANSFORM': MaterialNodeMeta(parse_func=nodes_vector.parse_vectortransform),
+
+    # --- arm_nodes
+    'ArmShaderDataNode': MaterialNodeMeta(
+        parse_func=shader_data_node.ShaderDataNode.parse,
+        compute_dxdy_offset=ComputeDXDYVariant.ALWAYS
+    )
+}
+
+
+def get_node_meta(node: bpy.types.Node) -> MaterialNodeMeta:
+    type_identifier = node.type if node.type != 'CUSTOM' else node.bl_idname
+    return ALL_NODES[type_identifier]

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -24,8 +24,11 @@ else:
 
     @unique
     class ParserPass(IntEnum):
-        """In some situations, a node tree needs to be parsed multiple times
-        in different contexts called _passes_.
+        """In some situations, a node tree (or a subtree of that) needs
+        to be parsed multiple times in different contexts called _passes_.
+        Nodes can output different code in reaction to the parser state's
+        current pass; for more information on the individual passes
+        please refer to below enum items.
         """
         REGULAR = 0
         """The tree is parsed to generate regular shader code."""
@@ -84,8 +87,9 @@ class ParserState:
         self.normal_parsed = False
 
         self.dxdy_varying_input_value = False
-        """Whether the result of the previously parsed node is a value to which
-        a dx/dy offset should be applied if required by the parser pass.
+        """Whether the result of the previously parsed node differs
+        between fragments and represents an input value to which to apply
+        dx/dy offsets (if required by the parser pass).
         """
 
         # Shader output values

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -12,6 +12,7 @@ if arm.is_reload(__name__):
 else:
     arm.enable_reload(__name__)
 
+
     @unique
     class ParserContext(IntEnum):
         """Describes which kind of node tree is parsed."""
@@ -21,11 +22,31 @@ else:
         WORLD = 2
 
 
+    @unique
+    class ParserPass(IntEnum):
+        """In some situations, a node tree needs to be parsed multiple times
+        in different contexts called _passes_.
+        """
+        REGULAR = 0
+        """The tree is parsed to generate regular shader code."""
+
+        DX_SCREEN_SPACE = 1
+        """The tree is parsed to output shader code to compute
+        the derivative of a value with respect to the screen's x coordinate."""
+
+        DY_SCREEN_SPACE = 2
+        """The tree is parsed to output shader code to compute
+        the derivative of a value with respect to the screen's y coordinate."""
+
+
 class ParserState:
     """Dataclass to keep track of the current state while parsing a shader tree."""
+
     def __init__(self, context: ParserContext, tree_name: str, world: Optional[bpy.types.World] = None):
         self.context = context
         self.tree_name = tree_name
+
+        self.current_pass = ParserPass.REGULAR
 
         # The current world, if parsing a world node tree
         self.world = world
@@ -39,6 +60,8 @@ class ParserState:
         self.geom: Shader = None
         self.tesc: Shader = None
         self.tese: Shader = None
+
+        self.temp_var_counter = 0
 
         # Group stack (last in the list = innermost group)
         self.parents: List[bpy.types.Node] = []
@@ -58,10 +81,12 @@ class ParserState:
         # an already existing texture as radiance/irradiance)
         self.radiance_written = False
 
-        # TODO: document those attributes
-        self.sample_bump = False
-        self.sample_bump_res = ''
         self.normal_parsed = False
+
+        self.dxdy_varying_input_value = False
+        """Whether the result of the previously parsed node is a value to which
+        a dx/dy offset should be applied if required by the parser pass.
+        """
 
         # Shader output values
         self.out_basecol: vec3str = 'vec3(0.8)'
@@ -86,3 +111,13 @@ class ParserState:
         """Return the shader output values as a tuple."""
         return (self.out_basecol, self.out_roughness, self.out_metallic, self.out_occlusion, self.out_specular,
                 self.out_opacity, self.out_emission_col)
+
+    def get_parser_pass_suffix(self) -> str:
+        """Return a suffix for the current parser pass that can be appended
+        to shader variables to avoid compilation errors due to redefinitions.
+        """
+        if self.current_pass == ParserPass.DX_SCREEN_SPACE:
+            return '_dx'
+        elif self.current_pass == ParserPass.DY_SCREEN_SPACE:
+            return '_dy'
+        return ''

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -190,6 +190,30 @@ def get_gapi():
     return 'direct3d11' if get_os() == 'win' else 'opengl'
 
 
+def is_gapi_gl_es() -> bool:
+    """Return whether the currently targeted graphics API is using OpenGL ES."""
+    wrd = bpy.data.worlds['Arm']
+
+    if state.is_export:
+        item_exporter = wrd.arm_exporterlist[wrd.arm_exporterlist_index]
+
+        # See Khamake's ShaderCompiler.findType() and krafix::Target.es in krafix.cpp ("target.es")
+        if state.target == 'android-hl':
+            return item_exporter.arm_gapi_android == 'opengl'
+        if state.target == 'ios-hl':
+            return item_exporter.arm_gapi_ios == 'opengl'
+        elif state.target == 'html5':
+            return True
+        return False
+
+    else:
+        return wrd.arm_runtime == 'Browser'
+
+
+def is_gapi_flipped_y() -> bool:
+    return state.target == 'html5' or get_gapi() == 'direct3d11'
+
+
 def get_rp() -> arm.props_renderpath.ArmRPListItem:
     wrd = bpy.data.worlds['Arm']
     if not state.is_export and wrd.arm_play_renderpath != '':
@@ -979,7 +1003,8 @@ def get_kha_target(target_name): # TODO: remove
         return ''
     return target_name
 
-def target_to_gapi(arm_project_target):
+
+def target_to_gapi(arm_project_target: str) -> str:
     # TODO: align target names
     if arm_project_target == 'krom':
         return 'arm_gapi_' + arm.utils.get_os()
@@ -1003,6 +1028,7 @@ def target_to_gapi(arm_project_target):
         return 'arm_gapi_html5'
     else: # html5, custom
         return 'arm_gapi_' + arm_project_target
+
 
 def check_default_props():
     wrd = bpy.data.worlds['Arm']


### PR DESCRIPTION
Previously, Armory ignored the "Height" input of the Bump node and instead only supported a predefined set of nodes as inputs for bump mapping. The first occurance of those nodes controlled how the bump output looked like, and if multiple of these nodes were combined (e.g. with a mix node), only one of them would be taken into account (that is, the output of the mix node is ignored in the example).

### Previous approach

My changes add support for arbitrary height inputs by changing how bump-related shader code is generated. Previously, the bump node would take the GLSL code that any of the supported input nodes generated and then inject coordinate offsets into that code in order to sample the values four times around the current texture coordinates to calculate a new normal vector. The offset was hard-coded and caused a blurring of the output (see images below) due to not matching the offset of a single fragment, and taking four additional samples was not really necessary (it only needs two additional samples to get good results).

Screenshot from Blender (the example material uses two wave pattern textures mixed together):
![Blender screenshot](https://user-images.githubusercontent.com/17685000/231245628-d6c14aa7-0d36-4288-9e18-e8fc4afbabdc.png)

Screenshot from Armory, with PR changes:
![Armory screenshot (with PR changes)](https://user-images.githubusercontent.com/17685000/231247609-cb97e143-7ba1-4e06-9e09-5c32b28a0fec.png)

Screenshot from Armory, before this PR (only one wave texture taken into account for bump, also note the blurred look):
![Armory screnshot (without PR changes)](https://user-images.githubusercontent.com/17685000/231246289-d4cbf21b-7d45-40a3-a283-79bef39b5a4f.png)

Please ignore the seams in above pictures, they result from using badly tiled textures.

### New approach

The new approach works by evaluating the subtree connected to the "Height" input three times in what I called – for lack of a better name – "parser passes". There exist three passes: `REGULAR` (generate code to get the regular value of the tree) and `DX_SCREEN_SPACE`/`DY_SCREEN_SPACE` that instruct the nodes to output GLSL code that calculates the result of the subtree if the input coordinates are offset by a single fragment (= screen-space offset). By doing so, we dynamically adapt the distance between multiple samples to that of a fragment.

If the parser is in one of the `DX_SCREEN_SPACE`/`DY_SCREEN_SPACE` passes, it decides for each node whether the node's output might differ with respect to different fragments, and if that is the case, create new variables in the GLSL code with suffixes `_dx` and `_dy` and run the node's parsing function again. If the node generates code representing input values that vary between fragments (controlled via `ParserState.dxdy_varying_input_value`), Armory will compute screen-space offsets of the result and store them in the dx/dy variants. If a node does not need to be re-evaluated in the current shader pass, it will resort to the already parsed code of the `REGULAR` pass. So if you mix a bump map with a constant value (no matter how complex calculating this value is), the constant value will only be calculated once per fragment.

Once the passes are parsed, the bump node then manually calculates the screen-space derivatives for the height based on the pass outputs, and combines them with the screen-space derivatives of the fragment's world position to calculate new tangent/bitangent vectors that then are used to calculate the new normal vector. One could skip all this hassle and directly use `dFdx/dFdy` functionality for the height input, however, this leads to pretty pixelated outputs as even with the `dFdxFine/dFdyFine` variants (not available on all targets), the derivatives are calculated over a group of 1x2 pixels (also see https://github.com/armory3d/armory/pull/1952#issuecomment-716389033). So instead, we only take the screen-space derivatives of (usually) low-frequency values like the position or texture coordinates and calculate the height derivatives ourselves, this results in much better quality and this is also what Blender seems to do (see https://github.com/blender/blender/commit/ffd5e1e6acd296a187e7af016f9d7f8a9f209f87).

Generally, the output now pretty much looks like in Blender, although we use slightly simpler maths. Blender [does a bit more work to calculate the normals](https://github.com/blender/blender/blob/dd0cd1df1d1a5668ded98f4eca51021cbbccf97c/source/blender/gpu/shaders/material/gpu_shader_material_bump.glsl#L35-L43), and I don't really understand why it's needed (especially the determinant). Similar code can be found in [this paper](https://mmikk.github.io/papers3d/mm_sfgrad_bump.pdf), which seems to originate from the ShaderX5 article "Normal Mapping Without Precomputed Tangents" that is discussed [here](http://www.thetenthplanet.de/archives/1180). If anyone knows whether the current solution does not work correctly in some cases please let me know, but I think we're fine with the current approach and if there are any edge cases we will eventually find them :)

### Performance

In the best case, and presumably also the average case (e.g. `UV -> Image Texture -> Bump`), the new method is a little faster since we only need three instead of five total samples per fragment, but if the subtree that is connected to the "Height" input is *much more complex*, shader performance can become a problem. This should align with common sense that shader trees should be kept as simple as possible, and I will document this in the wiki once (and if) this PR gets merged.

---

The "passes" technique introduced in this PR might also help to solve another issue in the future ([problem description on Discord](https://discord.com/channels/486771218599510021/487613529990365184/999041327301922938) and related [Discord thread](https://discord.com/channels/486771218599510021/999349203765571614)) which happens if Armory is not able to infer tangent/bitangent vectors.

Thanks to Discord user @ Shakespeare for reporting this issue!