### PR TITLE
Fix get letterbox size return value

### DIFF
--- a/Sources/armory/logicnode/LetterboxGetNode.hx
+++ b/Sources/armory/logicnode/LetterboxGetNode.hx
@@ -9,7 +9,7 @@ class LetterboxGetNode extends LogicNode {
 	override function get(from:Int):Dynamic {
 		return switch (from) {
 			case 0: armory.renderpath.Postprocess.letterbox_uniforms[0];
-			case 1: armory.renderpath.Postprocess.letterbox_uniforms[1];
+			case 1: armory.renderpath.Postprocess.letterbox_uniforms[1][0];
 			default: 0.0;
 		}
 	}

--- a/blender/arm/logicnode/postprocess/LN_set_letterbox_settings.py
+++ b/blender/arm/logicnode/postprocess/LN_set_letterbox_settings.py
@@ -4,11 +4,17 @@ class LetterboxSetNode(ArmLogicTreeNode):
     """Set the letterbox post-processing settings."""
     bl_idname = 'LNLetterboxSetNode'
     bl_label = 'Set Letterbox Settings'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
-        self.add_input('ArmColorSocket', 'Color', default_value=[0.0, 0.0, 0.0, 0.0])
+        self.add_input('ArmColorSocket', 'Color', default_value=[0.0, 0.0, 0.0, 1.0])
         self.add_input('ArmFloatSocket', 'Size', default_value=0.1)
 
         self.add_output('ArmNodeSocketAction', 'Out')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement.Identity(self)


### PR DESCRIPTION
My mistake that I did not catch this earlier.

<hr />

`Get Letterbox Settings` (Haxe)

Special thanks to @ Armory-Community-Channel for reporting the problem and to @ QuantumCoderQC for pointing out the incorrect return value (currently returns an array float when it should return a float)

<hr />

`Set Letterbox Settings` (Python)

While not important because the alpha value is never used, I set the default alpha value to `1.0` for the visual side of the set letterbox settings node, otherwise it looks a bit weird in Blender e.g.

![image](https://user-images.githubusercontent.com/69180012/236345487-b45ea9f5-42f2-44cc-91fc-ca66ee2b05da.png)