### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+tab_width = 4
+indent_style = tab
+
+[*.py]
+indent_size = 4
+tab_width = 4
+indent_style = space


### PR DESCRIPTION
Adds an [editorconfig](https://editorconfig.org/) following #2741 to support various editors ([outofthebox](https://editorconfig.org/#pre-installed)), not only vscode.

Imho, if accepted, `armory/.vscode/settings.json` should be removed, as it's non-standard.