### PR TITLE
Fix normal vectors for instanced objects

### DIFF
--- a/blender/arm/material/make_depth.py
+++ b/blender/arm/material/make_depth.py
@@ -77,7 +77,7 @@ def make(context_id, rpasses, shadowmap=False):
             if(con_depth.is_elem('ipos')):
                 vert.write('wposition = vec4(W * spos).xyz;')
                 if(con_depth.is_elem('irot')):
-                    vert.write('wnormal = transpose(inverse(mirot)) * wnormal;')
+                    vert.write('wnormal = normalize(N * mirot * vec3(nor.xy, pos.w));')
             cycles.parse(mat_state.nodes, con_depth, vert, frag, geom, tesc, tese, parse_surface=False, parse_opacity=parse_opacity)
             if con_depth.is_elem('tex'):
                 vert.add_out('vec2 texCoord') ## vs only, remove out

--- a/blender/arm/material/make_inst.py
+++ b/blender/arm/material/make_inst.py
@@ -15,7 +15,7 @@ def inst_pos(con, vert):
         vert.write(');')
         vert.write('spos.xyz = mirot * spos.xyz;')
         if((con.data['name'] == 'mesh' or 'translucent') and vert.contains('wnormal')):
-            vert.write('wnormal = transpose(inverse(mirot)) * wnormal;')
+            vert.write('wnormal = normalize(N * mirot * vec3(nor.xy, pos.w));')
 
     if con.is_elem('iscl'):
         vert.write('spos.xyz *= iscl;')


### PR DESCRIPTION
The normals were computed incorrectly when instanced objects  had rotations. This PR fixes it.

Thanks to @ Shakespeare and @ projectBP  on Discord for reporting the issue and testing the changes.