### PR TITLE
Fix compilation of draw nodes if "Zui" setting is set to "Auto"

### DIFF
--- a/Sources/armory/logicnode/DrawArcNode.hx
+++ b/Sources/armory/logicnode/DrawArcNode.hx
@@ -3,7 +3,9 @@ package armory.logicnode;
 import kha.Color;
 import armory.renderpath.RenderToTexture;
 
+#if arm_ui
 using zui.GraphicsExtension;
+#end
 
 class DrawArcNode extends LogicNode {
 
@@ -12,6 +14,7 @@ class DrawArcNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
+		#if arm_ui
 		RenderToTexture.ensure2DContext("DrawArcNode");
 
 		final colorVec = inputs[1].get();
@@ -30,6 +33,7 @@ class DrawArcNode extends LogicNode {
 		} else {
 			RenderToTexture.g.drawArc(cx, cy, radius, sAngle, eAngle, inputs[3].get(), ccw, segments);
 		}
+		#end
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/DrawCircleNode.hx
+++ b/Sources/armory/logicnode/DrawCircleNode.hx
@@ -3,7 +3,9 @@ package armory.logicnode;
 import kha.Color;
 import armory.renderpath.RenderToTexture;
 
+#if arm_ui
 using zui.GraphicsExtension;
+#end
 
 class DrawCircleNode extends LogicNode {
 
@@ -12,6 +14,7 @@ class DrawCircleNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
+		#if arm_ui
 		RenderToTexture.ensure2DContext("DrawCircleNode");
 
 		final colorVec = inputs[1].get();
@@ -28,6 +31,7 @@ class DrawCircleNode extends LogicNode {
 		else {
 			RenderToTexture.g.drawCircle(cx, cy, radius, inputs[3].get(), segments);
 		}
+		#end
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/DrawCurveNode.hx
+++ b/Sources/armory/logicnode/DrawCurveNode.hx
@@ -3,7 +3,9 @@ package armory.logicnode;
 import kha.Color;
 import armory.renderpath.RenderToTexture;
 
+#if arm_ui
 using zui.GraphicsExtension;
+#end
 
 class DrawCurveNode extends LogicNode {
 
@@ -12,6 +14,7 @@ class DrawCurveNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
+		#if arm_ui
 		RenderToTexture.ensure2DContext("DrawCurveNode");
 
 		final colorVec = inputs[1].get();
@@ -22,6 +25,7 @@ class DrawCurveNode extends LogicNode {
 			[inputs[5].get(), inputs[7].get(), inputs[9].get(), inputs[11].get()],
 			inputs[3].get(), inputs[2].get()
 		);
+		#end
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/DrawEllipseNode.hx
+++ b/Sources/armory/logicnode/DrawEllipseNode.hx
@@ -4,7 +4,9 @@ import iron.math.Vec4;
 import kha.Color;
 import armory.renderpath.RenderToTexture;
 
+#if arm_ui
 using zui.GraphicsExtension;
+#end
 
 class DrawEllipseNode extends LogicNode {
 
@@ -13,6 +15,7 @@ class DrawEllipseNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
+		#if arm_ui
 		RenderToTexture.ensure2DContext("DrawEllipseNode");
 
 		final colorVec: Vec4 = inputs[1].get();
@@ -41,6 +44,7 @@ class DrawEllipseNode extends LogicNode {
 
 		RenderToTexture.g.rotate(-angle, cx, cy);
 		RenderToTexture.g.scale(1.0, scaleInv);
+		#end
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/DrawPolygonNode.hx
+++ b/Sources/armory/logicnode/DrawPolygonNode.hx
@@ -4,7 +4,9 @@ import kha.Color;
 import kha.math.Vector2;
 import armory.renderpath.RenderToTexture;
 
+#if arm_ui
 using zui.GraphicsExtension;
+#end
 
 class DrawPolygonNode extends LogicNode {
 	static inline var numStaticInputs = 6;
@@ -16,6 +18,7 @@ class DrawPolygonNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
+		#if arm_ui
 		RenderToTexture.ensure2DContext("DrawPolygonNode");
 
 		if (vertices == null) {
@@ -43,6 +46,7 @@ class DrawPolygonNode extends LogicNode {
 		} else {
 			RenderToTexture.g.drawPolygon(inputs[4].get(), inputs[5].get(), vertices, inputs[3].get());
 		}
+		#end
 
 		runOutput(0);
 	}

--- a/Sources/armory/logicnode/DrawTextAreaStringNode.hx
+++ b/Sources/armory/logicnode/DrawTextAreaStringNode.hx
@@ -7,10 +7,10 @@ import armory.renderpath.RenderToTexture;
 import kha.graphics2.VerTextAlignment;
 import kha.graphics2.HorTextAlignment;
 
-using zui.GraphicsExtension;
-
 #if arm_ui
 import armory.ui.Canvas;
+
+using zui.GraphicsExtension;
 #end
 
 class DrawTextAreaStringNode extends LogicNode {
@@ -29,6 +29,7 @@ class DrawTextAreaStringNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
+		#if arm_ui
 		RenderToTexture.ensure2DContext("DrawTextAreaStringNode");
 
 		var string:String = Std.string(inputs[1].get());
@@ -124,6 +125,7 @@ class DrawTextAreaStringNode extends LogicNode {
 			++index;
 
 		}
+		#end
 
 		runOutput(0);
 	}

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -208,8 +208,11 @@ def export_data(fp, sdk_path):
     if network_found == False:
         export_network = False
 
-    if wrd.arm_ui == 'Enabled':
-        export_ui = True
+    # Ugly workaround: some logic nodes require Zui code even if no UI is used,
+    # for now enable UI export unless explicitly disabled.
+    export_ui = True
+    if wrd.arm_ui == 'Disabled':
+        export_ui = False
 
     if wrd.arm_network == 'Enabled':
         export_network = True


### PR DESCRIPTION
This PR fixes compilation of the draw nodes that use the GraphicsExtension class if Zui export is set to "Auto". It is more of a last-minute workaround for SDK 23.06 than a proper fix, so we should revisit this in the future and either remove the "Auto" setting (simple solution but this would always export the default font, code-wise DCE will take care of not increasing the output size too much) or maybe implement an export callback for each node such that a node could register its need for Zui classes.

@ luboslenco do you have any preference regarding a proper solution?