### PR TITLE
Fix Material Batching

### DIFF
--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -588,6 +588,8 @@ class ArmoryExporter:
             # Tilesheets
             elif bobject.arm_tilesheet != '':
                 variant_suffix = '_armtile'
+            elif arm.utils.export_morph_targets(bobject):
+                variant_suffix = '_armskey'
 
             if variant_suffix == '':
                 continue


### PR DESCRIPTION
Fixes #2887 

Add two new flags for skinned mesh and mesh with shape keys(morph targets). Also adds a material variant suffix for materials with shape keys.

Requires https://github.com/armory3d/iron/pull/193