### PR TITLE
Implement missing renderpath attributes for postprocessing logic nodes

### DIFF
--- a/Shaders/compositor_pass/compositor_pass.frag.glsl
+++ b/Shaders/compositor_pass/compositor_pass.frag.glsl
@@ -178,7 +178,7 @@ float vignette() {
 	#ifdef _CPostprocess
 		float uStrength = PPComp14.z;
 	#else
-		float uStrength = compoSharpenStrength;
+		float uStrength = compoVignetteStrength;
 	#endif
 	return (1.0 - uStrength) + uStrength * pow(16.0 * texCoord.x * texCoord.y * (1.0 - texCoord.x) * (1.0 - texCoord.y), 0.2);
 }

--- a/Shaders/compositor_pass/compositor_pass.frag.glsl
+++ b/Shaders/compositor_pass/compositor_pass.frag.glsl
@@ -175,7 +175,12 @@ vec4 LUTlookup(in vec4 textureColor, in sampler2D lookupTable) {
 
 #ifdef _CVignette
 float vignette() {
-	return (1.0 - compoVignetteStrength) + compoVignetteStrength * pow(16.0 * texCoord.x * texCoord.y * (1.0 - texCoord.x) * (1.0 - texCoord.y), 0.2);
+	#ifdef _CPostprocess
+		float uStrength = PPComp14.z;
+	#else
+		float uStrength = compoSharpenStrength;
+	#endif
+	return (1.0 - uStrength) + uStrength * pow(16.0 * texCoord.x * texCoord.y * (1.0 - texCoord.x) * (1.0 - texCoord.y), 0.2);
 }
 #endif
 
@@ -246,7 +251,6 @@ void main() {
 #endif
 
 #ifdef _CDistort
-	// const float compoDistortStrength = 4.0;
 	#ifdef _CPostprocess
 		float uStrength = PPComp14.x;
 	#else
@@ -336,12 +340,17 @@ void main() {
 #endif
 	
 #ifdef _CSharpen
+	#ifdef _CPostprocess
+		float uStrength = PPComp14.y;
+	#else
+		float uStrength = compoSharpenStrength;
+	#endif
 	vec3 col1 = textureLod(tex, texCo + vec2(-texStep.x, -texStep.y) * 1.5, 0.0).rgb;
 	vec3 col2 = textureLod(tex, texCo + vec2(texStep.x, -texStep.y) * 1.5, 0.0).rgb;
 	vec3 col3 = textureLod(tex, texCo + vec2(-texStep.x, texStep.y) * 1.5, 0.0).rgb;
 	vec3 col4 = textureLod(tex, texCo + vec2(texStep.x, texStep.y) * 1.5, 0.0).rgb;
 	vec3 colavg = (col1 + col2 + col3 + col4) * 0.25;
-	fragColor.rgb += (fragColor.rgb - colavg) * compoSharpenStrength;
+	fragColor.rgb += (fragColor.rgb - colavg) * uStrength;
 #endif
 
 #ifdef _CFog
@@ -372,7 +381,6 @@ void main() {
 #endif
 
 #ifdef _CGrain
-	// const float compoGrainStrength = 4.0;
 	float x = (texCo.x + 4.0) * (texCo.y + 4.0) * (time * 10.0);
 	#ifdef _CPostprocess
 		fragColor.rgb += vec3(mod((mod(x, 13.0) + 1.0) * (mod(x, 123.0) + 1.0), 0.01) - 0.005) * PPComp4.y;

--- a/Sources/armory/logicnode/CameraGetNode.hx
+++ b/Sources/armory/logicnode/CameraGetNode.hx
@@ -20,6 +20,8 @@ class CameraGetNode extends LogicNode {
 			case 9: armory.renderpath.Postprocess.camera_uniforms[9];//Tonemapping Method
 			case 10: armory.renderpath.Postprocess.camera_uniforms[10];//Distort
 			case 11: armory.renderpath.Postprocess.camera_uniforms[11];//Film Grain
+			case 12: armory.renderpath.Postprocess.camera_uniforms[12];//Sharpen
+			case 13: armory.renderpath.Postprocess.camera_uniforms[13];//Vignette
 			default: 0.0;
 		}
 	}

--- a/Sources/armory/logicnode/CameraSetNode.hx
+++ b/Sources/armory/logicnode/CameraSetNode.hx
@@ -19,6 +19,8 @@ class CameraSetNode extends LogicNode {
 		armory.renderpath.Postprocess.camera_uniforms[9] = inputs[10].get();//Tonemapping Method
 		armory.renderpath.Postprocess.camera_uniforms[10] = inputs[11].get();//Distort
 		armory.renderpath.Postprocess.camera_uniforms[11] = inputs[12].get();//Film Grain
+		armory.renderpath.Postprocess.camera_uniforms[12] = inputs[13].get();//Sharpen
+		armory.renderpath.Postprocess.camera_uniforms[13] = inputs[14].get();//Vignette
 
 		runOutput(0);
 	}

--- a/Sources/armory/renderpath/Postprocess.hx
+++ b/Sources/armory/renderpath/Postprocess.hx
@@ -53,7 +53,9 @@ class Postprocess {
 		128,				//8: DoF F-Stop
 		0,					//9: Tonemapping Method
 		2.0,				//10: Distort
-		2.0					//11: Film Grain
+		2.0,				//11: Film Grain
+		0.25,				//12: Sharpen
+		0.7					//13: Vignette
 	];
 
 	public static var tonemapper_uniforms = [
@@ -305,8 +307,8 @@ class Postprocess {
 		case "_PPComp14":
 			v = iron.object.Uniforms.helpVec;
 			v.x = camera_uniforms[10]; //Distort
-			v.y = 0;
-			v.z = 0;
+			v.y = camera_uniforms[12]; //Sharpen
+			v.z = camera_uniforms[13]; //Vignette
 		}
 
 		return v;

--- a/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
+++ b/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
@@ -4,7 +4,7 @@ class CameraGetNode(ArmLogicTreeNode):
     """Returns the post-processing effects of a camera."""
     bl_idname = 'LNCameraGetNode'
     bl_label = 'Get Camera Post Process'
-    arm_version = 3
+    arm_version = 4
 
     def arm_init(self, context):
         self.add_output('ArmFloatSocket', 'F-Stop')#0
@@ -19,9 +19,11 @@ class CameraGetNode(ArmLogicTreeNode):
         self.add_output('ArmBoolSocket', 'Tonemapping')#9
         self.add_output('ArmFloatSocket', 'Distort')#10
         self.add_output('ArmFloatSocket', 'Film Grain')#11
+        self.add_output('ArmFloatSocket', 'Sharpen')#12
+        self.add_output('ArmFloatSocket', 'Vignette')#13
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 2):
+        if self.arm_version not in (0, 3):
             raise LookupError()
             
         return NodeReplacement.Identity(self)

--- a/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
+++ b/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
@@ -4,7 +4,7 @@ class CameraSetNode(ArmLogicTreeNode):
     """Set the post-processing effects of a camera."""
     bl_idname = 'LNCameraSetNode'
     bl_label = 'Set Camera Post Process'
-    arm_version = 3
+    arm_version = 4
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
@@ -20,16 +20,20 @@ class CameraSetNode(ArmLogicTreeNode):
         self.add_input('ArmBoolSocket', 'Tonemapping', default_value=False)#9
         self.add_input('ArmFloatSocket', 'Distort', default_value=2.0)#10
         self.add_input('ArmFloatSocket', 'Film Grain', default_value=2.0)#11
+        self.add_input('ArmFloatSocket', 'Sharpen', default_value=0.25)#12
+        self.add_input('ArmFloatSocket', 'Vignette', default_value=0.7)#13
 
         self.add_output('ArmNodeSocketAction', 'Out')
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 2):
+        if self.arm_version not in range(0, 4):
             raise LookupError()
+        elif self.arm_version == 1:
+            newnode = node_tree.nodes.new('LNCameraSetNode')
 
-        newnode = node_tree.nodes.new('LNCameraSetNode')
+            for link in self.inputs[10].links:
+                node_tree.links.new(newnode.inputs[10], link.to_socket)
 
-        for link in self.inputs[10].links:
-            node_tree.links.new(newnode.inputs[10], link.to_socket)
-
-        return newnode
+            return newnode
+        else:
+            return NodeReplacement.Identity(self)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1914,10 +1914,10 @@ class ARM_PT_RenderPathCompositorPanel(bpy.types.Panel):
         layout.separator()
 
         col = layout.column()
-        draw_conditional_prop(col, 'Sharpen', rpdat, 'arm_sharpen', 'arm_sharpen_strength')
-        draw_conditional_prop(col, 'Vignette', rpdat, 'arm_vignette', 'arm_vignette_strength')
         draw_conditional_prop(col, 'Distort', rpdat, 'arm_distort', 'arm_distort_strength')
         draw_conditional_prop(col, 'Film Grain', rpdat, 'arm_grain', 'arm_grain_strength')
+        draw_conditional_prop(col, 'Sharpen', rpdat, 'arm_sharpen', 'arm_sharpen_strength')
+        draw_conditional_prop(col, 'Vignette', rpdat, 'arm_vignette', 'arm_vignette_strength')
         layout.separator()
 
         col = layout.column()


### PR DESCRIPTION
### TL;TR

For some reason, Shapren and Vignette attributes were never exposed/implemented with the get/set postprocessing logic nodes. This PR implements them.

### Changelog

`props_ui.py` | Matched alphabetical order.

`LN_get_camera_post_process.py` | Added new ***Sharpen*** and ***Vignette*** attributes.

`LN_set_camera_post_process.py` | Added new ***Sharpen*** and ***Vignette*** attributes.

`Postprocess.hx` | Added new ***Sharpen*** and ***Vignette*** attributes.

`CameraGetNode.hx` | Added new ***Sharpen*** and ***Vignette*** get returns.

`CameraSetNode.hx` | Added new ***Sharpen*** and ***Vignette*** set returns.

`compositor_pass.glsl` | Added realtime postprocessing features to ***Sharpen*** and ***Vignette*** code + removed unused/commented code.

### Special thanks

Special thanks to @ MoritzBrueckner for review and insightful help!