### PR TITLE
[3.6 LTS] Avoid warnings for default logic tree names

### DIFF
--- a/blender/arm/handlers.py
+++ b/blender/arm/handlers.py
@@ -89,6 +89,18 @@ def on_operator_post(operator_id: str) -> None:
             target_obj.arm_rb_ccd = source_obj.arm_rb_ccd
             target_obj.arm_rb_collision_filter_mask = source_obj.arm_rb_collision_filter_mask
 
+    elif operator_id == "NODE_OT_new_node_tree":
+        if bpy.context.space_data.tree_type == arm.nodes_logic.ArmLogicTree.bl_idname:
+            # In Blender 3.5+, new node trees are no longer called "NodeTree"
+            # but follow the bl_label attribute by default. New logic trees
+            # are thus called "Armory Logic Editor" which conflicts with Haxe's
+            # class naming convention. To avoid this, we listen for the
+            # creation of a node tree and then rename it.
+            # Unfortunately, manually naming the tree has the unfortunate
+            # side effect of not basing the new name on the name of the
+            # previously opened node tree, as it is the case for Blender trees...
+            bpy.context.space_data.edit_tree.name = "LogicTree"
+
 
 def send_operator(op):
     if hasattr(bpy.context, 'object') and bpy.context.object is not None:


### PR DESCRIPTION
As already mentioned in https://github.com/armory3d/armory/pull/2898, Blender now initializes the name of new custom node trees to their `bl_label` attribute which is identical to the editor name, which in our case causes warnings because logic nodes named `Logic Node Editor` have to be renamed in order to be valid Haxe class names.

Now, Armory listens to the creation of new logic node trees and renames them to `LogicTree` afterwards. This is potentially prone to timing-related errors in case the operator is called as part of some larger routine that reads/writes the name, but I don't know of any of such routines at the moment so it should be safe. It's definitely much better than greeting new users with a warning they might not understand...

---

Before choosing the current solution I first tried another approach which I want to document for completeness: In https://projects.blender.org/blender/blender/src/commit/59ce7bf5a941f4513938f50006351ed36e565bc1/source/blender/editors/space_node/node_add.cc#L852-L854, you can see that it's possible to initialize new node trees with a different name by using a `name` property like `name: StringProperty(name="name", default="LogicTree")`, and while this works well for the name displayed in the name text field of logic trees, it doesn't seem to affect the internally used `bl_rna.name` attribute which is still set to the editor name (and it's readonly from Python)... So this would cause both names to be displayed in the UI (see below image) and potentially cause a lot of other errors down the line. Also, since the name property would kind of act as an override to the UI name, it would be possible to give multiple trees the same names... After all, it's undocumented behaviour.

![Screenshot](https://github.com/armory3d/armory/assets/17685000/9a56169a-cd75-4251-9982-709850eaadf3)

Maybe some day Blender will allow to specify a custom default name different from the editor label, like suggested in https://projects.blender.org/blender/blender/issues/102458 with `bl_treename`...