### PR TITLE
Fix vscode settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
 	"editor.detectIndentation": false,
 	"editor.tabSize": 4,
-	"editor.insertSpaces": false
+	"editor.insertSpaces": false,
 	"[python]": {
 		"editor.insertSpaces": true
-	},
+	}
 }


### PR DESCRIPTION
Allows to read the vscode settings json file for tools not supporting jsonc.