### PR TITLE
Fix performance issue when creating zoo collection for correct modifier export

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -165,13 +165,15 @@ def export_data(fp, sdk_path):
     # have a "zoo" collection in the current scene
     export_coll = bpy.data.collections.new("export_coll")
     bpy.context.scene.collection.children.link(export_coll)
+    export_coll_names = set(export_coll.all_objects.keys())
     for scene in bpy.data.scenes:
         if scene == bpy.context.scene:
             continue
         for o in scene.collection.all_objects:
             if o.type in ('MESH', 'EMPTY'):
-                if o.name not in  export_coll.all_objects.keys():
+                if o.name not in export_coll_names:
                     export_coll.objects.link(o)
+                    export_coll_names.add(o.name)
     depsgraph = bpy.context.evaluated_depsgraph_get()
     bpy.data.collections.remove(export_coll) # destroy "zoo" collection
 

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -162,7 +162,11 @@ def export_data(fp, sdk_path):
     ArmoryExporter.optimize_enabled = state.is_publish and wrd.arm_optimize_data
     if not os.path.exists(build_dir + '/compiled/Assets'):
         os.makedirs(build_dir + '/compiled/Assets')
-    # have a "zoo" collection in the current scene
+
+    # Make all 'MESH' and 'EMPTY' objects visible to the depsgraph (we pass
+    # this to the exporter further below) with a temporary "zoo" collection
+    # in the current scene. We do this to ensure that (among other things)
+    # modifiers are applied to all exported objects.
     export_coll = bpy.data.collections.new("export_coll")
     bpy.context.scene.collection.children.link(export_coll)
     export_coll_names = set(export_coll.all_objects.keys())
@@ -175,7 +179,7 @@ def export_data(fp, sdk_path):
                     export_coll.objects.link(o)
                     export_coll_names.add(o.name)
     depsgraph = bpy.context.evaluated_depsgraph_get()
-    bpy.data.collections.remove(export_coll) # destroy "zoo" collection
+    bpy.data.collections.remove(export_coll)  # Destroy the "zoo" collection
 
     for scene in bpy.data.scenes:
         if scene.arm_export:


### PR DESCRIPTION
This PR fixes a performance issue that would happen in projects with scenes that have thousands of objects. Armory adds all mesh and empty objects to a temporary collection to make them visible to the depsgraph in order to apply modifiers (see https://github.com/armory3d/armory/pull/1498), but the code had at least quadratic complexity due to—for each object—calling `export_coll.all_objects.keys()` and iterating through the result (list). By using a _set_ of object names that we manually update, the complexity should be linear now.

The following profiler screenshot shows the impact of the fixed issue in a file with ~3800 objects (I had to force a single-threaded build to show everything in the profiler results):
![Profiler screenshot](https://user-images.githubusercontent.com/17685000/233859752-b9a2dde7-95b3-4c92-ae18-2701de9c8531.png)

I guess the current approach of using a Zoo collection is still somewhat slow in complex scenes due to linking many objects, but I currently have no idea how to further improve this.

Thanks to Discord user @ Shakespeare for reporting this issue and for providing a test file :)