### PR TITLE
Fix for TAA with environment light.

### DIFF
--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -259,7 +259,7 @@ def make_deferred(con_mesh, rpasses):
             frag.write('vec2 posa = (wvpposition.xy / wvpposition.w) * 0.5 + 0.5;')
             frag.write('vec2 posb = (prevwvpposition.xy / prevwvpposition.w) * 0.5 + 0.5;')
             frag.write('fragColor[GBUF_IDX_2].rg = vec2(posa - posb);')
-
+            frag.write('fragColor[GBUF_IDX_2].b = 0.0;')
         if mat_state.material.arm_ignore_irradiance:
             frag.write('fragColor[GBUF_IDX_2].b = 1.0;')
 


### PR DESCRIPTION
This pull request addresses issue #2172.
When taa is enabled, _Veloc is set in world_defs and there is an extra texture used:

    if '_gbuffer2' in wrd.world_defs:
        if '_Veloc' in wrd.world_defs:
            frag.write('vec2 posa = (wvpposition.xy / wvpposition.w) * 0.5 + 0.5;')
            frag.write('vec2 posb = (prevwvpposition.xy / prevwvpposition.w) * 0.5 + 0.5;')
            frag.write('fragColor[GBUF_IDX_2].rg = vec2(posa - posb);')

The texture's blue channel isn't initialized unless we disable radiance and irradiance.

        if mat_state.material.arm_ignore_irradiance:
            frag.write('fragColor[GBUF_IDX_2].b = 1.0;')
            
I found the way to fix this by setting the blue channel to 0 when _Veloc is used, and it solves the issue.