### PR TITLE
Fix potential division by zero in GGX normal distribution function

### DIFF
--- a/Shaders/std/brdf.glsl
+++ b/Shaders/std/brdf.glsl
@@ -29,7 +29,8 @@ float g2_approx(const float NdotL, const float NdotV, const float alpha)
 
 float d_ggx(const float nh, const float a) {
 	float a2 = a * a;
-	float denom = pow(nh * nh * (a2 - 1.0) + 1.0, 2.0);
+	float denom = nh * nh * (a2 - 1.0) + 1.0;
+	denom = max(denom * denom, 0.00006103515625 /* 2^-14 = smallest possible half float value, prevent div by zero */);
 	return a2 * (1.0 / 3.1415926535) / denom;
 }
 


### PR DESCRIPTION
This PR fixes a long-standing issue with NaN fragments that would happen with roughness values of 0 (or values close to that due to float precision) at some viewing angles relative to the light direction. While this wasn't really problematic in most cases, the bloom effect made the NaN values visible as white screen flickering like mentioned in https://github.com/armory3d/armory/pull/2725 (check the [render_bloom](https://github.com/armory3d/armory_examples/tree/master/render_bloom) example).

Some technical details, to whom it may interest:

From a mathematical point of view the division by zero is a consequence of narrowing the distribution function representing the specular dot until it is infinitesimally small and infinitely large (dirac delta). If the roughness approaches zero, the specular dot becomes infinitely bright but you can only see it if you're perfectly aligned with the light reflection.

Some GGX implementations simply clamp the roughness values, however, since the roughness is effectively raised to the 4th power, the minimum value needs to be quite high ([0.089 for half float precision](https://google.github.io/filament/Filament.html#roughnessremappingandclamping)) which in my experiments didn't look good anymore. So instead I cheated a little by only clamping the denominator that's causing the division by zero to the smallest half float value, which is equivalent to clamping the maximum brightness of the specular dot to 16384. Technically this isn't energy conserving anymore, but i doubt that it matters at all in this case and you need to be quite lucky anyways to see one of those pixels that would previously have NaN values :)

It's surprising how little information you can find about this issue (and how many implementations seemingly don't consider it at all), but I guess that in many situations one simply doesn't need to care about this...

While doing research for this PR I found two very helpful tools, maybe they're useful to someone else as well:
- https://oletus.github.io/float16-simulator.js/
- https://evanw.github.io/float-toy/