### PR TITLE
Improve compilation warnings

### DIFF
--- a/blender/arm/assets.py
+++ b/blender/arm/assets.py
@@ -66,7 +66,6 @@ def add(asset_file):
     for f in assets:
         f_file_base = os.path.basename(f)
         if f_file_base == asset_file_base:
-            log.warn(f'Asset name "{asset_file_base}" already exists, skipping')
             return
 
     assets.append(asset_file)

--- a/blender/arm/node_utils.py
+++ b/blender/arm/node_utils.py
@@ -140,8 +140,7 @@ def get_export_tree_name(tree: bpy.types.NodeTree, do_warn=False) -> str:
     export_name = arm.utils.safesrc(tree.name[0].upper() + tree.name[1:])
 
     if export_name != tree.name:
-        arm.log.warn('Logic node tree and generated trait names differ! Node'
-                     f' tree: "{tree.name}", trait: "{export_name}"')
+        arm.log.warn(f'The logic node tree "{tree.name}" had to be temporarily renamed to "{export_name}" on export due to Haxe limitations. Referencing the corresponding trait by its logic node tree name may not work as expected.')
 
     return export_name
 


### PR DESCRIPTION
### TL;TR

There are currently two compilation warnings that are rather confusing to Armory newcomers. The warnings also made early debugging for community members difficult, as the warnings outputted false-positives or misleading text for the newcomer.

### Changelog

`assets.py` - Remove the confusing log entirely.

`node_utils.py` - Improve wording of compilation warning.

### Preview

![image](https://user-images.githubusercontent.com/69180012/234423130-c9507f3b-dcc4-4383-82ff-a43be906ef73.png)

### Other

Special thanks to @ MoritzBrueckner for suggestions and review.