### PR TITLE
Improve and fix handling of tree variables

### DIFF
--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -299,7 +299,7 @@ class ArmLogicTreeNode(bpy.types.Node):
 
     def change_input_socket(self, socket_type: str, socket_index: int, socket_name: str, default_value: Any = None, is_var: bool = False) -> bpy.types.NodeSocket:
         """Change an input socket type retaining the previous socket links
-        
+
         If `is_var` is true, a dot is placed inside the socket to denote
         that this socket can be used for variable access (see
         SetVariable node).
@@ -321,7 +321,7 @@ class ArmLogicTreeNode(bpy.types.Node):
 
     def change_output_socket(self, socket_type: str, socket_index: int, socket_name: str, default_value: Any = None, is_var: bool = False) -> bpy.types.NodeSocket:
         """Change an output socket type retaining the previous socket links
-        
+
         If `is_var` is true, a dot is placed inside the socket to denote
         that this socket can be used for variable access (see
         SetVariable node).

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -427,18 +427,37 @@ class ArmLogicVariableNodeMixin(ArmLogicTreeNode):
 
             self.is_master_node = False  # Ignore this node in get_master_node below
             if self.__class__.get_master_node(target_tree, self.arm_logic_id) is None:
-                var_item = lst.add()
-                var_item['_name'] = arm.utils.unique_str_for_list(
-                    items=lst, name_attr='name', wanted_name=self.arm_logic_id, ignore_item=var_item
-                )
-                var_item.node_type = self.bl_idname
-                var_item.color = arm.utils.get_random_color_rgb()
 
-                target_tree.arm_treevariableslist_index = len(lst) - 1
-                arm.make_state.redraw_ui = True
+                # copy() is not only called when manually copying/pasting
+                # nodes, but also when duplicating logic trees.
+                # In that case, Blender duplicates the arm_treevariableslist
+                # property, so all tree variables already exist before
+                # adding a single node to the new tree. In turn, each
+                # tree variable exists without a master node before
+                # the first node referencing that variable is copied over
+                # to the new tree.
+                # For this reason, despite having no master node, we need
+                # to check whether the tree variable already exists.
+                target_tree_has_variable = False
+                for item in lst:
+                    if item.name == self.arm_logic_id:
+                        target_tree_has_variable = True
+                        break
+
+                if not target_tree_has_variable:
+                    var_item = lst.add()
+                    var_item['_name'] = arm.utils.unique_name_in_lists(
+                        item_lists=[lst], name_attr='name', wanted_name=self.arm_logic_id, ignore_item=var_item
+                    )
+                    var_item.node_type = self.bl_idname
+                    var_item.color = arm.utils.get_random_color_rgb()
+
+                    target_tree.arm_treevariableslist_index = len(lst) - 1
+                    arm.make_state.redraw_ui = True
 
                 self.is_master_node = True
             else:
+                # Use existing variable
                 for item in lst:
                     if item.name == self.arm_logic_id:
                         self.color = item.color

--- a/blender/arm/logicnode/tree_variables.py
+++ b/blender/arm/logicnode/tree_variables.py
@@ -357,7 +357,7 @@ class ARM_PG_TreeVarListItem(bpy.types.PropertyGroup):
             # Don't allow empty variable names
             new_name = old_name
         else:
-            new_name = arm.utils.unique_str_for_list(items=lst, name_attr='name', wanted_name=value, ignore_item=self)
+            new_name = arm.utils.unique_name_in_lists(item_lists=[lst], name_attr='name', wanted_name=value, ignore_item=self)
 
         self['_name'] = new_name
 
@@ -409,8 +409,8 @@ class ARM_PG_TreeVarListItem(bpy.types.PropertyGroup):
         lst = tree.arm_treevariableslist
 
         var_item: ARM_PG_TreeVarListItem = lst.add()
-        var_item['_name'] = arm.utils.unique_str_for_list(
-            items=lst, name_attr='name', wanted_name=item_name, ignore_item=var_item
+        var_item['_name'] = arm.utils.unique_name_in_lists(
+            item_lists=[lst], name_attr='name', wanted_name=item_name, ignore_item=var_item
         )
         var_item.node_type = item_type
         var_item.color = arm.utils.get_random_color_rgb()

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -2690,6 +2690,23 @@ def draw_error_box(layout: bpy.types.UILayout, text: str) -> bpy.types.UILayout:
 
     return box
 
+
+def draw_multiline_with_icon(layout: bpy.types.UILayout, layout_width_px: int, icon: str, text: str) -> bpy.types.UILayout:
+    """Draw a multiline string with an icon in the given UILayout
+    and return it for further optional modification.
+    The text is wrapped according to the given layout width.
+    """
+    textwrap_width = max(0, layout_width_px // 6)
+    lines = textwrap.wrap(text, width=textwrap_width, break_long_words=True)
+
+    col = layout.column(align=True)
+    col.scale_y = 0.8
+    for idx, line in enumerate(lines):
+        col.label(text=line, icon=icon if idx == 0 else 'BLANK1')
+
+    return col
+
+
 def register():
     bpy.utils.register_class(ARM_PT_ObjectPropsPanel)
     bpy.utils.register_class(ARM_PT_ModifiersPropsPanel)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1391,7 +1391,7 @@ class ARM_PT_TopbarPanel(bpy.types.Panel):
     bl_options = {'INSTANCED'}
 
     def draw_header(self, context):
-        row = self.layout.row(align=True)                
+        row = self.layout.row(align=True)
         if state.proc_play is None and state.proc_build is None:
             row.operator("arm.play", icon="PLAY", text="")
         else:
@@ -1405,7 +1405,7 @@ class ARM_PT_TopbarPanel(bpy.types.Panel):
 
         col.label(text="Armory Launch")
         col.separator()
-        
+
         col.prop(wrd, 'arm_runtime')
         col.prop(wrd, 'arm_play_camera')
         col.prop(wrd, 'arm_play_scene')
@@ -2350,7 +2350,7 @@ class ARM_OT_CopyToBundled(bpy.types.Operator):
                                 print(log.colorize(f'Asset name "{asset.name}" already exists, overriding the original', 33), file=sys.stderr)
                             # Invalid file or corrupted
                             else:
-                                # Syntax - Red 
+                                # Syntax - Red
                                 log.error(f'Asset name "{asset.name}" has no data to save or copy, skipping')
                                 continue
                         # Override -> No
@@ -2673,6 +2673,7 @@ def draw_conditional_prop(layout: bpy.types.UILayout, heading: str, data: bpy.ty
     sub = row.row()
     sub.enabled = getattr(data, prop_condition)
     sub.prop(data, prop_value, expand=True)
+
 
 def draw_error_box(layout: bpy.types.UILayout, text: str) -> bpy.types.UILayout:
     """Draw an error box in the given UILayout and return it for

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -1,5 +1,6 @@
 from enum import Enum, unique
 import glob
+import itertools
 import json
 import locale
 import os
@@ -9,7 +10,7 @@ import re
 import shlex
 import shutil
 import subprocess
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 import webbrowser
 
 import numpy as np
@@ -652,12 +653,12 @@ def color_to_int(val) -> int:
     return (int(val[3] * 255) << 24) + (int(val[0] * 255) << 16) + (int(val[1] * 255) << 8) + int(val[2] * 255)
 
 
-def unique_str_for_list(items: list, name_attr: str, wanted_name: str, ignore_item: Optional[Any] = None) -> str:
-    """Creates a unique name that no item in the given list already has.
+def unique_name_in_lists(item_lists: Iterable[list], name_attr: str, wanted_name: str, ignore_item: Optional[Any] = None) -> str:
+    """Creates a unique name that no item in the given lists already has.
     The format follows Blender's behaviour when handling duplicate
     object names.
 
-    @param items The list of items (any type).
+    @param item_lists An iterable of item lists (any type).
     @param name_attr The attribute of the items that holds the name.
     @param wanted_name The name that should be preferably returned, if
         no name collision occurs.
@@ -665,7 +666,7 @@ def unique_str_for_list(items: list, name_attr: str, wanted_name: str, ignore_it
         comparing names.
     """
     def _has_collision(name: str) -> bool:
-        for item in items:
+        for item in itertools.chain(*item_lists):
             if item == ignore_item:
                 continue
             if getattr(item, name_attr) == name:


### PR DESCRIPTION
This PR fixes/improves two issues reported by @ QuantumCoderQC on Discord:

- There was an error after duplicating a node tree with tree variables: When duplicating a node tree, Blender copies the original tree variable for which no master node exists in the copy and then calls `ArmLogicVariableNodeMixin.copy()` for each node. Because there is no master node in the copied tree, the previous implementation of `copy()` then assumed that the variable doesn't exist and in turn created a new variable without any node assigned to it (the copied nodes were still correctly assigned to the original variable copied by Blender).

   Now, there is a check in place whether the variable already exists. If so, we simply add the copied node to the existing variable, just like before if a node was copied normally between trees.

- While discussing the first issue with @ QC, we came to the conclusion that we should explicitly handle tree variable naming conflicts when ungrouping logic node groups since implicit merging of variables might not be wanted by the user in all cases (even if conflicts are pretty rare). Now, when there are naming conflicts when ungrouping a node group, a popup is displayed to the user in which they can then choose if a conflicting variable in the group tree should automatically be renamed to `<GroupName>.<VariableName>` (incl. accounting for potential conflicts of the renamed variable) or whether the variable should be merged with its counterpart in the enclosing tree:

   ![Screenshot: variable conflict popup](https://user-images.githubusercontent.com/17685000/235232854-35951de6-1629-49ca-a0d7-f85c758b4fc5.png)

Ideally there would be unit tests for some of the above things as there are a bunch of potential edge cases, I hope I found all of them while testing the changes. @ luboslenco In case I (or someone else) would like to add some Python unit tests for important or error-prone behaviour in the future, would it be ok if those were added to a folder in the armory repo? I know that there is an armory_ci repo, but to me this looks like a single project for build testing, and we should probably version unit tests along with the corresponding code.