### PR TITLE
Fix shader compilation for some node names with special characters

### DIFF
--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -538,7 +538,10 @@ def is_parsed(node_store_name: str):
 def res_var_name(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> str:
     """Return the name of the variable that stores the parsed result
     from the given node and socket."""
-    return node_name(node.name) + '_' + safesrc(socket.name) + '_res'
+    name = node_name(node.name) + '_' + safesrc(socket.name) + '_res'
+    if '__' in name:  # Consecutive _ are reserved
+        name = name.replace('_', '_x')
+    return name
 
 
 def write_result(link: bpy.types.NodeLink) -> Optional[str]:
@@ -600,8 +603,12 @@ def to_uniform(inp: bpy.types.NodeSocket):
     state.curshader.add_uniform(glsl_type(inp.type) + ' ' + uname)
     return uname
 
-def store_var_name(node: bpy.types.Node):
-    return node_name(node.name) + '_store'
+
+def store_var_name(node: bpy.types.Node) -> str:
+    name = node_name(node.name)
+    if name[-1] == "_":
+        return name + '_x_store'  # Prevent consecutive __
+    return name + '_store'
 
 
 def texture_store(node, tex, tex_name, to_linear=False, tex_link=None, default_value=None, is_arm_mat_param=None):
@@ -772,7 +779,7 @@ def node_name(s: str) -> str:
     if state.curshader.write_textures > 0:
         s += '_texread'
     s = safesrc(s)
-    if '__' in s: # Consecutive _ are reserved
+    if '__' in s:  # Consecutive _ are reserved
         s = s.replace('_', '_x')
     return s
 

--- a/blender/arm/utils.py
+++ b/blender/arm/utils.py
@@ -727,7 +727,7 @@ def safesrc(s):
 def safestr(s: str) -> str:
     """Outputs a string where special characters have been replaced with
     '_', which can be safely used in file and path names."""
-    for c in r'''[]/\;,><&*:%=+@!#^()|?^'"''':
+    for c in r'''[]/\;,><&*:§$%=+@!#^()|?^'"''':
         s = s.replace(c, '_')
     return ''.join([i if ord(i) < 128 else '_' for i in s])
 


### PR DESCRIPTION
This PR fixes shader compilation for nodes or sockets with `§` or `$` in their names and also fixes more cases where the shader compiler would output a warning because of consecutive underscores.

```
ERROR: [...]\compiled\Shaders\awning01_red__props_blend_mesh.frag.glsl:9: '$' : unexpected token

WARNING: [...]\compiled\Shaders\chimney005__props_blend_mesh.frag.glsl:38: 'VertexLitGeneric_GroupInput__bumpmap_texture__res' : identifiers containing consecutive underscores ("__") are reserved
WARNING: [...]\compiled\Shaders\chimney005__props_blend_mesh.frag.glsl:67: 'VertexLitGeneric_GroupInput__selfillummask_texturealpha__res' : identifiers containing consecutive underscores ("__") are reserved
```

There are more situations where Armory generates shader code with double underscores, but for some reason I couldn't reproduce a warning in the other cases I found... Nonetheless it may be a good idea to implement a function similar to `utils.safestr()` and `utils.safesrc()` but for shader identifiers, this way we could remove some of the (potentially redundant) double underscore correction code from other places and fix this whole class of errors once and for all. This function could also be used to ensure that generated variable names are unique (e.g. by appending consecutive numbers), I believe there are some cases where naming conflicts are possible...