### PR TITLE
Hashlink Null Float Fix 

### DIFF
--- a/Sources/armory/logicnode/RotationMathNode.hx
+++ b/Sources/armory/logicnode/RotationMathNode.hx
@@ -54,7 +54,7 @@ class RotationMathNode extends LogicNode {
 			}
 			case "Amplify": {
 				var v1: Quat = inputs[0].get();
-				var v2: Float = inputs[1].get();
+				var v2: Null<Float> = inputs[1].get();
 				if ((v1 == null) || (v2 == null)) return null;
 				res_q.setFrom(v1);
 				var fac2 = Math.sqrt(1- res_q.w*res_q.w);
@@ -78,7 +78,7 @@ class RotationMathNode extends LogicNode {
 				//var from = q;
 				var from: Quat = inputs[0].get();
 				var to: Quat = inputs[1].get();
-				var f: Float = inputs[2].get();
+				var f: Null<Single> = inputs[2].get();
 				if ((from == null) || (f == null) || (to == null)) return null;
 				res_q = res_q.lerp(from, to, f);
 			}
@@ -86,7 +86,7 @@ class RotationMathNode extends LogicNode {
 				//var from = q;
 				var from:Quat = inputs[0].get();
 				var to: Quat = inputs[1].get();
-				var f: Float = inputs[2].get();
+				var f: Null<Single> = inputs[2].get();
 				if ((from == null) || (f == null) || (to == null)) return null;
 				res_q = res_q.slerp(from, to, f);
 			}


### PR DESCRIPTION
Cannot check for Null on hashlink base types so I changed it to Null<Float> whereas the Lerp/Slerp wanted an f32 so those were set to Null<Single>. Other solutions are to use a Dynamic type to then check if null, or use another inputs.get(i) in the null check.