### PR TITLE
SoftBody physics overhaul

### DIFF
--- a/Sources/armory/trait/physics/bullet/PhysicsHook.hx
+++ b/Sources/armory/trait/physics/bullet/PhysicsHook.hx
@@ -92,17 +92,15 @@ class PhysicsHook extends Trait {
 
 			#if js
 			var nodes = sb.body.get_m_nodes();
-			#elseif cpp
+			#else
 			var nodes = sb.body.m_nodes;
 			#end
 
-			var geom = cast(object, MeshObject).data.geom;
-			var numNodes = Std.int(geom.positions.values.length / 4);
-			for (i in 0...numNodes) {
+			for (i in 0...nodes.size()) {
 				var node = nodes.at(i);
 				#if js
 				var nodePos = node.get_m_x();
-				#elseif cpp
+				#else
 				var nodePos = node.m_x;
 				#end
 

--- a/Sources/armory/trait/physics/bullet/SoftBody.hx
+++ b/Sources/armory/trait/physics/bullet/SoftBody.hx
@@ -51,9 +51,10 @@ class SoftBody extends Trait {
 		this.mass = mass;
 		this.margin = margin;
 
-		iron.Scene.active.notifyOnInit(function() {
-			notifyOnInit(init);
-		});
+		//notifyOnAdd(init);
+		//The above line works as well, but the object transforms are not set
+		//properly, so the positions are not accurate
+		notifyOnInit(init);
 	}
 
 	function fromI16(ar: kha.arrays.Int16Array, scalePos: Float): haxe.ds.Vector<Float> {
@@ -96,8 +97,20 @@ class SoftBody extends Trait {
 		}
 	}
 
-	var v = new Vec4();
 	function init() {
+		var mo = cast(object, MeshObject);
+		//Set new mesh data for this object
+		new MeshData(mo.data.raw, function (data) {
+			mo.setData(data);
+			//Init soft body after setting new data
+			initSoftBody();
+			//If the above line is commented out, the program becomes unresponsive with white screen
+			//and no errors.
+		});
+	}
+
+	var v = new Vec4();
+	function initSoftBody() {
 		if (ready) return;
 		ready = true;
 

--- a/Sources/armory/trait/physics/bullet/SoftBody.hx
+++ b/Sources/armory/trait/physics/bullet/SoftBody.hx
@@ -67,6 +67,7 @@ class SoftBody extends Trait {
 		for (ar in ars) {
 			for (j in 0...ar.length) {
 				vals[i] = ar[j];
+				trace(ar[j]);
 				i++;
 			}
 		}
@@ -101,6 +102,8 @@ class SoftBody extends Trait {
 			v.y *= object.transform.scale.y;
 			v.z *= object.transform.scale.z;
 			v.addf(object.transform.worldx(), object.transform.worldy(), object.transform.worldz());
+			trace("Position index" + i);
+			trace(v);
 			positions[i * 3    ] = v.x;
 			positions[i * 3 + 1] = v.y;
 			positions[i * 3 + 2] = v.z;
@@ -124,8 +127,36 @@ class SoftBody extends Trait {
 			helpersCreated = true;
 		}
 
+		var positionsVector: haxe.ds.Vector<Float> = new haxe.ds.Vector<Float>(positions.length);
+		for(i in 0...positions.length){
+			positionsVector.set(i, positions.get(i));
+		}
+
+		var vecindVector: haxe.ds.Vector<Int> = new haxe.ds.Vector<Int>(vecind.length);
+		for(i in 0...vecind.length){
+			vecindVector.set(i, vecind.get(i));
+		}
+
+		/* trace("_______________________________________________");
+		trace(worldInfo);
+
+		//var posVector: haxe.ds.Vector<Float> = cast positions;
+		trace(positions);
+		for(vvv in 0...positions.length) trace(positions.get(vvv));
+		trace("posVector");
+		for(vvv in 0...positionsVector.length) trace(positionsVector.get(vvv));
+
+		//var vecindVector: haxe.ds.Vector<Int> = cast vecind;
+		trace(vecind);
+		for(vvv in 0...vecind.length) trace(vecind.get(vvv));
+		trace("vecindVector");
+		for(vvv in 0...vecindVector.length) trace(vecindVector.get(vvv));
+
+		trace(numtri);
+		trace("_______________________________________________"); */
+
 		#if js
-		body = helpers.CreateFromTriMesh(worldInfo, cast positions, cast vecind, numtri);
+		body = helpers.CreateFromTriMesh(worldInfo, positionsVector, vecindVector, numtri);
 		#elseif cpp
 		untyped __cpp__("body = helpers.CreateFromTriMesh(worldInfo, positions->self.data, (int*)vecind->self.data, numtri);");
 		#end
@@ -195,6 +226,8 @@ class SoftBody extends Trait {
 			var node = nodes.at(i);
 			#if js
 			var nodePos = node.get_m_x();
+			trace("nodepos " + i);
+			trace("( " + nodePos.x() + ", " + nodePos.y() + ", " + nodePos.z() + " )");
 			#elseif cpp
 			var nodePos = node.m_x;
 			#end

--- a/Sources/armory/trait/physics/bullet/SoftBody.hx
+++ b/Sources/armory/trait/physics/bullet/SoftBody.hx
@@ -163,12 +163,12 @@ class SoftBody extends Trait {
 		}
 
 		var positionsVector: haxe.ds.Vector<Float> = new haxe.ds.Vector<Float>(verts.length);
-		for(i in 0...positions.length){
+		for(i in 0...positionsVector.length){
 			positionsVector.set(i, verts[i]);
 		}
 
 		var vecindVector: haxe.ds.Vector<Int> = new haxe.ds.Vector<Int>(vertexMapArray.length);
-		for(i in 0...vertexMapArray.length){
+		for(i in 0...vecindVector.length){
 			vecindVector.set(i, vertexMapArray.get(i));
 		}
 

--- a/Sources/armory/trait/physics/bullet/SoftBody.hx
+++ b/Sources/armory/trait/physics/bullet/SoftBody.hx
@@ -221,8 +221,8 @@ class SoftBody extends Trait {
 		var mo = cast(object, MeshObject);
 		var geom = mo.data.geom;
 		#if arm_deinterleaved
-		var v = geom.vertexBuffers[0].lock();
-		var n = geom.vertexBuffers[1].lock();
+		var v: ByteArray = geom.vertexBuffers[0].buffer.lock();
+		var n: ByteArray = geom.vertexBuffers[1].buffer.lock();
 		#else
 		var v:ByteArray = geom.vertexBuffer.lock();
 		var vbPos = geom.vertexBufferMap.get("pos");
@@ -263,15 +263,15 @@ class SoftBody extends Trait {
 			var nodeNor = node.m_n;
 			#end
 			for (idx in indices){
-				var vertIndex = idx * l * 2;
 				#if arm_deinterleaved
-				v.set(idx * 4    , Std.int(nodePos.x() * 32767 * (1 / scalePos)));
-				v.set(idx * 4 + 1, Std.int(nodePos.y() * 32767 * (1 / scalePos)));
-				v.set(idx * 4 + 2, Std.int(nodePos.z() * 32767 * (1 / scalePos)));
-				n.set(idx * 2    , Std.int(nodeNor.x() * 32767));
-				n.set(idx * 2 + 1, Std.int(nodeNor.y() * 32767));
-				v.set(idx * 4 + 3, Std.int(nodeNor.z() * 32767));
+				v.setInt16(idx * 8    , Std.int(nodePos.x() * 32767 * (1 / scalePos)));
+				v.setInt16(idx * 8 + 2, Std.int(nodePos.y() * 32767 * (1 / scalePos)));
+				v.setInt16(idx * 8 + 4, Std.int(nodePos.z() * 32767 * (1 / scalePos)));
+				n.setInt16(idx * 4    , Std.int(nodeNor.x() * 32767));
+				n.setInt16(idx * 4 + 2, Std.int(nodeNor.y() * 32767));
+				v.setInt16(idx * 8 + 6, Std.int(nodeNor.z() * 32767));
 				#else
+				var vertIndex = idx * l * 2;
 				v.setInt16(vertIndex        , Std.int(nodePos.x() * 32767 * (1 / scalePos)));
 				v.setInt16(vertIndex + 2, Std.int(nodePos.y() * 32767 * (1 / scalePos)));
 				v.setInt16(vertIndex + 4, Std.int(nodePos.z() * 32767 * (1 / scalePos)));
@@ -308,8 +308,8 @@ class SoftBody extends Trait {
 		// 	v.set(c * l + 5, cb.z);
 		// }
 		#if arm_deinterleaved
-		geom.vertexBuffers[0].unlock();
-		geom.vertexBuffers[1].unlock();
+		geom.vertexBuffers[0].buffer.unlock();
+		geom.vertexBuffers[1].buffer.unlock();
 		#else
 		geom.vertexBuffer.unlock();
 		if (vbPos != null) vbPos.unlock();

--- a/Sources/armory/trait/physics/bullet/SoftBody.hx
+++ b/Sources/armory/trait/physics/bullet/SoftBody.hx
@@ -160,6 +160,10 @@ class SoftBody extends Trait {
 			helpers = new bullet.Bt.SoftBodyHelpers();
 			worldInfo = physics.world.getWorldInfo();
 			helpersCreated = true;
+			#if hl
+			//world info is passed as value and not as a reference, need to set gravity again in HL.
+			worldInfo.m_gravity = physics.world.getGravity();
+			#end
 		}
 
 		var vertsLength = 0;
@@ -193,10 +197,11 @@ class SoftBody extends Trait {
 		for (i in 0...vecindVector.length){
 			intArray.set(i, vecindVector[i]);
 		}
-		//world info is passed as value and not as a reference, need to set gravity again in HL.
-		worldInfo.m_gravity = physics.world.getGravity();
 		//Create soft body
 		body = helpers.CreateFromTriMesh(worldInfo, floatArray.raw, intArray.raw, numtri, false);
+
+		floatArray.delete();
+		intArray.delete();
 		#end
 		// body.generateClusters(4);
 
@@ -233,6 +238,11 @@ class SoftBody extends Trait {
 		physics.world.addSoftBody(body, 1, -1);
 		body.setActivationState(CollisionObjectActivationState.DISABLE_DEACTIVATION);
 
+		#if hl
+		cfg.delete();
+		#end
+
+		notifyOnRemove(removeFromWorld);
 		notifyOnUpdate(update);
 	}
 
@@ -278,6 +288,11 @@ class SoftBody extends Trait {
 			vertOffsetX += mx;
 			vertOffsetY += my;
 			vertOffsetZ += mz;
+
+			#if hl
+			node.delete();
+			nodePos.delete();
+			#end
 		}
 		vertOffsetX /= numNodes;
 		vertOffsetY /= numNodes;
@@ -303,6 +318,11 @@ class SoftBody extends Trait {
 			if (Math.abs(mx * 2) > scalePos) scalePos = Math.abs(mx * 2);
 			if (Math.abs(my * 2) > scalePos) scalePos = Math.abs(my * 2);
 			if (Math.abs(mz * 2) > scalePos) scalePos = Math.abs(mz * 2);
+
+			#if hl
+			node.delete();
+			nodePos.delete();
+			#end
 		}
 		//Set scalePos and buildMatrix
 		mo.data.scalePos = scalePos;
@@ -351,6 +371,12 @@ class SoftBody extends Trait {
 				v.setInt16(vertIndex + 10, Std.int(nz * 32767));
 				#end
 			}
+
+			#if hl
+			node.delete();
+			nodePos.delete();
+			nodeNor.delete();
+			#end
 		}
 		// for (i in 0...Std.int(geom.indices[0].length / 3)) {
 		// 	var a = geom.indices[0][i * 3];
@@ -379,6 +405,18 @@ class SoftBody extends Trait {
 		#else
 		geom.vertexBuffer.unlock();
 		if (vbPos != null) vbPos.unlock();
+		#end
+		#if hl
+		nodes.delete();
+		#end
+	}
+
+	function removeFromWorld() {
+		physics.world.removeSoftBody(body);
+		#if js
+		bullet.Bt.Ammo.destroy(body);
+		#else
+		body.delete();
 		#end
 	}
 

--- a/Sources/armory/trait/physics/bullet/SoftBody.hx
+++ b/Sources/armory/trait/physics/bullet/SoftBody.hx
@@ -68,7 +68,6 @@ class SoftBody extends Trait {
 		for (ar in ars) {
 			for (j in 0...ar.length) {
 				vals[i] = ar[j];
-				trace(ar[j]);
 				i++;
 			}
 		}
@@ -103,8 +102,6 @@ class SoftBody extends Trait {
 			v.y *= object.transform.scale.y;
 			v.z *= object.transform.scale.z;
 			v.addf(object.transform.worldx(), object.transform.worldy(), object.transform.worldz());
-			trace("Position index" + i);
-			trace(v);
 			positions[i * 3    ] = v.x;
 			positions[i * 3 + 1] = v.y;
 			positions[i * 3 + 2] = v.z;
@@ -186,9 +183,7 @@ class SoftBody extends Trait {
 	function update() {
 		var mo = cast(object, MeshObject);
 		var geom = mo.data.geom;
-		trace(";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; UPDATE");
 		#if arm_deinterleaved
-		trace("deinterleieved");
 		var v = geom.vertexBuffers[0].lock();
 		var n = geom.vertexBuffers[1].lock();
 		#else
@@ -198,17 +193,6 @@ class SoftBody extends Trait {
 		var l = geom.structLength;
 		#end
 		var numVerts = geom.getVerticesCount();
-		trace("num verts = " + numVerts);
-		for(i in 0...numVerts * l) {
-			trace("point " + i + " = " + v.getInt16( i * 2 ));
-		}
-		trace("num tris = " + geom.numTris);
-		trace("structLength = " + l);
-		trace("total len =" + v.byteLength);
-		for(k in geom.vertexBufferMap.keys()){
-			trace("key = " + k);
-			trace(geom.vertexBufferMap.get(k));
-		}
 
 		#if js
 		var nodes = body.get_m_nodes();
@@ -221,8 +205,6 @@ class SoftBody extends Trait {
 			var node = nodes.at(i);
 			#if js
 			var nodePos = node.get_m_x();
-			trace("nodepos " + i);
-			trace("( " + nodePos.x() + ", " + nodePos.y() + ", " + nodePos.z() + " )");
 			#elseif cpp
 			var nodePos = node.m_x;
 			#end

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -1579,6 +1579,7 @@ Make sure the mesh only has tris/quads.""")
             if tris == 0: # No face assigned
                 continue
             prim = np.empty(tris * 3, dtype='<i4')
+            v_map = np.empty(tris * 3, dtype='<i4')
 
             i = 0
             for poly in polys:
@@ -1588,7 +1589,15 @@ Make sure the mesh only has tris/quads.""")
                     prim[i + 2] = loops[loop.loops[2]].index
                     i += 3
 
-            ia = {'values': prim, 'material': 0}
+            j = 0
+            for poly in polys:
+                for loop in tri_loops[poly.index]:
+                    v_map[j    ] = loops[loop.loops[0]].vertex_index
+                    v_map[j + 1] = loops[loop.loops[1]].vertex_index
+                    v_map[j + 2] = loops[loop.loops[2]].vertex_index
+                    j += 3
+
+            ia = {'values': prim, 'material': 0, 'vertex_map': v_map}
             if len(mats) > 1:
                 for i in range(len(mats)):  # Multi-mat mesh
                     if mats[i] == mats[index]:  # Default material for empty slots

--- a/blender/arm/exporter_opt.py
+++ b/blender/arm/exporter_opt.py
@@ -30,22 +30,11 @@ class Vertex:
         self.col = [0.0, 0.0, 0.0] if vcol0 is None else vcol0.data[loop_idx].color[:]
         self.loop_indices = [loop_idx]
         self.index = 0
-        print("******************************************************************")
-        print(self.vertex_index)
-        print(loop_idx)
-        print(self.co)
-        print(self.normal)
-        print(self.uvs)
-        print(self.col)
-        print(self.loop_indices)
 
     def __hash__(self):
-        print("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
-        print(hash((self.co, self.normal, self.uvs)))
         return hash((self.co, self.normal, self.uvs))
 
     def __eq__(self, other):
-        print("111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
         eq = (
             (self.co == other.co) and
             (self.normal == other.normal) and
@@ -53,7 +42,6 @@ class Vertex:
             (self.col == other.col)
             )
         if eq:
-            print("EQUAL")
             indices = self.loop_indices + other.loop_indices
             self.loop_indices = indices
             other.loop_indices = indices
@@ -130,11 +118,7 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
     # exportMesh.calc_loop_triangles()
     vcol0 = self.get_nth_vertex_colors(export_mesh, 0)
     vert_list = {Vertex(export_mesh, loop, vcol0): 0 for loop in export_mesh.loops}.keys()
-    print("EXPORT")
-    print({Vertex(export_mesh, loop, vcol0): 0 for loop in export_mesh.loops})
-    print(vert_list)
     num_verts = len(vert_list)
-    print(num_verts)
     num_uv_layers = len(export_mesh.uv_layers)
     # Check if shape keys were exported
     has_morph_target = self.get_shape_keys(bobject.data)

--- a/blender/arm/exporter_opt.py
+++ b/blender/arm/exporter_opt.py
@@ -118,7 +118,9 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
     # exportMesh.calc_loop_triangles()
     vcol0 = self.get_nth_vertex_colors(export_mesh, 0)
     vert_list = {Vertex(export_mesh, loop, vcol0): 0 for loop in export_mesh.loops}.keys()
+    print("EXPORT")
     num_verts = len(vert_list)
+    print(num_verts)
     num_uv_layers = len(export_mesh.uv_layers)
     # Check if shape keys were exported
     has_morph_target = self.get_shape_keys(bobject.data)

--- a/blender/arm/exporter_opt.py
+++ b/blender/arm/exporter_opt.py
@@ -30,11 +30,22 @@ class Vertex:
         self.col = [0.0, 0.0, 0.0] if vcol0 is None else vcol0.data[loop_idx].color[:]
         self.loop_indices = [loop_idx]
         self.index = 0
+        print("******************************************************************")
+        print(self.vertex_index)
+        print(loop_idx)
+        print(self.co)
+        print(self.normal)
+        print(self.uvs)
+        print(self.col)
+        print(self.loop_indices)
 
     def __hash__(self):
+        print("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+        print(hash((self.co, self.normal, self.uvs)))
         return hash((self.co, self.normal, self.uvs))
 
     def __eq__(self, other):
+        print("111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
         eq = (
             (self.co == other.co) and
             (self.normal == other.normal) and
@@ -42,6 +53,7 @@ class Vertex:
             (self.col == other.col)
             )
         if eq:
+            print("EQUAL")
             indices = self.loop_indices + other.loop_indices
             self.loop_indices = indices
             other.loop_indices = indices
@@ -119,6 +131,8 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
     vcol0 = self.get_nth_vertex_colors(export_mesh, 0)
     vert_list = {Vertex(export_mesh, loop, vcol0): 0 for loop in export_mesh.loops}.keys()
     print("EXPORT")
+    print({Vertex(export_mesh, loop, vcol0): 0 for loop in export_mesh.loops})
+    print(vert_list)
     num_verts = len(vert_list)
     print(num_verts)
     num_uv_layers = len(export_mesh.uv_layers)


### PR DESCRIPTION
This PR is an overhaul of the SoftBody physics on both HL and JS targets.

Fixes #2654 and #1920 

Requires https://github.com/armory3d/iron/pull/194 and https://github.com/armory3d/haxebullet/pull/41

1. For #1920, I export an extra index buffer called `vertex_map`. This maps Blender's [`vertex_index`](https://docs.blender.org/api/current/bpy.types.MeshLoop.html#bpy.types.MeshLoop.vertex_index) attribute to Armory's index buffer. This information was lost at export. This is then used to connect vertices and faces properly at SoftBody initialization.

2. For #2654, I changed the data type passed to the SoftBody initialization function.

## Other fixes/ additions apart from the above two issues:
* **Added support to HL targets**: This was done by creating a custom array type to overcome HL to WebIDL constraints on array data types such as [this](https://community.haxe.org/t/question-about-pointers-as-parametes/2732) and https://github.com/ncannasse/webidl/issues/21

* **Runtime spawning**: Since SoftBodies modify an object's mesh data directly, simply "duplicating" the mesh at runtime for a spawn does not give the required result. So, at spawn, a new instance of the data is created and is set as the mesh data for current object. This way, the meshes do not share mesh data and are independent.

* **Adaptively move the SoftBody origin** to the mean positions of the vertices. This should improve graphical precision as the SoftBody goes away from the origin. May be used for other game logic such as detection and tracking.

* Smaller fixes such as enabling Soft-Soft collisions.

Thanks to everyone on Discord for testing the changes and providing valuable feedback and suggestions.


