### PR TITLE
Add support for Bullet physics debug drawing

### DIFF
--- a/Sources/armory/trait/physics/bullet/DebugDrawHelper.hx
+++ b/Sources/armory/trait/physics/bullet/DebugDrawHelper.hx
@@ -1,0 +1,224 @@
+package armory.trait.physics.bullet;
+
+import bullet.Bt.Vector3;
+
+import kha.FastFloat;
+import kha.System;
+
+import iron.math.Vec4;
+
+#if arm_ui
+import armory.ui.Canvas;
+#end
+
+using StringTools;
+
+class DebugDrawHelper {
+	static inline var contactPointSizePx = 4;
+	static inline var contactPointNormalColor = 0xffffffff;
+	static inline var contactPointDrawLifetime = true;
+
+	final physicsWorld: PhysicsWorld;
+	final lines: Array<LineData> = [];
+	final texts: Array<TextData> = [];
+	var font: kha.Font = null;
+
+	var debugMode: PhysicsWorld.DebugDrawMode = NoDebug;
+
+	public function new(physicsWorld: PhysicsWorld) {
+		this.physicsWorld = physicsWorld;
+
+		#if arm_ui
+		iron.data.Data.getFont(Canvas.defaultFontName, function(defaultFont: kha.Font) {
+			font = defaultFont;
+		});
+		#end
+
+		iron.App.notifyOnRender2D(onRender);
+	}
+
+	public function drawLine(from: bullet.Bt.Vector3, to: bullet.Bt.Vector3, color: bullet.Bt.Vector3) {
+		#if js
+			// https://github.com/InfiniteLee/ammo-debug-drawer/pull/1/files
+			// https://emscripten.org/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html#pointers-and-comparisons
+			from = js.Syntax.code("Ammo.wrapPointer({0}, Ammo.btVector3)", from);
+			to = js.Syntax.code("Ammo.wrapPointer({0}, Ammo.btVector3)", to);
+			color = js.Syntax.code("Ammo.wrapPointer({0}, Ammo.btVector3)", color);
+		#end
+
+		final fromScreenSpace = worldToScreenFast(new Vec4(from.x(), from.y(), from.z(), 1.0));
+		final toScreenSpace = worldToScreenFast(new Vec4(to.x(), to.y(), to.z(), 1.0));
+
+		// For now don't draw lines if any point is outside of clip space z,
+		// investigate how to clamp lines to clip space borders
+		if (fromScreenSpace.w == 1 && toScreenSpace.w == 1) {
+			lines.push({
+				fromX: fromScreenSpace.x,
+				fromY: fromScreenSpace.y,
+				toX: toScreenSpace.x,
+				toY: toScreenSpace.y,
+				color: kha.Color.fromFloats(color.x(), color.y(), color.z(), 1.0)
+			});
+		}
+	}
+
+	public function drawContactPoint(pointOnB: Vector3, normalOnB: Vector3, distance: kha.FastFloat, lifeTime: Int, color: Vector3) {
+		#if js
+			pointOnB = js.Syntax.code("Ammo.wrapPointer({0}, Ammo.btVector3)", pointOnB);
+			normalOnB = js.Syntax.code("Ammo.wrapPointer({0}, Ammo.btVector3)", normalOnB);
+			color = js.Syntax.code("Ammo.wrapPointer({0}, Ammo.btVector3)", color);
+		#end
+
+		final contactPointScreenSpace = worldToScreenFast(new Vec4(pointOnB.x(), pointOnB.y(), pointOnB.z(), 1.0));
+		final toScreenSpace = worldToScreenFast(new Vec4(pointOnB.x() + normalOnB.x() * distance, pointOnB.y() + normalOnB.y() * distance, pointOnB.z() + normalOnB.z() * distance, 1.0));
+
+		if (contactPointScreenSpace.w == 1) {
+			final color = kha.Color.fromFloats(color.x(), color.y(), color.z(), 1.0);
+
+			lines.push({
+				fromX: contactPointScreenSpace.x - contactPointSizePx,
+				fromY: contactPointScreenSpace.y - contactPointSizePx,
+				toX: contactPointScreenSpace.x + contactPointSizePx,
+				toY: contactPointScreenSpace.y + contactPointSizePx,
+				color: color
+			});
+
+			lines.push({
+				fromX: contactPointScreenSpace.x - contactPointSizePx,
+				fromY: contactPointScreenSpace.y + contactPointSizePx,
+				toX: contactPointScreenSpace.x + contactPointSizePx,
+				toY: contactPointScreenSpace.y - contactPointSizePx,
+				color: color
+			});
+
+			if (toScreenSpace.w == 1) {
+				lines.push({
+					fromX: contactPointScreenSpace.x,
+					fromY: contactPointScreenSpace.y,
+					toX: toScreenSpace.x,
+					toY: toScreenSpace.y,
+					color: contactPointNormalColor
+				});
+			}
+
+			if (contactPointDrawLifetime && font != null) {
+				texts.push({
+					x: contactPointScreenSpace.x,
+					y: contactPointScreenSpace.y,
+					color: color,
+					text: Std.string(lifeTime), // lifeTime: number of frames the contact point existed
+				});
+			}
+		}
+	}
+
+	public function reportErrorWarning(warningString: bullet.Bt.BulletString) {
+		trace(warningString.toHaxeString().trim());
+	}
+
+	public function draw3dText(location: Vector3, textString: bullet.Bt.BulletString) {
+		if (font == null) {
+			return;
+		}
+
+		#if js
+			location = js.Syntax.code("Ammo.wrapPointer({0}, Ammo.btVector3)", location);
+		#end
+
+		final locationScreenSpace = worldToScreenFast(new Vec4(location.x(), location.y(), location.z(), 1.0));
+
+		texts.push({
+			x: locationScreenSpace.x,
+			y: locationScreenSpace.y,
+			color: kha.Color.fromFloats(0.0, 0.0, 0.0, 1.0),
+			text: textString.toHaxeString()
+		});
+	}
+
+	public function setDebugMode(debugMode: PhysicsWorld.DebugDrawMode) {
+		this.debugMode = debugMode;
+	}
+
+	public function getDebugMode(): PhysicsWorld.DebugDrawMode {
+		#if js
+			return debugMode;
+		#elseif hl
+			return physicsWorld.getDebugDrawMode();
+		#else
+			return NoDebug;
+		#end
+	}
+
+	function onRender(g: kha.graphics2.Graphics) {
+		if (getDebugMode() == NoDebug) {
+			return;
+		}
+
+		// It might be a bit unusual to call this method in a render callback
+		// instead of the update loop (after all it doesn't draw anything but
+		// will cause Bullet to call the btIDebugDraw callbacks), but this way
+		// we can ensure that--within a frame--the function will not be called
+		// before some user-specific physics update, which would result in a
+		// one-frame drawing delay... Ideally we would ensure that debugDrawWorld()
+		// is called when all other (late) update callbacks are already executed...
+		physicsWorld.world.debugDrawWorld();
+
+		g.opacity = 1.0;
+
+		for (line in lines) {
+			g.color = line.color;
+			g.drawLine(line.fromX, line.fromY, line.toX, line.toY, 1.0);
+		}
+		lines.resize(0);
+
+		if (font != null) {
+			g.font = font;
+			g.fontSize = 12;
+			for (text in texts) {
+				g.color = text.color;
+				g.drawString(text.text, text.x, text.y);
+			}
+			texts.resize(0);
+		}
+	}
+
+	/**
+		Transform a world coordinate vector into screen space and store the
+		result in the input vector's x and y coordinates. The w coordinate is
+		set to 0 if the input vector is outside the active camera's far and near
+		planes, and 1 otherwise.
+	**/
+	inline function worldToScreenFast(loc: Vec4): Vec4 {
+		final cam = iron.Scene.active.camera;
+		loc.w = 1.0;
+		loc.applyproj(cam.VP);
+
+		if (loc.z < -1 || loc.z > 1) {
+			loc.w = 0.0;
+		}
+		else {
+			loc.x = (loc.x + 1) * 0.5 * System.windowWidth();
+			loc.y = (1 - loc.y) * 0.5 * System.windowHeight();
+			loc.w = 1.0;
+		}
+
+		return loc;
+	}
+}
+
+@:structInit
+class LineData {
+	public var fromX: FastFloat;
+	public var fromY: FastFloat;
+	public var toX: FastFloat;
+	public var toY: FastFloat;
+	public var color: kha.Color;
+}
+
+@:structInit
+class TextData {
+	public var x: FastFloat;
+	public var y: FastFloat;
+	public var color: kha.Color;
+	public var text: String;
+}

--- a/blender/arm/exporter.py
+++ b/blender/arm/exporter.py
@@ -2951,6 +2951,16 @@ Make sure the mesh only has tris/quads.""")
             if rbw is not None and rbw.enabled:
                 out_trait['parameters'] = [str(rbw.time_scale), str(rbw.substeps_per_frame), str(rbw.solver_iterations)]
 
+                if phys_pkg == 'bullet':
+                    debug_draw_mode = 1 if wrd.arm_bullet_dbg_draw_wireframe else 0
+                    debug_draw_mode |= 2 if wrd.arm_bullet_dbg_draw_aabb else 0
+                    debug_draw_mode |= 8 if wrd.arm_bullet_dbg_draw_contact_points else 0
+                    debug_draw_mode |= 2048 if wrd.arm_bullet_dbg_draw_constraints else 0
+                    debug_draw_mode |= 4096 if wrd.arm_bullet_dbg_draw_constraint_limits else 0
+                    debug_draw_mode |= 16384 if wrd.arm_bullet_dbg_draw_normals else 0
+                    debug_draw_mode |= 32768 if wrd.arm_bullet_dbg_draw_axis_gizmo else 0
+                    out_trait['parameters'].append(str(debug_draw_mode))
+
             self.output['traits'].append(out_trait)
 
         if wrd.arm_navigation != 'Disabled' and ArmoryExporter.export_navigation:

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -197,6 +197,40 @@ def init_properties():
         items=[('Bullet', 'Bullet', 'Bullet'),
                ('Oimo', 'Oimo', 'Oimo')],
         name="Physics Engine", default='Bullet', update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_bullet_dbg_draw_wireframe = BoolProperty(
+        name="Collider Wireframes", default=False,
+        description="Draw wireframes of the physics collider meshes and suspensions of raycast vehicle simulations"
+    )
+    bpy.types.World.arm_bullet_dbg_draw_aabb = BoolProperty(
+        name="Axis-aligned Minimum Bounding Boxes", default=False,
+        description="Draw axis-aligned minimum bounding boxes (AABBs) of the physics collider meshes"
+    )
+    bpy.types.World.arm_bullet_dbg_draw_contact_points = BoolProperty(
+        name="Contact Points", default=False,
+        description="Visualize contact points of multiple colliders"
+    )
+    bpy.types.World.arm_bullet_dbg_draw_constraints = BoolProperty(
+        name="Constraints", default=False,
+        description="Draw axis gizmos for important constraint points"
+    )
+    bpy.types.World.arm_bullet_dbg_draw_constraint_limits = BoolProperty(
+        name="Constraint Limits", default=False,
+        description="Draw additional constraint information such as distance or angle limits"
+    )
+    bpy.types.World.arm_bullet_dbg_draw_normals = BoolProperty(
+        name="Face Normals", default=False,
+        description=(
+            "Draw the normal vectors of the triangles of the physics collider meshes."
+            " This only works for mesh collision shapes"
+        )
+    )
+    bpy.types.World.arm_bullet_dbg_draw_axis_gizmo = BoolProperty(
+        name="Axis Gizmos", default=False,
+        description=(
+            "Draw a small axis gizmo at the origin of the collision shape."
+            " Only works if \"Collider Wireframes\" is enabled as well"
+        )
+    )
     bpy.types.World.arm_navigation = EnumProperty(
         items=[('Disabled', 'Disabled', 'Disabled'),
                ('Auto', 'Auto', 'Auto'),

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -2641,6 +2641,39 @@ class ArmoryUpdateListInstalledVSButton(bpy.types.Operator):
 
         return {'FINISHED'}
 
+
+class ARM_PT_BulletDebugDrawingPanel(bpy.types.Panel):
+    bl_label = "Armory Debug Drawing"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "scene"
+    bl_options = {'DEFAULT_CLOSED'}
+    bl_parent_id = "SCENE_PT_rigid_body_world"
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.rigidbody_world is not None
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        wrd = bpy.data.worlds['Arm']
+
+        if wrd.arm_physics_engine != 'Bullet':
+            row = layout.row()
+            row.alert = True
+            row.label(text="Physics debug drawing is only supported for the Bullet physics engine")
+
+        col = layout.column(align=False)
+        col.prop(wrd, "arm_bullet_dbg_draw_wireframe")
+        col.prop(wrd, "arm_bullet_dbg_draw_aabb")
+        col.prop(wrd, "arm_bullet_dbg_draw_contact_points")
+        col.prop(wrd, "arm_bullet_dbg_draw_constraints")
+        col.prop(wrd, "arm_bullet_dbg_draw_constraint_limits")
+        col.prop(wrd, "arm_bullet_dbg_draw_normals")
+        col.prop(wrd, "arm_bullet_dbg_draw_axis_gizmo")
+
 def draw_custom_node_menu(self, context):
     """Extension of the node context menu.
 
@@ -2774,6 +2807,7 @@ def register():
     bpy.utils.register_class(ArmoryUpdateListAndroidEmulatorButton)
     bpy.utils.register_class(ArmoryUpdateListAndroidEmulatorRunButton)
     bpy.utils.register_class(ArmoryUpdateListInstalledVSButton)
+    bpy.utils.register_class(ARM_PT_BulletDebugDrawingPanel)
 
     bpy.utils.register_class(scene.TLM_PT_Settings)
     bpy.utils.register_class(scene.TLM_PT_Denoise)
@@ -2796,6 +2830,7 @@ def unregister():
     bpy.types.VIEW3D_HT_header.remove(draw_view3d_header)
     bpy.types.TOPBAR_HT_upper_bar.remove(draw_space_topbar)
 
+    bpy.utils.unregister_class(ARM_PT_BulletDebugDrawingPanel)
     bpy.utils.unregister_class(ArmoryUpdateListInstalledVSButton)
     bpy.utils.unregister_class(ArmoryUpdateListAndroidEmulatorRunButton)
     bpy.utils.unregister_class(ArmoryUpdateListAndroidEmulatorButton)


### PR DESCRIPTION
This PR adds debug drawing support for Bullet physics. It requires https://github.com/armory3d/haxebullet/pull/42 where I explained some more technical details.

![Collider Wireframes](https://github.com/armory3d/armory/assets/17685000/01d87638-fb13-4ab8-a586-b0dfa46b42c4)

![Contact Points](https://github.com/armory3d/armory/assets/17685000/8d1477b5-1fa2-45df-901c-0b6bc76b924a)

![Ragdoll Constraints](https://github.com/armory3d/armory/assets/17685000/7474c7b9-9085-4835-955f-4a96f2c805b9)

The debug drawing settings can be found in the `Rigid Body World` panel of the scene properties:

![grafik](https://github.com/armory3d/armory/assets/17685000/d1c599b8-0a2c-42e2-9969-c2543bbec14b)

On the Haxe side there are more debug flags available, however, these do not take effect in Armory since Bullet does not use them in the library core, instead they seem to be used in individual (and sometimes obsolete) Bullet examples only (urgh...). Some flags have dependencies between each other, the wireframe flag even leads to drawing the suspension of raycast vehicles for whatever reason (Bullet's codebase truly is something else... :D). In some cases I have put some explanations for the unused flags as comments to the code.

Tested on krom, html5 and windows-hl.

## Potential future work
- Implement proper clipping for drawing lines. Currently lines aren't rendered if any end is out of the far/near camera range.
- Investigate whether we can implement debug drawing for Oimo physics, if we still plan to support it. @luboslenco What was the reason for adding it in the first place? Does it have some features that Bullet hasn't?
- We could merge the line drawing with the debug console's line drawing, but then we need to decide whether we want to use the same kind of line drawing (2D vs. 3D) for both.
- Perhaps improve the drawing of the contact points, there are probably better ways to vizualize these than using diagonal crosses (+ normal vector).
- Expose the debug drawing flags in the debug console
- If someone knows a way to better align the checkboxes in the Blender UI and still have a good-looking margin to one of the panel sides (which does not exist if `layout.use_property_split == False`), please let me know :)

Thanks to all involved on the Discord server with providing feedback and ideas!