### PR TITLE
Fix new RP items

### DIFF
--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -45,9 +45,8 @@ def update_point_atlas_size_options(scene: bpy.types.Scene, context: bpy.types.C
 
 
 def update_preset(self, context):
-    rpdat = arm.utils.get_rp()
-    if rpdat is None:
-        rpdat = self.arm_rplist[-1]
+    rpdat = self.arm_rplist[-1]
+
     if self.rp_preset == 'Desktop':
         rpdat.rp_renderer = 'Deferred'
         rpdat.arm_material_model = 'Full'


### PR DESCRIPTION
### TL;TR
Initially, I had attempted to fix the bug here: #2716. And while it _does_ fix new RP items if the Armory Player RenderPath data-block was _invalid_ or _empty_, it apparently is still broken for _valid_ RenderPath items.

### Old bug that was fixed in #2716
The bug happened when the Armory Player RenderPath data-block was invalid.

https://github.com/armory3d/armory/assets/69180012/01f448e0-c18e-463c-b5bb-754e6dad6e6f

### Current/unfixed bug
The bug still happens when the Armory Player RenderPath data-block is valid.

https://github.com/armory3d/armory/assets/69180012/1c09e2cd-3d6a-44bf-9b9e-d6627bc873bc

Special thanks to @ MoritzBrueckner for code review.