### PR TITLE
Allow to configure canvas image scaling quality from Blender UI

### DIFF
--- a/Sources/armory/ui/Canvas.hx
+++ b/Sources/armory/ui/Canvas.hx
@@ -16,6 +16,7 @@ class Canvas {
 	public static var screenW = -1;
 	public static var screenH = -1;
 	public static var locale = "en";
+	public static var imageScaleQuality = kha.graphics2.ImageScaleQuality.Low;
 	static var _ui: Zui;
 	static var h = new zui.Zui.Handle(); // TODO: needs one handle per canvas
 
@@ -29,6 +30,7 @@ class Canvas {
 		_ui = ui;
 
 		g.end();
+		g.imageScaleQuality = Canvas.imageScaleQuality;
 		ui.begin(g); // Bake elements
 		g.begin(false);
 

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -254,6 +254,15 @@ def init_properties():
                ('Enabled', 'Enabled', 'Enabled')],
         name="Audio", default='Enabled', update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_khafile = PointerProperty(name="Append Khafile", description="Source appended to the project's khafile.js after it is generated", update=assets.invalidate_compiler_cache, type=bpy.types.Text)
+    bpy.types.World.arm_canvas_img_scaling_quality = EnumProperty(
+        name='Canvas Image Quality',
+        description='The quality with which to scale images drawn to Kha canvases',
+        items=[
+            ('low', 'Low', 'Low quality. Scaling usually takes place using a point filter.'),
+            ('high', 'High', 'High quality. Scaling usually takes place using a bilinear filter.'),
+        ],
+        default='low'
+    )
     bpy.types.World.arm_texture_quality = FloatProperty(name="Texture Quality", default=1.0, min=0.0, max=1.0, subtype='FACTOR', update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_sound_quality = FloatProperty(name="Sound Quality", default=0.9, min=0.0, max=1.0, subtype='FACTOR', update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_copy_override = BoolProperty(name="Copy Override", description="Overrides any existing files when copying", default=False, update=assets.invalidate_compiled_data)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1072,6 +1072,8 @@ class ARM_PT_ProjectFlagsPanel(bpy.types.Panel):
         col.prop(wrd, 'arm_export_tangents')
 
         col = layout.column(heading='Quality')
+        row = col.row()  # To expand below property UI horizontally
+        row.prop(wrd, 'arm_canvas_img_scaling_quality', expand=True)
         col.prop(wrd, 'arm_texture_quality')
         col.prop(wrd, 'arm_sound_quality')
 

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -498,6 +498,10 @@ class Main {
             f.write("""
         armory.system.Starter.numAssets = """ + str(len(asset_references)) + """;
         armory.system.Starter.drawLoading = """ + loadscreen_class + """.render;""")
+        if wrd.arm_canvas_img_scaling_quality == 'low':
+            f.write(f"armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.Low;")
+        elif wrd.arm_canvas_img_scaling_quality == 'high':
+            f.write(f"armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.High;")
         f.write("""
         armory.system.Starter.main(
             '""" + arm.utils.safestr(scene_name) + scene_ext + """',


### PR DESCRIPTION
This PR "fixes" https://forums.armory3d.org/t/solved-canvas-asset-distortion-when-scaling/5274, which was caused by always using low quality image scaling for canvases. Now the canvas image scaling quality is exposed to the Blender UI as a global setting and doesn't have to be set via Haxe:

![grafik](https://github.com/armory3d/armory/assets/17685000/8444f5d9-a714-4bc4-b779-5869f3cdd95d)