### PR TITLE
Fix collection spawning

### DIFF
--- a/Sources/armory/logicnode/SpawnCollectionNode.hx
+++ b/Sources/armory/logicnode/SpawnCollectionNode.hx
@@ -73,7 +73,6 @@ class SpawnCollectionNode extends LogicNode {
 						values: transform.toFloat32Array()
 					}
 				};
-				raw.objects.push(rawOwnerObject);
 
 				iron.Scene.active.createObject(rawOwnerObject, raw, null, null,
 					(created: Object) -> {

--- a/Sources/armory/logicnode/SpawnCollectionNode.hx
+++ b/Sources/armory/logicnode/SpawnCollectionNode.hx
@@ -1,6 +1,8 @@
 package armory.logicnode;
 
+import iron.data.Data;
 import iron.data.SceneFormat.TObj;
+import iron.data.SceneFormat.TSceneFormat;
 import iron.math.Mat4;
 import iron.object.Object;
 
@@ -8,6 +10,8 @@ class SpawnCollectionNode extends LogicNode {
 
 	/** Collection name **/
 	public var property0: Null<String>;
+	/** scene name **/
+	public var property1: Null<String>;
 
 	var topLevelObjects: Array<Object>;
 	var allObjects: Array<Object>;
@@ -22,10 +26,36 @@ class SpawnCollectionNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
-		var raw = iron.Scene.active.raw;
-
 		if (property0 == null) return;
 
+		//Raw scene not specified, using current active scene
+		if (property1 == "" || property1 == null) {
+			var raw = iron.Scene.active.raw;
+			spawnCollectionFromSceneRaw(raw);
+			return;
+		}
+
+		//Raw scene specified, using the given scene
+		var sceneFileName = property1;
+		#if arm_json
+		sceneFileName += ".json";
+		#elseif arm_compress
+		sceneFileName += ".lz4";
+		#end
+		Data.getSceneRaw(sceneFileName, spawnCollectionFromSceneRaw);
+		return;
+	}
+
+	override function get(from: Int): Dynamic {
+		switch (from) {
+			case 1: return topLevelObjects;
+			case 2: return allObjects;
+			case 3: return ownerObject;
+		}
+		return null;
+	}
+
+	function spawnCollectionFromSceneRaw(raw: TSceneFormat) {
 		// Check if the group exists
 		for (g in raw.groups) {
 			if (g.name == property0) {
@@ -57,14 +87,5 @@ class SpawnCollectionNode extends LogicNode {
 				return;
 			}
 		}
-	}
-
-	override function get(from: Int): Dynamic {
-		switch (from) {
-			case 1: return topLevelObjects;
-			case 2: return allObjects;
-			case 3: return ownerObject;
-		}
-		return null;
 	}
 }

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1870,14 +1870,7 @@ Make sure the mesh only has tris/quads.""")
             if bobject.parent is None or bobject.parent.name not in collection.objects:
                 asset_name = arm.utils.asset_name(bobject)
 
-                # Collection is in the same file
-                if collection.library is None:
-                    # Only export linked objects (from other scenes for example),
-                    # all other objects (in scene_objects) are already exported.
-                    if bobject.name not in scene_objects:
-                        self.process_bobject(bobject)
-                        self.export_object(bobject)
-                else:
+                if collection.library:
                     # Add external linked objects
                     # Iron differentiates objects based on their names,
                     # so errors will happen if two objects with the

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2424,7 +2424,8 @@ Make sure the mesh only has tris/quads.""")
                 if collection.name.startswith(('RigidBodyWorld', 'Trait|')):
                     continue
 
-                self.export_collection(collection)
+                if self.scene.user_of_id(collection):
+                    self.export_collection(collection)
 
         if not ArmoryExporter.option_mesh_only:
             if self.scene.camera is not None:

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2424,7 +2424,7 @@ Make sure the mesh only has tris/quads.""")
                 if collection.name.startswith(('RigidBodyWorld', 'Trait|')):
                     continue
 
-                if self.scene.user_of_id(collection):
+                if self.scene.user_of_id(collection) or collection.library:
                     self.export_collection(collection)
 
         if not ArmoryExporter.option_mesh_only:

--- a/blender/arm/logicnode/scene/LN_spawn_collection.py
+++ b/blender/arm/logicnode/scene/LN_spawn_collection.py
@@ -5,10 +5,13 @@ from arm.logicnode.arm_nodes import *
 
 class SpawnCollectionNode(ArmLogicTreeNode):
     """
-    Spawns a new instance of the selected collection. Each spawned instance
-    has an empty owner object to control the instance as a whole (like Blender
+    Spawns a new instance of the selected `collection` from the given `scene`. 
+    If the `scene` is empty or null, the current active scene is used. Each spawned 
+    instance has an empty owner object to control the instance as a whole (like Blender
     uses it for collection instances).
 
+    @input Scene: Scene in which the collection belongs.
+    @input Collection: Collection to be spawned.
     @input In: activates the node.
     @input Transform: the transformation of the instance that should be
         spawned. Please note that the collection's instance offset is
@@ -26,9 +29,14 @@ class SpawnCollectionNode(ArmLogicTreeNode):
     bl_idname = 'LNSpawnCollectionNode'
     bl_label = 'Spawn Collection'
     arm_section = 'collection'
-    arm_version = 1
+    arm_version = 2
 
     property0: HaxePointerProperty('property0', name='Collection', type=bpy.types.Collection)
+
+    property1: HaxePointerProperty(
+        'property1',
+        type=bpy.types.Scene, name='Scene',
+        description='The scene from which to take the object')
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
@@ -40,4 +48,11 @@ class SpawnCollectionNode(ArmLogicTreeNode):
         self.add_output('ArmNodeSocketObject', 'Owner Object')
 
     def draw_buttons(self, context, layout):
+        layout.prop_search(self, 'property1', bpy.data, "scenes")
         layout.prop_search(self, 'property0', bpy.data, 'collections', icon='NONE', text='')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement.Identity(self)


### PR DESCRIPTION
This PR requires: https://github.com/armory3d/iron/pull/190

This PR intends to solve the following issue with collection spawning:

1. Collections, when spawned from other scenes into the current scene had multiple instances of traits, which ideally should not be. This was because each collection was exported for each scene creating redundancies. Now, there still is a some redundancy, but each collection is exported only if used by the scene that is being exported.

2. The collections when spawned, added an instance of it also to the raw scene data. This meant that when the scene is reset, the collection instance is again spawned. This is fixed by not adding the collection to the raw data.

3. The spawn collection node now has a scene reference to spawn the collection from the given scene raw data. If the collection is not present in the specified scene, it is not spawned. If the scene is not specified, the current active scene raw data is used.

Thanks to @ MoritzBrueckner, @ Onek8 for their help in this and @ Shakespeare for pointing out the issue.