### PR TITLE
Fix runtime exception when non-camera object is used as scene camera

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2473,6 +2473,14 @@ Make sure the mesh only has tris/quads.""")
             self.create_default_camera(is_viewport_camera=True)
             self.camera_spawned = True
 
+        elif self.scene.camera is not None and self.scene.camera.type != 'CAMERA':
+            # Blender doesn't directly allow to set arbitrary objects as cameras,
+            # but there is a `Set Active Object as Camera` operator which might
+            # cause cases like this to happen
+            log.warn(f'Camera "{self.scene.camera.name}" in scene "{self.scene.name}" is not a camera object, using default camera')
+            self.create_default_camera()
+            self.camera_spawned = True
+
         # No camera found
         if not self.camera_spawned:
             log.warn( f'Scene "{self.scene.name}" is missing a camera')


### PR DESCRIPTION
In some rare cases it can happen that the scene camera isn't actually a camera object, previously causing exceptions at runtime such as
```
Trace: TypeError: Cannot read property 'V' of null
    at Function.setObjectConstant (<anonymous>:24561:21)
    at Function.setObjectConstants (<anonymous>:22348:26)
    at iron_object_MeshObject.render (<anonymous>:20167:25)
    at iron_RenderPath.submitDraw (<anonymous>:8570:6)
    at iron_RenderPath.drawMeshes (<anonymous>:8530:9)
    at Function.drawMeshes (<anonymous>:1668:45)
    at Function.commands (<anonymous>:1755:39)
    at iron_RenderPath.armory_renderpath_RenderPathCreator.path.commands (<anonymous>:1838:41)
    at iron_RenderPath.renderFrame (<anonymous>:8317:8)
    at iron_Scene.renderFrame (<anonymous>:9234:27)
```
(trying to access `camera.V` with `camera == null` here)

Thanks to @ Miggli on Discord for reporting this :)