### PR TITLE
voxel AO & GI + clipmaps.

### DIFF
--- a/Shaders/deferred_light/deferred_light.json
+++ b/Shaders/deferred_light/deferred_light.json
@@ -12,10 +12,6 @@
 					"link": "_cameraPosition"
 				},
 				{
-					"name": "clipmapCount",
-					"link": "_clipmapCount"
-				},
-				{
 					"name": "viewerPos",
 					"link": "_viewerPos"
 				},

--- a/Shaders/deferred_light/deferred_light.json
+++ b/Shaders/deferred_light/deferred_light.json
@@ -12,14 +12,17 @@
 					"link": "_cameraPosition"
 				},
 				{
-					"name": "eyeSnap",
-					"link": "_cameraPositionSnap",
-					"ifdef": ["_VoxelGICam"]
+					"name": "clipmapCount",
+					"link": "_clipmapCount"
+				},
+				{
+					"name": "viewerPos",
+					"link": "_viewerPos"
 				},
 				{
 					"name": "voxelBlend",
 					"link": "_voxelBlend",
-					"ifdef": ["_VoxelGITemporal"]
+					"ifdef": ["_VoxelTemporal"]
 				},
 				{
 					"name": "eyeLook",

--- a/Shaders/smaa_blend_weight/smaa_blend_weight.frag.glsl
+++ b/Shaders/smaa_blend_weight/smaa_blend_weight.frag.glsl
@@ -364,7 +364,7 @@ vec4 SMAABlendingWeightCalculationPS(vec2 texcoord, vec2 pixcoord,
 		// one of the boundaries is enough.
 		weights.rg = SMAACalculateDiagWeights(texcoord, e, subsampleIndices);
 
-		// We give priority to diagonals, so if we find a diagonal we skip
+		// We give piority to diagonals, so if we find a diagonal we skip
 		// horizontal/vertical processing.
 		//SMAA_BRANCH
 		if (weights.r == -weights.g) { // weights.r + weights.g == 0.0

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -10,6 +10,9 @@
 #ifdef _VoxelAOvar
 #include "std/conetrace.glsl"
 #endif
+#ifdef _VoxelGI
+#include "std/conetrace.glsl"
+#endif
 #ifdef _LTC
 #include "std/ltc.glsl"
 #endif
@@ -94,6 +97,11 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 		, sampler3D voxels, vec3 voxpos
 	#endif
 	#endif
+	#ifdef _VoxelGI
+	#ifdef _VoxelShadow
+		, sampler3D voxels, vec3 voxpos
+	#endif
+	#endif
 	#ifdef _MicroShadowing
 		, float occ
 	#endif
@@ -125,8 +133,8 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	vec3 direct = lambertDiffuseBRDF(albedo, dotNL) +
 				  specularBRDF(f0, rough, dotNL, dotNH, dotNV, dotVH) * spec;
 	#endif
-	direct *= attenuate(distance(p, lp));
 	direct *= lightCol;
+	direct *= attenuate(distance(p, lp));
 
 	#ifdef _MicroShadowing
 	direct *= clamp(dotNL + 2.0 * occ * occ - 1.0, 0.0, 1.0);
@@ -137,6 +145,12 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	#endif
 
 	#ifdef _VoxelAOvar
+	#ifdef _VoxelShadow
+	direct *= 1.0 - traceShadow(voxels, voxpos, l);
+	#endif
+	#endif
+
+	#ifdef _VoxelGI
 	#ifdef _VoxelShadow
 	direct *= 1.0 - traceShadow(voxels, voxpos, l);
 	#endif

--- a/Sources/armory/object/Uniforms.hx
+++ b/Sources/armory/object/Uniforms.hx
@@ -18,7 +18,7 @@ class Uniforms {
 		iron.object.Uniforms.externalVec3Links = [vec3Link];
 		iron.object.Uniforms.externalVec4Links = [];
 		iron.object.Uniforms.externalFloatLinks = [floatLink];
-		iron.object.Uniforms.externalIntLinks = [intLink];
+		iron.object.Uniforms.externalIntLinks = [];
 	}
 
 	public static function textureLink(object: Object, mat: MaterialData, link: String): Null<kha.Image> {
@@ -218,16 +218,6 @@ class Uniforms {
 			case "_voxelBlend": { // Blend current and last voxels
 				var freq = armory.renderpath.RenderPathCreator.voxelFreq;
 				return (armory.renderpath.RenderPathCreator.voxelFrame % freq) / freq;
-			}
-			#end
-		}
-		return null;
-	}
-	public static function intLink(object: Object, mat: MaterialData, link: String): Null<Int> {
-		switch(link) {
-			#if (rp_voxels != "Off")
-			case "_clipmapCount": {
-				return Main.voxelgiClipmapCount;
 			}
 			#end
 		}

--- a/Sources/armory/object/Uniforms.hx
+++ b/Sources/armory/object/Uniforms.hx
@@ -18,7 +18,7 @@ class Uniforms {
 		iron.object.Uniforms.externalVec3Links = [vec3Link];
 		iron.object.Uniforms.externalVec4Links = [];
 		iron.object.Uniforms.externalFloatLinks = [floatLink];
-		iron.object.Uniforms.externalIntLinks = [];
+		iron.object.Uniforms.externalIntLinks = [intLink];
 	}
 
 	public static function textureLink(object: Object, mat: MaterialData, link: String): Null<kha.Image> {
@@ -166,17 +166,13 @@ class Uniforms {
 				}
 			}
 			#end
-			#if rp_voxels
-			case "_cameraPositionSnap": {
-				v = iron.object.Uniforms.helpVec;
+
+			#if (rp_voxels != "Off")
+			case "_viewerPos": {
 				var camera = iron.Scene.active.camera;
-				v.set(camera.transform.worldx(), camera.transform.worldy(), camera.transform.worldz());
-				var l = camera.lookWorld();
-				var e = Main.voxelgiHalfExtents;
-				v.x += l.x * e * 0.9;
-				v.y += l.y * e * 0.9;
-				var f = Main.voxelgiVoxelSize * 8; // Snaps to 3 mip-maps range
-				v.set(Math.floor(v.x / f) * f, Math.floor(v.y / f) * f, Math.floor(v.z / f) * f);
+				var viewerPos = new iron.math.Vec3(camera.transform.worldx(), camera.transform.worldy(), camera.transform.worldz());
+				v = iron.object.Uniforms.helpVec;
+				v.set(viewerPos.x, viewerPos.y, viewerPos.z);
 			}
 			#end
 		}
@@ -213,15 +209,25 @@ class Uniforms {
 				return armory.trait.internal.DebugConsole.debugFloat;
 			}
 			#end
-			#if rp_voxels
+			#if rp_bloom
+			case "_bloomSampleScale": {
+				return Postprocess.bloom_uniforms[3];
+			}
+			#end
+			#if (rp_voxels != 'Off')
 			case "_voxelBlend": { // Blend current and last voxels
 				var freq = armory.renderpath.RenderPathCreator.voxelFreq;
 				return (armory.renderpath.RenderPathCreator.voxelFrame % freq) / freq;
 			}
 			#end
-			#if rp_bloom
-			case "_bloomSampleScale": {
-				return Postprocess.bloom_uniforms[3];
+		}
+		return null;
+	}
+	public static function intLink(object: Object, mat: MaterialData, link: String): Null<Int> {
+		switch(link) {
+			#if (rp_voxels != "Off")
+			case "_clipmapCount": {
+				return Main.voxelgiClipmapCount;
 			}
 			#end
 		}

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -472,6 +472,17 @@ class Inc {
 		t.mipmaps = true;
 		path.createRenderTarget(t);
 
+		#if arm_voxelgi_bounces
+		var t = new RenderTargetRaw();
+		t.name = "voxelsBounce";
+		t.width = res;
+		t.height = res;
+		t.depth = Std.int(res * resZ);
+		t.is_image = true;
+		t.mipmaps = true;
+		path.createRenderTarget(t);
+		#end
+
 		#if arm_voxelgi_temporal
 		{
 			var tB = new RenderTargetRaw();

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -14,7 +14,7 @@ class Inc {
 	static var spotIndex = 0;
 	static var lastFrame = -1;
 
-	#if (rp_voxels && arm_config)
+	#if ((rp_voxels != 'Off') && arm_config)
 	static var voxelsCreated = false;
 	#end
 
@@ -356,7 +356,7 @@ class Inc {
 			path.resize();
 		}
 		// Init voxels
-		#if rp_voxels
+		#if (rp_voxels != 'Off')
 		if (!voxelsCreated) initGI();
 		#end
 		#end // arm_config
@@ -442,17 +442,27 @@ class Inc {
 	}
 	#end
 
-	#if rp_voxels
+	#if (rp_voxels != 'Off')
 	public static function initGI(tname = "voxels") {
+		var t = new RenderTargetRaw();
+		t.name = tname;
+		
 		#if arm_config
 		var config = armory.data.Config.raw;
-		if (config.rp_gi != true || voxelsCreated) return;
+		if (config.rp_voxels != true || voxelsCreated) return;
 		voxelsCreated = true;
 		#end
 
-		var t = new RenderTargetRaw();
-		t.name = tname;
-		t.format = "R8";
+		#if (rp_voxels == "Voxel AO")
+		{
+			t.format = "R8";
+		}
+		#else
+		{
+			t.format = "RGBA64";
+		}
+		#end
+
 		var res = getVoxelRes();
 		var resZ =  getVoxelResZ();
 		t.width = res;

--- a/Sources/armory/renderpath/RenderPathCreator.hx
+++ b/Sources/armory/renderpath/RenderPathCreator.hx
@@ -57,7 +57,7 @@ class RenderPathCreator {
 		return path;
 	}
 
-	#if rp_voxels
+	#if (rp_voxels != "Off")
 	public static var voxelFrame = 0;
 	public static var voxelFreq = 6; // Revoxelizing frequency
 	#end

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -547,10 +547,12 @@ class RenderPathDeferred {
 			}
 			#end
 
-			path.setTarget("gbuffer_voxpos");
-			var res = Inc.getVoxelRes();
-			path.setViewport(res, res)
+
+			path.setTarget("", ["gbuffer_voxpos"]);
 			path.bindTarget(voxels, "voxels");
+
+			var res = Inc.getVoxelRes();
+			path.setViewport(res, res);
 
 			#if (rp_voxels == "Voxel GI")
 			#if rp_shadowmap
@@ -568,10 +570,11 @@ class RenderPathDeferred {
 			path.generateMipmaps(voxels);
 
 			#if arm_voxelgi_bounces
-			path.bindTarget(voxels, "voxels")
-			path.bindTarget("voxelsBounce", "voxelsBounce")
-			path.drawMeshes("voxel_bounce")
-			path.generateMipmaps("voxel_bounce")
+			path.bindTarget(voxels, "voxels");
+			path.bindTarget("gbuffer_voxpos", "gbuffer_voxpos");
+			path.bindTarget("voxelsBounce", "voxelsBounce");
+			path.drawMeshes("voxelbounce");
+			path.generateMipmaps("voxelsBounce");
 			#end
 		}
 		#end

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -567,6 +567,13 @@ class RenderPathDeferred {
 
 			path.drawMeshes("voxel");
 			path.generateMipmaps(voxels);
+
+			#if arm_voxelgi_bounces
+			path.bindTarget(voxels, "voxels")
+			path.bindTarget("voxelsBounce", "voxelsBounce")
+			path.drawMeshes("voxel_bounce")
+			path.generateMipmaps("voxel_bounce")
+			#end
 		}
 		#end
 
@@ -617,7 +624,12 @@ class RenderPathDeferred {
 			#end
 
 			path.bindTarget("gbuffer_voxpos", "gbuffer_voxpos");
+
+			#if arm_voxelgi_bounces
+			path.bindTarget(voxels, "voxelsBounce");
+			#else
 			path.bindTarget(voxels, "voxels");
+			#end
 
 			#if arm_voxelgi_temporal
 			{

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -9,7 +9,7 @@ class RenderPathDeferred {
 
 	static var path: RenderPath;
 
-	#if rp_voxels
+	#if (rp_voxels != "Off")
 	static var voxels = "voxels";
 	static var voxelsLast = "voxels";
 	#end
@@ -24,7 +24,8 @@ class RenderPathDeferred {
 		path.setTarget("gbuffer0", [
 			"gbuffer1",
 			#if rp_gbuffer2 "gbuffer2", #end
-			#if rp_gbuffer_emission "gbuffer_emission" #end
+			#if rp_gbuffer_emission "gbuffer_emission", #end
+			#if rp_voxelgi_refract "gbuffer_refraction" #end
 		]);
 	}
 
@@ -55,60 +56,64 @@ class RenderPathDeferred {
 		}
 		#end
 
-		#if rp_voxels
+		#if (rp_voxels != 'Off')
 		{
 			Inc.initGI();
+
+			var t = new RenderTargetRaw();
+			t.name = "gbuffer_voxpos";
+			t.width = 0;
+			t.height = 0;
+			t.displayp = Inc.getDisplayp();
+			t.format = "RGBA64";
+			t.scale = Inc.getSuperSampling();
+			path.createRenderTarget(t);
+
+			#if (rp_voxels == "Voxel AO")
 			path.loadShader("shader_datas/deferred_light/deferred_light_VoxelAOvar");
+			#end
 		}
 		#end
 
-		{
-			path.createDepthBuffer("main", "DEPTH24");
+		path.createDepthBuffer("main", "DEPTH24");
 
-			var t = new RenderTargetRaw();
-			t.name = "gbuffer0";
-			t.width = 0;
-			t.height = 0;
-			t.displayp = Inc.getDisplayp();
-			t.format = "RGBA64";
-			t.scale = Inc.getSuperSampling();
-			t.depth_buffer = "main";
-			path.createRenderTarget(t);
-		}
+		var t = new RenderTargetRaw();
+		t.name = "gbuffer0";
+		t.width = 0;
+		t.height = 0;
+		t.displayp = Inc.getDisplayp();
+		t.format = "RGBA64";
+		t.scale = Inc.getSuperSampling();
+		t.depth_buffer = "main";
+		path.createRenderTarget(t);
 
-		{
-			var t = new RenderTargetRaw();
-			t.name = "tex";
-			t.width = 0;
-			t.height = 0;
-			t.displayp = Inc.getDisplayp();
-			t.format = Inc.getHdrFormat();
-			t.scale = Inc.getSuperSampling();
-			t.depth_buffer = "main";
-			path.createRenderTarget(t);
-		}
+		var t = new RenderTargetRaw();
+		t.name = "tex";
+		t.width = 0;
+		t.height = 0;
+		t.displayp = Inc.getDisplayp();
+		t.format = Inc.getHdrFormat();
+		t.scale = Inc.getSuperSampling();
+		t.depth_buffer = "main";
+		path.createRenderTarget(t);
 
-		{
-			var t = new RenderTargetRaw();
-			t.name = "buf";
-			t.width = 0;
-			t.height = 0;
-			t.displayp = Inc.getDisplayp();
-			t.format = Inc.getHdrFormat();
-			t.scale = Inc.getSuperSampling();
-			path.createRenderTarget(t);
-		}
+		var t = new RenderTargetRaw();
+		t.name = "buf";
+		t.width = 0;
+		t.height = 0;
+		t.displayp = Inc.getDisplayp();
+		t.format = Inc.getHdrFormat();
+		t.scale = Inc.getSuperSampling();
+		path.createRenderTarget(t);
 
-		{
-			var t = new RenderTargetRaw();
-			t.name = "gbuffer1";
-			t.width = 0;
-			t.height = 0;
-			t.displayp = Inc.getDisplayp();
-			t.format = "RGBA64";
-			t.scale = Inc.getSuperSampling();
-			path.createRenderTarget(t);
-		}
+		var t = new RenderTargetRaw();
+		t.name = "gbuffer1";
+		t.width = 0;
+		t.height = 0;
+		t.displayp = Inc.getDisplayp();
+		t.format = "RGBA64";
+		t.scale = Inc.getSuperSampling();
+		path.createRenderTarget(t);
 
 		#if rp_gbuffer2
 		{
@@ -120,9 +125,7 @@ class RenderPathDeferred {
 			t.format = "RGBA64";
 			t.scale = Inc.getSuperSampling();
 			path.createRenderTarget(t);
-		}
 
-		{
 			var t = new RenderTargetRaw();
 			t.name = "taa";
 			t.width = 0;
@@ -138,6 +141,19 @@ class RenderPathDeferred {
 		{
 			var t = new RenderTargetRaw();
 			t.name = "gbuffer_emission";
+			t.width = 0;
+			t.height = 0;
+			t.displayp = Inc.getDisplayp();
+			t.format = "RGBA64";
+			t.scale = Inc.getSuperSampling();
+			path.createRenderTarget(t);
+		}
+		#end
+
+		#if rp_voxelgi_refract
+		{
+			var t = new RenderTargetRaw();
+			t.name = "gbuffer_refraction";
 			t.width = 0;
 			t.height = 0;
 			t.displayp = Inc.getDisplayp();
@@ -201,8 +217,7 @@ class RenderPathDeferred {
 			t.scale *= 0.5;
 			#end
 			path.createRenderTarget(t);
-		}
-		{
+
 			var t = new RenderTargetRaw();
 			t.name = "singleb";
 			t.width = 0;
@@ -227,8 +242,7 @@ class RenderPathDeferred {
 			t.format = "RGBA32";
 			t.scale = Inc.getSuperSampling();
 			path.createRenderTarget(t);
-		}
-		{
+
 			var t = new RenderTargetRaw();
 			t.name = "bufb";
 			t.width = 0;
@@ -308,9 +322,7 @@ class RenderPathDeferred {
 			t.height = 1;
 			t.format = Inc.getHdrFormat();
 			path.createRenderTarget(t);
-		}
 
-		{
 			path.loadShader("shader_datas/histogram_pass/histogram_pass");
 		}
 		#end
@@ -324,16 +336,14 @@ class RenderPathDeferred {
 
 		#if (rp_ssr_half || rp_ssgi_half)
 		{
-			{
-				path.loadShader("shader_datas/downsample_depth/downsample_depth");
-				var t = new RenderTargetRaw();
-				t.name = "half";
-				t.width = 0;
-				t.height = 0;
-				t.scale = Inc.getSuperSampling() * 0.5;
-				t.format = "R32"; // R16
-				path.createRenderTarget(t);
-			}
+			path.loadShader("shader_datas/downsample_depth/downsample_depth");
+			var t = new RenderTargetRaw();
+			t.name = "half";
+			t.width = 0;
+			t.height = 0;
+			t.scale = Inc.getSuperSampling() * 0.5;
+			t.format = "R32"; // R16
+			path.createRenderTarget(t);	
 		}
 		#end
 
@@ -352,8 +362,7 @@ class RenderPathDeferred {
 				t.scale = Inc.getSuperSampling() * 0.5;
 				t.format = Inc.getHdrFormat();
 				path.createRenderTarget(t);
-			}
-			{
+
 				var t = new RenderTargetRaw();
 				t.name = "ssrb";
 				t.width = 0;
@@ -523,33 +532,44 @@ class RenderPathDeferred {
 		#end
 
 		// Voxels
-		#if rp_voxels
+		#if (rp_voxels != 'Off')
+		var relight = false;
 		if (armory.data.Config.raw.rp_gi != false)
 		{
-			var voxelize = path.voxelize();
+			var path = RenderPath.active;
+
+			path.clearImage(voxels, 0x00000000);
 
 			#if arm_voxelgi_temporal
-			voxelize = ++RenderPathCreator.voxelFrame % RenderPathCreator.voxelFreq == 0;
-
-			if (voxelize) {
+			if(++armory.renderpath.RenderPathCreator.voxelFrame % armory.renderpath.RenderPathCreator.voxelFreq == 0) {
 				voxels = voxels == "voxels" ? "voxelsB" : "voxels";
 				voxelsLast = voxels == "voxels" ? "voxelsB" : "voxels";
 			}
 			#end
 
-			if (voxelize) {
-				var res = Inc.getVoxelRes();
-				var voxtex = voxels;
+			path.setTarget("");
+			var res = Inc.getVoxelRes();
+			path.setViewport(res, res);
+			path.bindTarget("gbuffer_voxpos", "gbuffer_voxpos");
+			path.bindTarget(voxels, "voxels");
 
-				path.clearImage(voxtex, 0x00000000);
-				path.setTarget("");
-				path.setViewport(res, res);
-				path.bindTarget(voxtex, "voxels");
-				path.drawMeshes("voxel");
-				path.generateMipmaps(voxels);
+			#if (rp_voxels == "Voxel GI")
+			#if rp_shadowmap
+			{
+				#if arm_shadowmap_atlas
+				Inc.bindShadowMapAtlas();
+				#else
+				Inc.bindShadowMap();
+				#end
 			}
+			#end
+			#end
+
+			path.drawMeshes("voxel");
+			path.generateMipmaps(voxels);
 		}
 		#end
+
 		// ---
 		// Deferred light
 		// ---
@@ -561,6 +581,10 @@ class RenderPathDeferred {
 		path.bindTarget("gbuffer0", "gbuffer0");
 		path.bindTarget("gbuffer1", "gbuffer1");
 
+		#if rp_voxelgi_refract
+		path.bindTarget("gbuffer_refraction", "gbuffer_refraction");
+		#end
+	
 		#if rp_gbuffer2
 		{
 			path.bindTarget("gbuffer2", "gbuffer2");
@@ -583,14 +607,18 @@ class RenderPathDeferred {
 			}
 		}
 		#end
+
 		var voxelao_pass = false;
-		#if rp_voxels
+		#if (rp_voxels != "Off")
 		if (armory.data.Config.raw.rp_gi != false)
 		{
-			#if arm_config
+			#if (arm_config && (rp_voxels == "Voxel AO"))
 			voxelao_pass = true;
 			#end
+
+			path.bindTarget("gbuffer_voxpos", "gbuffer_voxpos");
 			path.bindTarget(voxels, "voxels");
+
 			#if arm_voxelgi_temporal
 			{
 				path.bindTarget(voxelsLast, "voxelsLast");

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -570,6 +570,7 @@ class RenderPathDeferred {
 			path.generateMipmaps(voxels);
 
 			#if arm_voxelgi_bounces
+			path.setTarget("");
 			path.bindTarget(voxels, "voxels");
 			path.bindTarget("gbuffer_voxpos", "gbuffer_voxpos");
 			path.bindTarget("voxelsBounce", "voxelsBounce");

--- a/Sources/armory/renderpath/RenderPathForward.hx
+++ b/Sources/armory/renderpath/RenderPathForward.hx
@@ -9,7 +9,7 @@ class RenderPathForward {
 
 	static var path: RenderPath;
 
-	#if rp_voxels
+	#if (rp_voxels != "Off")
 	static var voxels = "voxels";
 	static var voxelsLast = "voxels";
 	#end
@@ -22,11 +22,10 @@ class RenderPathForward {
 	public static function setTargetMeshes() {
 		#if rp_render_to_texture
 		{
-			#if rp_ssr
-			path.setTarget("lbuffer0", ["lbuffer1"]);
-			#else
-			path.setTarget("lbuffer0");
-			#end
+			path.setTarget("lbuffer0", [
+			#if rp_ssr "lbuffer1", #end
+			#if (rp_voxels != "Off") "gbuffer_voxpos", #end
+			]);
 		}
 		#else
 		{
@@ -157,9 +156,18 @@ class RenderPathForward {
 		}
 		#end
 
-		#if rp_voxels
+		#if (rp_voxels != 'Off')
 		{
 			Inc.initGI();
+
+			var t = new RenderTargetRaw();
+			t.name = "gbuffer_voxpos";
+			t.width = 0;
+			t.height = 0;
+			t.displayp = Inc.getDisplayp();
+			t.format = "RGBA64";
+			t.scale = Inc.getSuperSampling();
+			path.createRenderTarget(t);
 		}
 		#end
 
@@ -173,8 +181,7 @@ class RenderPathForward {
 			t.format = "RGBA32";
 			t.scale = Inc.getSuperSampling();
 			path.createRenderTarget(t);
-		}
-		{
+
 			var t = new RenderTargetRaw();
 			t.name = "bufb";
 			t.width = 0;
@@ -203,26 +210,24 @@ class RenderPathForward {
 			path.loadShader("shader_datas/volumetric_light/volumetric_light");
 			path.loadShader("shader_datas/blur_bilat_pass/blur_bilat_pass_x");
 			path.loadShader("shader_datas/blur_bilat_blend_pass/blur_bilat_blend_pass_y");
-			{
-				var t = new RenderTargetRaw();
-				t.name = "singlea";
-				t.width = 0;
-				t.height = 0;
-				t.displayp = Inc.getDisplayp();
-				t.format = "R8";
-				t.scale = Inc.getSuperSampling();
-				path.createRenderTarget(t);
-			}
-			{
-				var t = new RenderTargetRaw();
-				t.name = "singleb";
-				t.width = 0;
-				t.height = 0;
-				t.displayp = Inc.getDisplayp();
-				t.format = "R8";
-				t.scale = Inc.getSuperSampling();
-				path.createRenderTarget(t);
-			}
+
+			var t = new RenderTargetRaw();
+			t.name = "singlea";
+			t.width = 0;
+			t.height = 0;
+			t.displayp = Inc.getDisplayp();
+			t.format = "R8";
+			t.scale = Inc.getSuperSampling();
+			path.createRenderTarget(t);
+
+			var t = new RenderTargetRaw();
+			t.name = "singleb";
+			t.width = 0;
+			t.height = 0;
+			t.displayp = Inc.getDisplayp();
+			t.format = "R8";
+			t.scale = Inc.getSuperSampling();
+			path.createRenderTarget(t);
 		}
 		#end
 
@@ -248,16 +253,14 @@ class RenderPathForward {
 
 		#if (rp_ssr_half || rp_ssgi_half)
 		{
-			{
-				path.loadShader("shader_datas/downsample_depth/downsample_depth");
-				var t = new RenderTargetRaw();
-				t.name = "half";
-				t.width = 0;
-				t.height = 0;
-				t.scale = Inc.getSuperSampling() * 0.5;
-				t.format = "R32"; // R16
-				path.createRenderTarget(t);
-			}
+			path.loadShader("shader_datas/downsample_depth/downsample_depth");
+			var t = new RenderTargetRaw();
+			t.name = "half";
+			t.width = 0;
+			t.height = 0;
+			t.scale = Inc.getSuperSampling() * 0.5;
+			t.format = "R32"; // R16
+			path.createRenderTarget(t);	
 		}
 		#end
 
@@ -276,8 +279,7 @@ class RenderPathForward {
 				t.scale = Inc.getSuperSampling() * 0.5;
 				t.format = Inc.getHdrFormat();
 				path.createRenderTarget(t);
-			}
-			{
+
 				var t = new RenderTargetRaw();
 				t.name = "ssrb";
 				t.width = 0;
@@ -310,30 +312,42 @@ class RenderPathForward {
 		}
 		#end
 
-		#if rp_voxels
+		// Voxels
+		#if (rp_voxels != 'Off')
+		if (armory.data.Config.raw.rp_gi != false)
 		{
-			var voxelize = path.voxelize();
+			var path = RenderPath.active;
+
+			path.clearImage(voxels, 0x00000000);
 
 			#if arm_voxelgi_temporal
-			voxelize = ++RenderPathCreator.voxelFrame % RenderPathCreator.voxelFreq == 0;
-
-			if (voxelize) {
+			if(++armory.renderpath.RenderPathCreator.voxelFrame % armory.renderpath.RenderPathCreator.voxelFreq == 0) {
 				voxels = voxels == "voxels" ? "voxelsB" : "voxels";
 				voxelsLast = voxels == "voxels" ? "voxelsB" : "voxels";
+				Voxels.voxelize(voxels);
 			}
 			#end
 
-			if (voxelize) {
-				var res = Inc.getVoxelRes();
-				var voxtex = voxels;
+			path.setTarget("");
+			var res = Inc.getVoxelRes();
+			path.setViewport(res, res);
+			path.bindTarget("gbuffer_voxpos", "gbuffer_voxpos");
+			path.bindTarget(voxels, "voxels");
 
-				path.clearImage(voxtex, 0x00000000);
-				path.setTarget("");
-				path.setViewport(res, res);
-				path.bindTarget(voxtex, "voxels");
-				path.drawMeshes("voxel");
-				path.generateMipmaps(voxels);
+			#if (rp_voxels == "Voxel GI")
+			#if rp_shadowmap
+			{
+				#if arm_shadowmap_atlas
+				Inc.bindShadowMapAtlas();
+				#else
+				Inc.bindShadowMap();
+				#end
 			}
+			#end
+			#end
+
+			path.drawMeshes("voxel");
+			path.generateMipmaps(voxels);
 		}
 		#end
 
@@ -366,9 +380,10 @@ class RenderPathForward {
 		}
 		#end
 
-		#if rp_voxels
+		#if (rp_voxels != "Off")
 		{
 			path.bindTarget(voxels, "voxels");
+			path.bindTarget("gbuffer_voxpos", "gbuffer_voxpos");
 			#if arm_voxelgi_temporal
 			{
 				path.bindTarget(voxelsLast, "voxelsLast");

--- a/Sources/armory/renderpath/RenderPathForward.hx
+++ b/Sources/armory/renderpath/RenderPathForward.hx
@@ -328,10 +328,11 @@ class RenderPathForward {
 			}
 			#end
 
-			path.setTarget("gbuffer_voxpos");
+			path.setTarget("", ["gbuffer_voxpos"]);
+			path.bindTarget(voxels, "voxels");
+
 			var res = Inc.getVoxelRes();
 			path.setViewport(res, res);
-			path.bindTarget(voxels, "voxels");
 
 			#if (rp_voxels == "Voxel GI")
 			#if rp_shadowmap
@@ -347,6 +348,14 @@ class RenderPathForward {
 
 			path.drawMeshes("voxel");
 			path.generateMipmaps(voxels);
+
+			#if arm_voxelgi_bounces
+			path.bindTarget(voxels, "voxels");
+			path.bindTarget("gbuffer_voxpos", "gbuffer_voxpos");
+			path.bindTarget("voxelsBounce", "voxelsBounce");
+			path.drawMeshes("voxel_bounce");
+			path.generateMipmaps("voxelsBounce");
+			#end
 		}
 		#end
 

--- a/blender/arm/assets.py
+++ b/blender/arm/assets.py
@@ -54,6 +54,7 @@ def reset():
     shader_cons['voxel_vert'] = []
     shader_cons['voxel_frag'] = []
     shader_cons['voxel_geom'] = []
+    shader_cons['voxelbounce_frag'] = []
 
 def add(asset_file):
     global assets

--- a/blender/arm/lightmapper/properties/renderer/cycles.py
+++ b/blender/arm/lightmapper/properties/renderer/cycles.py
@@ -11,9 +11,9 @@ class TLM_CyclesSceneProperties(bpy.types.PropertyGroup):
                 default="CPU")
 
     tlm_quality : EnumProperty(
-        items = [('0', 'Exterior Preview', 'Best for fast exterior previz'),
-                    ('1', 'Interior Preview', 'Best for fast interior previz with bounces'),
-                    ('2', 'Medium', 'Best for complicated interior preview and final for isometric environments'),
+        items = [('0', 'Exteior Preview', 'Best for fast exteior previz'),
+                    ('1', 'Inteior Preview', 'Best for fast inteior previz with bounces'),
+                    ('2', 'Medium', 'Best for complicated inteior preview and final for isometric environments'),
                     ('3', 'High', 'Best used for final baking for 3rd person games'),
                     ('4', 'Production', 'Best for first-person and Archviz'),
                     ('5', 'Custom', 'Uses the cycles sample settings provided the user')],

--- a/blender/arm/logicnode/arm_nodes.py
+++ b/blender/arm/logicnode/arm_nodes.py
@@ -190,7 +190,7 @@ class ArmLogicTreeNode(bpy.types.Node):
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
         # needs to be overridden by individual node classes with arm_version>1
-        """(only called if the node's version is inferior to the node class's version)
+        """(only called if the node's version is infeior to the node class's version)
         Help with the node replacement process, by explaining how a node (`self`) should be replaced.
         This method can either return a NodeReplacement object (see `nodes_logic.py`), or a brand new node.
 

--- a/blender/arm/logicnode/draw/LN_draw_arc.py
+++ b/blender/arm/logicnode/draw/LN_draw_arc.py
@@ -15,7 +15,7 @@ class DrawArcNode(ArmLogicTreeNode):
     @input Radius: The radius of the arc in pixels.
     @input Start Angle/End Angle: The angles in radians where the
         arc starts/ends, starting right of the arc's center.
-    @input Exterior Angle: Whether the angles describe an exterior angle.
+    @input Exteior Angle: Whether the angles describe an exteior angle.
 
     @output Out: Activated after the arc has been drawn.
 
@@ -38,6 +38,6 @@ class DrawArcNode(ArmLogicTreeNode):
         self.add_input('ArmFloatSocket', 'Radius', default_value=20.0)
         self.add_input('ArmFloatSocket', 'Start Angle')
         self.add_input('ArmFloatSocket', 'End Angle')
-        self.add_input('ArmBoolSocket', 'Exterior Angle', default_value=False)
+        self.add_input('ArmBoolSocket', 'Exteior Angle', default_value=False)
 
         self.add_output('ArmNodeSocketAction', 'Out')

--- a/blender/arm/logicnode/native/LN_call_haxe_static.py
+++ b/blender/arm/logicnode/native/LN_call_haxe_static.py
@@ -3,7 +3,7 @@ from arm.logicnode.arm_nodes import *
 class CallHaxeStaticNode(ArmLogicTreeNode):
     """Calls the given static Haxe function and optionally passes arguments to it.
 
-    **Compatibility info**: prior versions of this node didn't accept arguments and instead implicitly passed the current logic tree object as the first argument. In newer versions you need to pass that argument explicitly if the called function expects it.
+    **Compatibility info**: pior versions of this node didn't accept arguments and instead implicitly passed the current logic tree object as the first argument. In newer versions you need to pass that argument explicitly if the called function expects it.
 
     @input Function: the full module path to the function.
     @output Result: the result of the function."""

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -99,6 +99,10 @@ def add_world_defs():
         if rpdat.arm_voxelgi_shadows:
             wrd.world_defs += '_VoxelShadow'
 
+        if rpdat.arm_voxelgi_bounces:
+            wrd.world_defs += '_VoxelBounces'
+            assets.add_khafile_def('arm_voxelgi_bounces')
+
         if rpdat.arm_voxelgi_temporal:
             wrd.world_defs += '_VoxelTemporal'
             assets.add_khafile_def('arm_voxelgi_temporal')

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -94,14 +94,10 @@ def add_world_defs():
             voxelao = True
 
     if voxelgi or voxelao:
-        assets.add_khafile_def('arm_voxelgi')#might be uneeded
+        assets.add_khafile_def('arm_voxelgi')# might be uneeded
         wrd.world_defs += "_VoxelCones" + rpdat.arm_voxelgi_cones
         if rpdat.arm_voxelgi_shadows:
             wrd.world_defs += '_VoxelShadow'
-
-        if rpdat.arm_voxelgi_bounces:
-            wrd.world_defs += '_VoxelBounces'
-            assets.add_khafile_def('arm_voxelgi_bounces')
 
         if rpdat.arm_voxelgi_temporal:
             wrd.world_defs += '_VoxelTemporal'
@@ -112,7 +108,11 @@ def add_world_defs():
             if rpdat.arm_voxelgi_refraction:
                 wrd.world_defs += '_VoxelRefract'
                 assets.add_khafile_def('rp_voxelgi_refract')
-            assets.add_khafile_def('arm_voxelgi_clipmap_count={0}'.format(rpdat.arm_voxelgi_clipmap_count))
+            #assets.add_khafile_def('arm_voxelgi_clipmap_count={0}'.format(rpdat.arm_voxelgi_clipmap_count))
+
+            if rpdat.arm_voxelgi_bounces == '2':
+                wrd.world_defs += '_VoxelBounces'
+                assets.add_khafile_def('arm_voxelgi_bounces')
 
         elif voxelao:
             wrd.world_defs += '_VoxelAOvar' # Write a shader variant

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -108,7 +108,6 @@ def add_world_defs():
             if rpdat.arm_voxelgi_refraction:
                 wrd.world_defs += '_VoxelRefract'
                 assets.add_khafile_def('rp_voxelgi_refract')
-            #assets.add_khafile_def('arm_voxelgi_clipmap_count={0}'.format(rpdat.arm_voxelgi_clipmap_count))
 
             if rpdat.arm_voxelgi_bounces == '2':
                 wrd.world_defs += '_VoxelBounces'

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -113,7 +113,8 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
         curshader = state.frag
         state.curshader = curshader
 
-        out_basecol, out_roughness, out_metallic, out_occlusion, out_specular, out_opacity, out_emission_col = parse_shader_input(node.inputs[0])
+        out_basecol, out_roughness, out_metallic, out_occlusion, out_specular, out_opacity, out_ior, out_emission_col = parse_shader_input(node.inputs[0])
+
         if parse_surface:
             curshader.write(f'basecol = {out_basecol};')
             curshader.write(f'roughness = {out_roughness};')
@@ -131,7 +132,8 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
                     arm.assets.add_khafile_def('rp_gbuffer_emission')
 
         if parse_opacity:
-            curshader.write('opacity = {0} - 0.0002;'.format(out_opacity))
+            curshader.write('opacity = {0};'.format(out_opacity))
+            curshader.write('ior = {0};'.format(out_ior))
 
     # Volume
     # parse_volume_input(node.inputs[1])
@@ -258,6 +260,7 @@ def parse_shader(node: bpy.types.Node, socket: bpy.types.NodeSocket) -> Tuple[st
                     mat_state.emission_type = mat_state.EmissionType.SHADED
             if state.parse_opacity:
                 state.out_opacity = parse_value_input(node.inputs[1])
+                state.out_ior = 1.450;
         else:
             return parse_group(node, socket)
 

--- a/blender/arm/material/cycles_nodes/nodes_input.py
+++ b/blender/arm/material/cycles_nodes/nodes_input.py
@@ -35,7 +35,7 @@ def parse_attribute(node: bpy.types.ShaderNodeAttribute, out_socket: bpy.types.N
             return '1.0'
         return c.cast_value('time', from_type='float', to_type=out_type)
 
-    # UV maps (higher priority) and vertex colors
+    # UV maps (higher piority) and vertex colors
     if node.attribute_type == 'GEOMETRY':
 
         # Alpha output. Armory doesn't support vertex colors with alpha

--- a/blender/arm/material/cycles_nodes/nodes_shader.py
+++ b/blender/arm/material/cycles_nodes/nodes_shader.py
@@ -35,11 +35,11 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
     state.curshader.write('{0}float {1} = 1.0 - {2};'.format(prefix, fac_inv_var, fac_var))
 
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
-    bc1, rough1, met1, occ1, spec1, opac1, emi1 = c.parse_shader_input(node.inputs[1])
+    bc1, rough1, met1, occ1, spec1, opac1, ior1, emi1 = c.parse_shader_input(node.inputs[1])
     ek1 = mat_state.emission_type
 
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
-    bc2, rough2, met2, occ2, spec2, opac2, emi2 = c.parse_shader_input(node.inputs[2])
+    bc2, rough2, met2, occ2, spec2, opac2, ior2, emi2 = c.parse_shader_input(node.inputs[2])
     ek2 = mat_state.emission_type
 
     if state.parse_surface:
@@ -52,15 +52,15 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
         mat_state.emission_type = mat_state.EmissionType.get_effective_combination(ek1, ek2)
     if state.parse_opacity:
         state.out_opacity = '({0} * {3} + {1} * {2})'.format(opac1, opac2, fac_var, fac_inv_var)
-
+        state.out_ior = '({0} * {3} + {1} * {2})'.format(ior1, ior2, fac_var, fac_inv_var)
 
 def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket, state: ParserState) -> None:
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
-    bc1, rough1, met1, occ1, spec1, opac1, emi1 = c.parse_shader_input(node.inputs[0])
+    bc1, rough1, met1, occ1, spec1, opac1, ior1, emi1 = c.parse_shader_input(node.inputs[0])
     ek1 = mat_state.emission_type
 
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
-    bc2, rough2, met2, occ2, spec2, opac2, emi2 = c.parse_shader_input(node.inputs[1])
+    bc2, rough2, met2, occ2, spec2, opac2, ior2, emi2 = c.parse_shader_input(node.inputs[1])
     ek2 = mat_state.emission_type
 
     if state.parse_surface:
@@ -73,7 +73,7 @@ def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket,
         mat_state.emission_type = mat_state.EmissionType.get_effective_combination(ek1, ek2)
     if state.parse_opacity:
         state.out_opacity = '({0} * 0.5 + {1} * 0.5)'.format(opac1, opac2)
-
+        state.out_ior = '({0} * 0.5 + {1} * 0.5)'.format(ior1, ior2)
 
 def parse_bsdfprincipled(node: bpy.types.ShaderNodeBsdfPrincipled, out_socket: NodeSocket, state: ParserState) -> None:
     if state.parse_surface:
@@ -106,6 +106,7 @@ def parse_bsdfprincipled(node: bpy.types.ShaderNodeBsdfPrincipled, out_socket: N
         # clearcoar_normal = c.parse_vector_input(node.inputs[21])
         # tangent = c.parse_vector_input(node.inputs[22])
     if state.parse_opacity:
+        state.out_ior = c.parse_value_input(node.inputs[16]);
         if len(node.inputs) >= 21:
             state.out_opacity = c.parse_value_input(node.inputs[21])
 
@@ -154,10 +155,13 @@ def parse_emission(node: bpy.types.ShaderNodeEmission, out_socket: NodeSocket, s
 
 def parse_bsdfglass(node: bpy.types.ShaderNodeBsdfGlass, out_socket: NodeSocket, state: ParserState) -> None:
     if state.parse_surface:
+        state.out_basecol = c.parse_vector_input(node.inputs[0])
         c.write_normal(node.inputs[3])
         state.out_roughness = c.parse_value_input(node.inputs[1])
     if state.parse_opacity:
-        state.out_opacity = '(1.0 - {0}.r)'.format(c.parse_vector_input(node.inputs[0]))
+        state.out_opacity = '0.0'
+        state.out_specular = '1.0'
+        state.out_ior = c.parse_value_input(node.inputs[2])
 
 
 def parse_bsdfhair(node: bpy.types.ShaderNodeBsdfHair, out_socket: NodeSocket, state: ParserState) -> None:
@@ -170,9 +174,14 @@ def parse_holdout(node: bpy.types.ShaderNodeHoldout, out_socket: NodeSocket, sta
         state.out_occlusion = '0.0'
 
 
-def parse_bsdfrefraction(node: bpy.types.ShaderNodeBsdfRefraction, out_socket: NodeSocket, state: ParserState) -> None:
-    # c.write_normal(node.inputs[3])
-    pass
+def parse_bsdfrefraction(node: bpy.types.ShaderNodeBsdfRefraction, out_socket: NodeSocket, state: ParserState) -> None: 
+    if state.parse_surface:
+        state.out_basecol = c.parse_vector_input(node.inputs[0])
+        c.write_normal(node.inputs[3])
+        state.out_roughness = c.parse_value_input(node.inputs[1])
+    if state.parse_opacity:
+        state.out_opacity = '0.0'
+        state.out_ior = c.parse_value_input(node.inputs[2])
 
 
 def parse_subsurfacescattering(node: bpy.types.ShaderNodeSubsurfaceScattering, out_socket: NodeSocket, state: ParserState) -> None:

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -74,6 +74,7 @@ def write(vert: shader.Shader, frag: shader.Shader):
     frag.write('    roughness,')
     frag.write('    specular,')
     frag.write('    f0')
+
     if is_shadows:
         frag.write('\t, li, lightsArray[li * 3 + 2].x, lightsArray[li * 3 + 2].z != 0.0') # bias
     if '_Spot' in wrd.world_defs:
@@ -83,7 +84,7 @@ def write(vert: shader.Shader, frag: shader.Shader):
         frag.write('\t, lightsArraySpot[li].xyz') # spotDir
         frag.write('\t, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w)') # scale
         frag.write('\t, lightsArraySpot[li * 2 + 1].xyz') # right
-    if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:
+    if '_VoxelShadow' in wrd.world_defs and ('_VoxelAOvar' in wrd.world_defs or '_VoxelGI' in wrd.world_defs):
         frag.write('\t, voxels, voxpos')
     if '_MicroShadowing' in wrd.world_defs and not is_mobile:
         frag.write('\t, occlusion')

--- a/blender/arm/material/make_depth.py
+++ b/blender/arm/material/make_depth.py
@@ -52,6 +52,7 @@ def make(context_id, rpasses, shadowmap=False):
 
     if parse_opacity:
         frag.write('float opacity;')
+        frag.write('float ior;')
 
     if(con_depth).is_elem('morph'):
         make_morph_target.morph_pos(vert)

--- a/blender/arm/material/make_shader.py
+++ b/blender/arm/material/make_shader.py
@@ -17,6 +17,7 @@ import arm.material.make_mesh as make_mesh
 import arm.material.make_overlay as make_overlay
 import arm.material.make_transluc as make_transluc
 import arm.material.make_voxel as make_voxel
+import arm.material.make_voxel_bounce as make_voxel_bounce
 import arm.material.mat_state as mat_state
 import arm.material.mat_utils as mat_utils
 from arm.material.shader import Shader, ShaderContext, ShaderData
@@ -34,6 +35,7 @@ if arm.is_reload(__name__):
     make_overlay = arm.reload_module(make_overlay)
     make_transluc = arm.reload_module(make_transluc)
     make_voxel = arm.reload_module(make_voxel)
+    make_voxel_bounce = arm.reload_module(make_voxel_bounce)
     mat_state = arm.reload_module(mat_state)
     mat_utils = arm.reload_module(mat_utils)
     arm.material.shader = arm.reload_module(arm.material.shader)
@@ -107,6 +109,9 @@ def build(material: Material, mat_users: Dict[Material, List[Object]], mat_armus
 
         elif rp == 'voxel':
             con = make_voxel.make(rp)
+
+        elif rp == 'voxel_bounce':
+            con = make_voxel_bounce.make(rp)
 
         elif rpass_hook is not None:
             con = rpass_hook(rp)

--- a/blender/arm/material/make_shader.py
+++ b/blender/arm/material/make_shader.py
@@ -17,7 +17,7 @@ import arm.material.make_mesh as make_mesh
 import arm.material.make_overlay as make_overlay
 import arm.material.make_transluc as make_transluc
 import arm.material.make_voxel as make_voxel
-import arm.material.make_voxel_bounce as make_voxel_bounce
+import arm.material.make_voxelbounce as make_voxelbounce
 import arm.material.mat_state as mat_state
 import arm.material.mat_utils as mat_utils
 from arm.material.shader import Shader, ShaderContext, ShaderData
@@ -35,7 +35,7 @@ if arm.is_reload(__name__):
     make_overlay = arm.reload_module(make_overlay)
     make_transluc = arm.reload_module(make_transluc)
     make_voxel = arm.reload_module(make_voxel)
-    make_voxel_bounce = arm.reload_module(make_voxel_bounce)
+    make_voxelbounce = arm.reload_module(make_voxelbounce)
     mat_state = arm.reload_module(mat_state)
     mat_utils = arm.reload_module(mat_utils)
     arm.material.shader = arm.reload_module(arm.material.shader)
@@ -110,8 +110,8 @@ def build(material: Material, mat_users: Dict[Material, List[Object]], mat_armus
         elif rp == 'voxel':
             con = make_voxel.make(rp)
 
-        elif rp == 'voxel_bounce':
-            con = make_voxel_bounce.make(rp)
+        elif rp == 'voxelbounce':
+            con = make_voxelbounce.make(rp)
 
         elif rpass_hook is not None:
             con = rpass_hook(rp)

--- a/blender/arm/material/make_voxel.py
+++ b/blender/arm/material/make_voxel.py
@@ -118,7 +118,8 @@ def make_gi(context_id):
         vert.write('texCoordGeom = tex;')
 
     vert.add_uniform('vec3 viewerPos', '_viewerPos')
-    vert.add_uniform('vec3 eyeLook', '_cameraLook')
+    vert.add_uniform('vec3 eyeLook', '_cameraLook')
+
     vert.add_out('int clipmapLevelGeom')
     vert.add_out('float voxelSize')
 
@@ -134,7 +135,6 @@ def make_gi(context_id):
     geom.add_out('vec3 voxnormal')
     geom.add_out('flat int clipmapLevel')
     geom.add_out('float clipmapOffset')
-    geom.add_uniform('int clipmapCount', '_clipmapCount')
 
     if con_voxel.is_elem('col'):
         geom.add_out('vec3 vcolor')
@@ -334,7 +334,8 @@ def make_gi(context_id):
         frag.write('basecol *= visibility * lightsArray[li * 3 + 1].xyz;')
         frag.write('}')
 
-    frag.write('vec3 uvw = (voxposition * 0.5 + 0.5 + clipmapOffset) * voxelgiResolution;')
+    frag.write('vec3 uvw = (voxposition * 0.5 + 0.5 + clipmapOffset) * voxelgiResolution;')
+
     frag.add_out('vec3 voxpos')
     frag.write('voxpos.rgb = voxposition;')
     frag.write('imageStore(voxels, ivec3(uvw), vec4(min(surfaceAlbedo(basecol, metallic) + emissionCol, vec3(1.0)), 1.0));')
@@ -367,7 +368,7 @@ def make_ao(context_id):
     vert.add_out('vec3 voxpositionGeom')
 
     vert.add_uniform('vec3 viewerPos', '_viewerPos')
-    vert.add_uniform('vec3 eyeLook', '_cameraLook)
+    vert.add_uniform('vec3 eyeLook', '_cameraLook')
     vert.add_out('int clipmapLevelGeom')
     vert.add_out('float voxelSize')
 

--- a/blender/arm/material/make_voxel.py
+++ b/blender/arm/material/make_voxel.py
@@ -55,7 +55,6 @@ def make_gi(context_id):
 
     rpdat = arm.utils.get_rp()
     frag.add_uniform('layout(binding = 0, rgba8) image3D voxels')
-    frag.add_uniform('layout(binding = 1, rgba8) image3D voxelsNor')
 
     frag.write('vec3 basecol;')
     frag.write('float roughness;') #

--- a/blender/arm/material/make_voxel.py
+++ b/blender/arm/material/make_voxel.py
@@ -178,9 +178,7 @@ def make_gi(context_id):
     geom.write('}')
     geom.write('EndPrimitive();')
 
-    frag.add_uniform('int clipmapCount', '_clipmapCount')
     frag.write('if (abs(voxposition.x) > ' + rpdat.rp_voxelgi_resolution_z + ' || abs(voxposition.y) > 1 || abs(voxposition.z) > 1) return;')
-    frag.write('if (abs(voxposition.x) < (clipmapLevel / clipmapCount) * voxelgiResolution.x || abs(voxposition.y) < (clipmapLevel / clipmapCount) * voxelgiResolution.x || abs(voxposition.z) < (clipmapLevel / clipmapCount) * voxelgiResolution.x) return;')
 
     is_shadows = '_ShadowMap' in wrd.world_defs
     is_shadows_atlas = '_ShadowMapAtlas' in wrd.world_defs
@@ -404,9 +402,7 @@ def make_ao(context_id):
     geom.write('}')
     geom.write('EndPrimitive();')
 
-    frag.add_uniform('int clipmapCount', '_clipmapCount')
     frag.write('if (abs(voxposition.z) > ' + rpdat.rp_voxelgi_resolution_z + ' || abs(voxposition.x) > 1 || abs(voxposition.y) > 1) return;')
-    frag.write('if (abs(voxposition.x) < (clipmapLevel / clipmapCount) * voxelgiResolution.x || abs(voxposition.y) < (clipmapLevel / clipmapCount) * voxelgiResolution.x || abs(voxposition.z) < (clipmapLevel / clipmapCount) * voxelgiResolution.x) return;')
 
     frag.write('vec3 uvw = (voxposition * 0.5 + 0.5 + clipmapOffset) * voxelgiResolution;')
     frag.write('imageStore(voxels, ivec3(uvw), vec4(1.0));')

--- a/blender/arm/material/make_voxel.py
+++ b/blender/arm/material/make_voxel.py
@@ -2,6 +2,14 @@ import bpy
 
 import arm.utils
 import arm.assets as assets
+import arm.material.cycles as cycles
+import arm.material.mat_state as mat_state
+import arm.material.mat_utils as mat_utils
+import arm.material.make_particle as make_particle
+import arm.make_state as state
+
+import arm.utils
+import arm.assets as assets
 import arm.material.mat_state as mat_state
 
 if arm.is_reload(__name__):
@@ -11,16 +19,330 @@ if arm.is_reload(__name__):
 else:
     arm.enable_reload(__name__)
 
-
 def make(context_id):
     rpdat = arm.utils.get_rp()
-    con = make_ao(context_id)
+    if rpdat.rp_voxels == 'Voxel GI':
+        con = make_gi(context_id)
+    else:
+        con = make_ao(context_id)
 
     assets.vs_equal(con, assets.shader_cons['voxel_vert'])
     assets.fs_equal(con, assets.shader_cons['voxel_frag'])
     assets.gs_equal(con, assets.shader_cons['voxel_geom'])
 
     return con
+
+def make_gi(context_id):
+    con_voxel = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'always', 'cull_mode': 'none', 'color_write_red': False, 'color_write_green': False, 'color_write_blue': False, 'color_write_alpha': False, 'conservative_raster': True })
+    wrd = bpy.data.worlds['Arm']
+
+    vert = con_voxel.make_vert()
+    frag = con_voxel.make_frag()
+    geom = con_voxel.make_geom()
+    tesc = None
+    tese = None
+    geom.ins = vert.outs
+    frag.ins = geom.outs
+
+    vert.add_include('compiled.inc')
+    geom.add_include('compiled.inc')
+    frag.add_include('compiled.inc')
+    frag.add_include('std/math.glsl')
+    frag.add_include('std/imageatomic.glsl')
+    frag.add_include('std/gbuffer.glsl')
+    frag.add_include('std/brdf.glsl')
+    frag.write_header('#extension GL_ARB_shader_image_load_store : enable')
+
+    rpdat = arm.utils.get_rp()
+    frag.add_uniform('layout(binding = 0, rgba8) image3D voxels')
+    frag.add_uniform('layout(binding = 1, rgba8) image3D voxelsNor')
+
+    frag.write('vec3 basecol;')
+    frag.write('float roughness;') #
+    frag.write('float metallic;') #
+    frag.write('float occlusion;') #
+    frag.write('float specular;') #
+    frag.write('vec3 emissionCol = vec3(0.0);')
+    parse_opacity = rpdat.arm_voxelgi_refraction
+    if parse_opacity:
+        frag.write('float opacity;')
+        frag.write('float ior;')
+
+    frag.write('float dotNV = 0.0;')
+    cycles.parse(mat_state.nodes, con_voxel, vert, frag, geom, tesc, tese, parse_opacity=False, parse_displacement=False, basecol_only=True)
+
+    # Voxelized particles
+    particle = mat_state.material.arm_particle_flag
+    if particle and rpdat.arm_particles == 'On':
+        # make_particle.write(vert, particle_info=cycles.particle_info)
+        frag.write_pre = True
+        frag.write('const float p_index = 0;')
+        frag.write('const float p_age = 0;')
+        frag.write('const float p_lifetime = 0;')
+        frag.write('const vec3 p_location = vec3(0);')
+        frag.write('const float p_size = 0;')
+        frag.write('const vec3 p_velocity = vec3(0);')
+        frag.write('const vec3 p_angular_velocity = vec3(0);')
+        frag.write_pre = False
+
+    if not frag.contains('vec3 n ='):
+        frag.write_pre = True
+        frag.write('vec3 n;')
+        frag.write_pre = False
+
+    export_mpos = frag.contains('mposition') and not frag.contains('vec3 mposition')
+    if export_mpos:
+        vert.add_out('vec3 mpositionGeom')
+        vert.write_pre = True
+        vert.write('mpositionGeom = pos;')
+        vert.write_pre = False
+
+    export_bpos = frag.contains('bposition') and not frag.contains('vec3 bposition')
+    if export_bpos:
+        vert.add_out('vec3 bpositionGeom')
+        vert.add_uniform('vec3 dim', link='_dim')
+        vert.add_uniform('vec3 hdim', link='_halfDim')
+        vert.write_pre = True
+        vert.write('bpositionGeom = (pos.xyz + hdim) / dim;')
+        vert.write_pre = False
+
+    vert.add_uniform('mat4 W', '_worldMatrix')
+    vert.add_uniform('mat3 N', '_normalMatrix')
+    vert.add_out('vec3 voxpositionGeom')
+
+    if con_voxel.is_elem('col'):
+        vert.add_out('vec3 vcolorGeom')
+        vert.write('vcolorGeom = col.rgb;')
+
+    if con_voxel.is_elem('tex'):
+        vert.add_out('vec2 texCoordGeom')
+        vert.write('texCoordGeom = tex;')
+
+    vert.add_uniform('vec3 viewerPos', '_viewerPos')
+    vert.add_uniform('vec3 eyeLook', '_cameraLook')
+    vert.add_uniform('int clipmapCount', '_clipmapCount')
+    vert.add_out('int clipmapLevelGeom')
+    vert.add_out('float voxelSize')
+
+    vert.write('vec3 P = vec3(W * vec4(pos.xyz, 1.0));')
+    vert.write('float dist = max(abs(viewerPos.x - P.x), max(abs(viewerPos.y - P.y), abs(viewerPos.z - P.z)));')
+    vert.write('clipmapLevelGeom = int(max(log2(dist / voxelgiHalfExtents.x), 0));')
+    vert.write('float clipmapLevelSize = voxelgiHalfExtents.x * pow(2.0, clipmapLevelGeom);')
+    vert.write('float voxelSize = clipmapLevelSize / voxelgiResolution.x;')
+    vert.write('vec3 eyeSnap = floor((normalize(viewerPos + eyeLook) * voxelgiHalfExtents.x / 4.0) / voxelSize) * voxelSize;')
+    vert.write('voxpositionGeom = (P - eyeSnap) / clipmapLevelSize;')
+
+    geom.add_out('vec3 voxposition')
+    geom.add_out('vec3 voxnormal')
+    geom.add_out('flat int clipmapLevel')
+    geom.add_out('float clipmapOffset')
+    geom.add_uniform('int clipmapCount', '_clipmapCount')
+
+    if con_voxel.is_elem('col'):
+        geom.add_out('vec3 vcolor')
+    if con_voxel.is_elem('tex'):
+        geom.add_out('vec2 texCoord')
+    if export_mpos:
+        geom.add_out('vec3 mposition')
+    if export_bpos:
+        geom.add_out('vec3 bposition')
+
+    geom.write('vec3 p1 = voxpositionGeom[1] - voxpositionGeom[0];')
+    geom.write('vec3 p2 = voxpositionGeom[2] - voxpositionGeom[0];')
+
+    geom.write('vec3 p = abs(cross(p1, p2));')
+    geom.write('for (uint i = 0; i < 3; ++i) {')
+    geom.write('    voxposition = voxpositionGeom[i];')
+    geom.write('    clipmapLevel = clipmapLevelGeom[i];')
+    geom.write('    clipmapOffset = voxelSize[i] - 1.0 / voxelgiResolution.x;')
+    if '_Sun' in wrd.world_defs:
+        geom.write('lightPosition = lightPositionGeom[i];')
+    if '_SinglePoint' in wrd.world_defs and '_Spot' in wrd.world_defs:
+        geom.write('spotPosition = spotPositionGeom[i];')
+    if con_voxel.is_elem('col'):
+        geom.write('    vcolor = vcolorGeom[i];')
+    if con_voxel.is_elem('tex'):
+        geom.write('    texCoord = texCoordGeom[i];')
+    if export_mpos:
+        geom.write('    mposition = mpositionGeom[i];')
+    if export_bpos:
+        geom.write('    bposition = bpositionGeom[i];')
+    geom.write('    if (p.z > p.x && p.z > p.y) {')
+    geom.write('        gl_Position = vec4(voxposition.x, voxposition.y, 0.0, 1.0);')
+    geom.write('    }')
+    geom.write('    else if (p.x > p.y && p.x > p.z) {')
+    geom.write('        gl_Position = vec4(voxposition.y, voxposition.z, 0.0, 1.0);')
+    geom.write('    }')
+    geom.write('    else {')
+    geom.write('        gl_Position = vec4(voxposition.x, voxposition.z, 0.0, 1.0);')
+    geom.write('    }')
+    geom.write('    EmitVertex();')
+    geom.write('}')
+    geom.write('EndPrimitive();')
+
+    frag.add_uniform('int clipmapCount', '_clipmapCount')
+    frag.write('if (abs(voxposition.x) > ' + rpdat.rp_voxelgi_resolution_z + ' || abs(voxposition.y) > 1 || abs(voxposition.z) > 1) return;')
+    frag.write('if (abs(voxposition.x) < (clipmapLevel / clipmapCount) * voxelgiResolution.x || abs(voxposition.y) < (clipmapLevel / clipmapCount) * voxelgiResolution.x || abs(voxposition.z) < (clipmapLevel / clipmapCount) * voxelgiResolution.x) return;')
+
+    is_shadows = '_ShadowMap' in wrd.world_defs
+    is_shadows_atlas = '_ShadowMapAtlas' in wrd.world_defs
+    shadowmap_sun = 'shadowMap'
+    if is_shadows_atlas:
+        is_single_atlas = '_SingleAtlas' in wrd.world_defs
+        shadowmap_sun = 'shadowMapAtlasSun' if not is_single_atlas else 'shadowMapAtlas'
+        frag.add_uniform('vec2 smSizeUniform', '_shadowMapSize', included=True)
+    frag.write('vec3 direct = vec3(0.0);')
+
+    if '_Sun' in wrd.world_defs:
+        frag.add_uniform('vec3 sunCol', '_sunColor')
+        frag.add_uniform('vec3 sunDir', '_sunDirection')
+        frag.write('float svisibility = 1.0;')
+        frag.write('float sdotNL = max(dot(n, sunDir), 0.0);')
+        vert.add_out('vec4 lightPositionGeom')
+        geom.add_out('vec4 lightPosition')
+        if is_shadows:
+            vert.add_uniform('mat4 LWVP', '_biasLightWorldViewProjectionMatrixSun')
+            vert.write('lightPositionGeom = LWVP * pos;')
+            frag.add_uniform('bool receiveShadow')
+            frag.add_uniform(f'sampler2DShadow {shadowmap_sun}')
+            frag.add_uniform('float shadowsBias', '_sunShadowsBias')
+
+            frag.write('if (receiveShadow) {')
+            frag.write('    if (lightPosition.w > 0.0) {')
+            frag.write('    vec3 lPos = lightPosition.xyz / lightPosition.w;')
+            if '_Legacy' in wrd.world_defs:
+                frag.write(f'       svisibility = float(texture({shadowmap_sun}, vec2(lPos.xy)).r > lPos.z - shadowsBias);')
+            else:
+                frag.write(f'        svisibility = texture({shadowmap_sun}, vec3(lPos.xy, lPos.z - shadowsBias)).r;')
+            frag.write('    }')
+            frag.write('}') # receiveShadow
+            frag.write('basecol *= sunCol * svisibility;// * sdotNL;')
+
+    if '_SinglePoint' in wrd.world_defs:
+        frag.add_uniform('vec3 pointPos', '_pointPosition')
+        frag.add_uniform('vec3 pointCol', '_pointColor')
+        if '_Spot' in wrd.world_defs:
+            frag.add_uniform('vec3 spotDir', link='_spotDirection')
+            frag.add_uniform('vec3 spotRight', link='_spotRight')
+            frag.add_uniform('vec4 spotData', link='_spotData')
+        frag.write('float visibility = 1.0;')
+        frag.write('vec3 ld = pointPos - voxposition;')
+        frag.write('vec3 l = normalize(ld);')
+        frag.write('float dotNL = max(dot(n, l), 0.0);')
+        if is_shadows:
+            frag.add_uniform('bool receiveShadow')
+            frag.add_uniform('float pointBias', link='_pointShadowsBias')
+            frag.add_include('std/shadows.glsl')
+
+            frag.write('if (receiveShadow) {')
+            if '_Spot' in wrd.world_defs:
+                vert.add_out('vec4 spotPositionGeom')
+                geom.add_out('vec4 spotPosition')
+                vert.add_uniform('mat4 LWVPSpotArray[1]', link='_biasLightWorldViewProjectionMatrixSpotArray')
+                vert.write('spotPositionGeom = LWVPSpotArray[0] * pos;')
+                frag.add_uniform('sampler2DShadow shadowMapSpot[1]')
+                frag.write('if (spotPosition.w > 0.0) {')
+                frag.write('    vec3 lPos = spotPosition.xyz / spotPosition.w;')
+                if '_Legacy' in wrd.world_defs:
+                    frag.write('    visibility = float(texture(shadowMapSpot[0], vec2(lPos.xy)).r > lPos.z - pointBias);')
+                else:
+                    frag.write('    visibility = texture(shadowMapSpot[0], vec3(lPos.xy, lPos.z - pointBias)).r;')
+                frag.write('}')
+            else:
+                frag.add_uniform('vec2 lightProj', link='_lightPlaneProj')
+                frag.add_uniform('samplerCubeShadow shadowMapPoint[1]')
+                frag.write('const float s = shadowmapCubePcfSize;') # TODO: incorrect...
+                frag.write('float compare = lpToDepth(ld, lightProj) - pointBias * 1.5;')
+                frag.write('#ifdef _InvY')
+                frag.write('l.y = -l.y;')
+                frag.write('#endif')
+                if '_Legacy' in wrd.world_defs:
+                    frag.write('visibility *= float(texture(shadowMapPoint[0], vec3(-l + n * pointBias * 20)).r > compare);')
+                else:
+                    frag.write('visibility *= texture(shadowMapPoint[0], vec4(-l + n * pointBias * 20, compare)).r;')
+            frag.write('}')
+            frag.write('basecol *= pointCol * attenuate(distance(voxposition, pointPos)) * visibility;')
+
+    if '_Clusters' in wrd.world_defs:
+        is_shadows = '_ShadowMap' in wrd.world_defs
+        is_shadows_atlas = '_ShadowMapAtlas' in wrd.world_defs
+        is_single_atlas = '_SingleAtlas' in wrd.world_defs
+        frag.add_include_front('std/clusters.glsl')
+        frag.add_uniform('vec2 cameraProj', link='_cameraPlaneProj')
+        frag.add_uniform('vec2 cameraPlane', link='_cameraPlane')
+        frag.add_uniform('vec4 lightsArray[maxLights * 3]', link='_lightsArray')
+        frag.add_uniform('sampler2D clustersData', link='_clustersData')
+        if is_shadows:
+            frag.add_uniform('bool receiveShadow')
+            frag.add_uniform('vec2 lightProj', link='_lightPlaneProj')
+            frag.add_include('std/shadows.glsl')
+            if is_shadows_atlas:
+                if not is_single_atlas:
+                    frag.add_uniform('sampler2DShadow shadowMapAtlasPoint')
+                    frag.add_uniform('sampler2DShadow shadowMapAtlasSpot')
+                else:
+                    frag.add_uniform('sampler2DShadow shadowMapAtlas', top=True)
+                    frag.add_uniform('sampler2DShadow shadowMapAtlas', top=True)
+                frag.add_uniform('vec4 pointLightDataArray[maxLightsCluster]', link='_pointLightsAtlasArray')
+            else:
+                frag.add_uniform('samplerCubeShadow shadowMapPoint[4]')
+                frag.add_uniform('sampler2DShadow shadowMapSpot[4]')
+            frag.add_uniform('vec4 LWVPSpotArray[maxLightsCluster]', link='_biasLightWorldViewProjectionMatrixSpotArray')
+
+        frag.write('float viewz = linearize(voxposition.z, cameraProj);')
+        frag.write('int clusterI = getClusterI((voxposition.xy) * 0.5 + 0.5, viewz, cameraPlane);')
+        frag.write('int numLights = int(texelFetch(clustersData, ivec2(clusterI, 0), 0).r * 255);')
+
+        frag.add_uniform('vec4 lightsArraySpot[maxLights * 2]', link='_lightsArraySpot')
+        frag.write('int numSpots = int(texelFetch(clustersData, ivec2(clusterI, 1 + maxLightsCluster), 0).r * 255);')
+        frag.write('int numPoints = numLights - numSpots;')
+
+        frag.write('#ifdef HLSL')
+        frag.write('viewz += texture(clustersData, vec2(0.0)).r * 1e-9;') # TODO: krafix bug, needs to generate sampler
+        frag.write('#endif')
+
+        frag.write('for (int i = 0; i < min(numLights, maxLightsCluster); i++) {')
+        frag.write('float visibility = 1.0;')
+        frag.write('    int li = int(texelFetch(clustersData, ivec2(clusterI, i + 1), 0).r * 255);')
+        frag.write('    if(lightsArray[li * 3 + 2].y == 0.0) {') #point light
+        frag.write('    visibility = attenuate(distance(lightsArray[li * 3].xyz, voxposition));')
+        if is_shadows_atlas:
+            if not is_single_atlas:
+                frag.write('    visibility *= texture(shadowMapAtlasPoint, vec4(-normalize(lightsArray[li * 3].xyz - voxposition), lpToDepth(lightsArray[li * 3].xyz, lightProj) - lightsArray[li * 3 + 2].x)).r;')
+            else:
+                frag.write('    visibility *= texture(shadowMapAtlas, vec4(-normalize(lightsArray[li * 3].xyz - voxposition), lpToDepth(lightsArray[li * 3].xyz, lightProj) - lightsArray[li * 3 + 2].x)).r;')
+        else:
+            frag.write('if (li == 0) visibility *= texture(shadowMapPoint[0], vec4(-normalize(lightsArray[li * 3].xyz - voxposition), lpToDepth(lightsArray[li * 3].xyz, lightProj) - lightsArray[li * 3 + 2].x)).r;')
+            frag.write('if (li == 1) visibility *= texture(shadowMapPoint[1], vec4(-normalize(lightsArray[li * 3].xyz - voxposition), lpToDepth(lightsArray[li * 3].xyz, lightProj) - lightsArray[li * 3 + 2].x)).r;')
+            frag.write('if (li == 2) visibility *= texture(shadowMapPoint[2], vec4(-normalize(lightsArray[li * 3].xyz - voxposition), lpToDepth(lightsArray[li * 3].xyz, lightProj) - lightsArray[li * 3 + 2].x)).r;')
+            frag.write('if (li == 3) visibility *= texture(shadowMapPoint[3], vec4(-normalize(lightsArray[li * 3].xyz - voxposition), lpToDepth(lightsArray[li * 3].xyz, lightProj) - lightsArray[li * 3 + 2].x)).r;')
+
+        frag.write('}')
+        frag.write('    else {')#spot light
+        frag.write('        vec4 lightPosition = LWVPSpotArray[li * 3] * vec4(voxposition, 1.0);')
+        frag.write('        vec3 lPos = lightPosition.xyz / lightPosition.w;')
+        if is_shadows_atlas:
+            if not is_single_atlas:
+                frag.write('        visibility *= texture(shadowMapAtlaSpot, vec3(lPos.xy, lPos.z - lightsArray[li * 3 + 2].x)).r;')
+            else:
+                frag.write('        visibility *= texture(shadowMapAtla, vec3(lPos.xy, lPos.z - lightsArray[li * 3 + 2].x)).r;')
+        else:
+            frag.write('    if (li == 0) visibility *= texture(shadowMapSpot[0], vec3(lPos.xy, lPos.z - lightsArray[li * 3 + 2].x)).r;')
+            frag.write('    if (li == 1) visibility *= texture(shadowMapSpot[1], vec3(lPos.xy, lPos.z - lightsArray[li * 3 + 2].x)).r;')
+            frag.write('    if (li == 2) visibility *= texture(shadowMapSpot[2], vec3(lPos.xy, lPos.z - lightsArray[li * 3 + 2].x)).r;')
+            frag.write('    if (li == 3) visibility *= texture(shadowMapSpot[3], vec3(lPos.xy, lPos.z - lightsArray[li * 3 + 2].x)).r;')
+
+        frag.write('    }')
+        frag.write('basecol *= visibility * lightsArray[li * 3 + 1].xyz;')
+        frag.write('}')
+
+    frag.write('vec3 uvw = (voxposition * 0.5 + 0.5 + clipmapOffset) * voxelgiResolution;')
+    frag.add_uniform('sampler2D gbuffer_voxpos')
+    frag.add_out('vec3 voxpos')
+    frag.write('voxpos.rgb = voxposition;')
+    frag.write('imageStore(voxels, ivec3(uvw), vec4(min(surfaceAlbedo(basecol, metallic) + emissionCol, vec3(1.0)), 1.0));')
+    return con_voxel
+
 
 def make_ao(context_id):
     con_voxel = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'always', 'cull_mode': 'none', 'color_writes_red': [False], 'color_writes_green': [False], 'color_writes_blue': [False], 'color_writes_alpha': [False], 'conservative_raster': False })
@@ -33,109 +355,65 @@ def make_ao(context_id):
     tesc = None
     tese = None
 
-    if arm.utils.get_gapi() == 'direct3d11':
-        for e in con_voxel.data['vertex_elements']:
-            if e['name'] == 'nor':
-                con_voxel.data['vertex_elements'].remove(e)
-                break
+    geom.ins = vert.outs
+    frag.ins = geom.outs
 
-        # No geom shader compiler for hlsl yet
-        vert.noprocessing = True
-        frag.noprocessing = True
-        geom.noprocessing = True
+    frag.add_include('compiled.inc')
+    geom.add_include('compiled.inc')
+    frag.add_include('std/math.glsl')
+    frag.add_include('std/imageatomic.glsl')
+    frag.write_header('#extension GL_ARB_shader_image_load_store : enable')
+    frag.add_uniform('layout(r8) writeonly image3D voxels')
 
-        vert.add_uniform('mat4 W', '_worldMatrix')
-        vert.write('uniform float4x4 W;')
-        if rpdat.arm_voxelgi_revoxelize and rpdat.arm_voxelgi_camera:
-            vert.add_uniform('vec3 eyeSnap', '_cameraPositionSnap')
-            vert.write('uniform float3 eyeSnap;')
-        vert.write('struct SPIRV_Cross_Input { float4 pos : TEXCOORD0; };')
-        vert.write('struct SPIRV_Cross_Output { float4 svpos : SV_POSITION; };')
-        vert.write('SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input) {')
-        vert.write('  SPIRV_Cross_Output stage_output;')
-        voxHalfExt = str(round(rpdat.arm_voxelgi_dimensions / 2.0))
-        if rpdat.arm_voxelgi_revoxelize and rpdat.arm_voxelgi_camera:
-            vert.write('  stage_output.svpos.xyz = (mul(float4(stage_input.pos.xyz, 1.0), W).xyz - eyeSnap) / float3(' + voxHalfExt + ', ' + voxHalfExt + ', ' + voxHalfExt + ');')
-        else:
-            vert.write('  stage_output.svpos.xyz = mul(float4(stage_input.pos.xyz, 1.0), W).xyz / float3(' + voxHalfExt + ', ' + voxHalfExt + ', ' + voxHalfExt + ');')
-        vert.write('  stage_output.svpos.w = 1.0;')
-        vert.write('  return stage_output;')
-        vert.write('}')
+    vert.add_include('compiled.inc')
+    vert.add_uniform('mat4 W', '_worldMatrix')
+    vert.add_out('vec3 voxpositionGeom')
 
-        geom.write('struct SPIRV_Cross_Input { float4 svpos : SV_POSITION; };')
-        geom.write('struct SPIRV_Cross_Output { float3 wpos : TEXCOORD0; float4 svpos : SV_POSITION; };')
-        geom.write('[maxvertexcount(3)]')
-        geom.write('void main(triangle SPIRV_Cross_Input stage_input[3], inout TriangleStream<SPIRV_Cross_Output> output) {')
-        geom.write('  float3 p1 = stage_input[1].svpos.xyz - stage_input[0].svpos.xyz;')
-        geom.write('  float3 p2 = stage_input[2].svpos.xyz - stage_input[0].svpos.xyz;')
-        geom.write('  float3 p = abs(cross(p1, p2));')
-        geom.write('  for (int i = 0; i < 3; ++i) {')
-        geom.write('    SPIRV_Cross_Output stage_output;')
-        geom.write('    stage_output.wpos = stage_input[i].svpos.xyz;')
-        geom.write('    if (p.z > p.x && p.z > p.y) {')
-        geom.write('      stage_output.svpos = float4(stage_input[i].svpos.x, stage_input[i].svpos.y, 0.0, 1.0);')
-        geom.write('    }')
-        geom.write('    else if (p.x > p.y && p.x > p.z) {')
-        geom.write('      stage_output.svpos = float4(stage_input[i].svpos.y, stage_input[i].svpos.z, 0.0, 1.0);')
-        geom.write('    }')
-        geom.write('    else {')
-        geom.write('      stage_output.svpos = float4(stage_input[i].svpos.x, stage_input[i].svpos.z, 0.0, 1.0);')
-        geom.write('    }')
-        geom.write('    output.Append(stage_output);')
-        geom.write('  }')
-        geom.write('}')
+    vert.add_uniform('vec3 viewerPos', '_viewerPos')
+    vert.add_uniform('vec3 eyeLook', '_cameraLook')
+    vert.add_uniform('int clipmapCount', '_clipmapCount')
+    vert.add_out('int clipmapLevelGeom')
+    vert.add_out('float voxelSize')
 
-        frag.add_uniform('layout(r8) writeonly image3D voxels')
-        frag.write('RWTexture3D<float> voxels;')
-        frag.write('struct SPIRV_Cross_Input { float3 wpos : TEXCOORD0; };')
-        frag.write('struct SPIRV_Cross_Output { float4 FragColor : SV_TARGET0; };')
-        frag.write('void main(SPIRV_Cross_Input stage_input) {')
-        frag.write('  if (abs(stage_input.wpos.z) > ' + rpdat.rp_voxelgi_resolution_z + ' || abs(stage_input.wpos.x) > 1 || abs(stage_input.wpos.y) > 1) return;')
-        voxRes = str(rpdat.rp_voxelgi_resolution)
-        voxResZ = str(int(int(rpdat.rp_voxelgi_resolution) * float(rpdat.rp_voxelgi_resolution_z)))
-        frag.write('  voxels[int3(' + voxRes + ', ' + voxRes + ', ' + voxResZ + ') * (stage_input.wpos * 0.5 + 0.5)] = 1.0;')
-        frag.write('')
-        frag.write('}')
-    else:
-        geom.ins = vert.outs
-        frag.ins = geom.outs
+    vert.write('vec3 P = vec3(W * vec4(pos.xyz, 1.0));')
+    vert.write('float dist = max(abs(viewerPos.x - P.x), max(abs(viewerPos.y - P.y), abs(viewerPos.z - P.z)));')
+    vert.write('clipmapLevelGeom = int(max(log2(dist / voxelgiHalfExtents.x), 0));')
+    vert.write('float clipmapLevelSize = voxelgiHalfExtents.x * pow(2.0, clipmapLevelGeom);')
+    vert.write('float voxelSize = clipmapLevelSize / voxelgiResolution.x;')
+    vert.write('vec3 eyeSnap = floor((normalize(viewerPos + eyeLook) * voxelgiHalfExtents.x / 4.0) / voxelSize) * voxelSize;')
+    vert.write('voxpositionGeom = (P - eyeSnap) / clipmapLevelSize;')
 
-        frag.add_include('compiled.inc')
-        frag.add_include('std/math.glsl')
-        frag.add_include('std/imageatomic.glsl')
-        frag.write_header('#extension GL_ARB_shader_image_load_store : enable')
-        frag.add_uniform('layout(r8) writeonly image3D voxels')
+    geom.add_out('vec3 voxposition')
+    geom.add_out('flat int clipmapLevel')
+    geom.add_out('float clipmapOffset')
 
-        vert.add_include('compiled.inc')
-        vert.add_uniform('mat4 W', '_worldMatrix')
-        vert.add_out('vec3 voxpositionGeom')
+    geom.write('vec3 p1 = voxpositionGeom[1] - voxpositionGeom[0];')
+    geom.write('vec3 p2 = voxpositionGeom[2] - voxpositionGeom[0];')
+    geom.write('vec3 p = abs(cross(p1, p2));')
+    geom.write('for (uint i = 0; i < 3; ++i) {')
+    geom.write('    voxposition = voxpositionGeom[i];')
+    geom.write('    clipmapLevel = clipmapLevelGeom[i];')
+    geom.write('    clipmapOffset = voxelSize[i] - 1.0 / voxelgiResolution.x;')
+    geom.write('    if (p.z > p.x && p.z > p.y) {')
+    geom.write('        gl_Position = vec4(voxposition.x, voxposition.y, 0.0, 1.0);')
+    geom.write('    }')
+    geom.write('    else if (p.x > p.y && p.x > p.z) {')
+    geom.write('        gl_Position = vec4(voxposition.y, voxposition.z, 0.0, 1.0);')
+    geom.write('    }')
+    geom.write('    else {')
+    geom.write('        gl_Position = vec4(voxposition.x, voxposition.z, 0.0, 1.0);')
+    geom.write('    }')
+    geom.write('    EmitVertex();')
+    geom.write('}')
+    geom.write('EndPrimitive();')
 
-        if rpdat.arm_voxelgi_revoxelize and rpdat.arm_voxelgi_camera:
-            vert.add_uniform('vec3 eyeSnap', '_cameraPositionSnap')
-            vert.write('voxpositionGeom = (vec3(W * vec4(pos.xyz, 1.0)) - eyeSnap) / voxelgiHalfExtents;')
-        else:
-            vert.write('voxpositionGeom = vec3(W * vec4(pos.xyz, 1.0)) / voxelgiHalfExtents;')
+    frag.add_uniform('int clipmapCount', '_clipmapCount')
+    frag.write('if (abs(voxposition.z) > ' + rpdat.rp_voxelgi_resolution_z + ' || abs(voxposition.x) > 1 || abs(voxposition.y) > 1) return;')
+    frag.write('if (abs(voxposition.x) < (clipmapLevel / clipmapCount) * voxelgiResolution.x || abs(voxposition.y) < (clipmapLevel / clipmapCount) * voxelgiResolution.x || abs(voxposition.z) < (clipmapLevel / clipmapCount) * voxelgiResolution.x) return;')
 
-        geom.add_out('vec3 voxposition')
-        geom.write('vec3 p1 = voxpositionGeom[1] - voxpositionGeom[0];')
-        geom.write('vec3 p2 = voxpositionGeom[2] - voxpositionGeom[0];')
-        geom.write('vec3 p = abs(cross(p1, p2));')
-        geom.write('for (uint i = 0; i < 3; ++i) {')
-        geom.write('    voxposition = voxpositionGeom[i];')
-        geom.write('    if (p.z > p.x && p.z > p.y) {')
-        geom.write('        gl_Position = vec4(voxposition.x, voxposition.y, 0.0, 1.0);')
-        geom.write('    }')
-        geom.write('    else if (p.x > p.y && p.x > p.z) {')
-        geom.write('        gl_Position = vec4(voxposition.y, voxposition.z, 0.0, 1.0);')
-        geom.write('    }')
-        geom.write('    else {')
-        geom.write('        gl_Position = vec4(voxposition.x, voxposition.z, 0.0, 1.0);')
-        geom.write('    }')
-        geom.write('    EmitVertex();')
-        geom.write('}')
-        geom.write('EndPrimitive();')
-
-        frag.write('if (abs(voxposition.z) > ' + rpdat.rp_voxelgi_resolution_z + ' || abs(voxposition.x) > 1 || abs(voxposition.y) > 1) return;')
-        frag.write('imageStore(voxels, ivec3(voxelgiResolution * (voxposition * 0.5 + 0.5)), vec4(1.0));')
+    frag.write('vec3 uvw = (voxposition * 0.5 + 0.5 + clipmapOffset) * voxelgiResolution;')
+    frag.write('imageStore(voxels, ivec3(uvw), vec4(1.0));')
+    frag.add_out('vec3 voxpos')
+    frag.write('voxpos = voxposition;')
 
     return con_voxel

--- a/blender/arm/material/make_voxel_bounce.py
+++ b/blender/arm/material/make_voxel_bounce.py
@@ -1,0 +1,43 @@
+import bpy
+
+import arm.utils
+import arm.assets as assets
+import arm.material.cycles as cycles
+import arm.material.mat_state as mat_state
+import arm.material.mat_utils as mat_utils
+import arm.material.make_particle as make_particle
+import arm.make_state as state
+
+import arm.utils
+import arm.assets as assets
+import arm.material.mat_state as mat_state
+
+if arm.is_reload(__name__):
+    arm.utils = arm.reload_module(arm.utils)
+    assets = arm.reload_module(assets)
+    mat_state = arm.reload_module(mat_state)
+else:
+    arm.enable_reload(__name__)
+
+def make(context_id):
+    con_voxel = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'always', 'cull_mode': 'none', 'color_write_red': False, 'color_write_green': False, 'color_write_blue': False, 'color_write_alpha': False, 'conservative_raster': True })
+
+    frag = con_voxel.make_frag()
+
+    frag.add_include('compiled.inc')
+    frag.add_include('std/conetrace.glsl')
+    frag.write_header('#extension GL_ARB_shader_image_load_store : enable')
+
+    frag.add_uniform('sampler3D voxels')
+    frag.add_uniform('sampler3D voxelsBounce')
+    frag.add_uniform('sampler2D gbuffer_voxpos')
+    frag.add_uniform('mat3 N', '_normalMatrix')
+
+    frag.write('vec3 voxpos = textureLod(gbuffer_voxpos, texCoord, 0.0).rgb;')
+    frag.write('vec3 wnormal = normalize(N * vec3(nor.xy, pos.w));')
+    frag.write('vec4 col = traceDiffure(voxpos, wnormal, voxels);')
+    frag.write('imageStore(voxelsBounce, voxpos, col);')
+
+    assets.fs_equal(con_voxel, assets.shader_cons['voxel_bounce_frag'])
+
+    return con_voxel

--- a/blender/arm/material/make_voxel_bounce.py
+++ b/blender/arm/material/make_voxel_bounce.py
@@ -29,15 +29,19 @@ def make(context_id):
     frag.write_header('#extension GL_ARB_shader_image_load_store : enable')
 
     frag.add_uniform('sampler3D voxels')
-    frag.add_uniform('sampler3D voxelsBounce')
+    frag.add_uniform('layout(binding = 0, rgba8) image3D voxelsBounce')
     frag.add_uniform('sampler2D gbuffer_voxpos')
     frag.add_uniform('mat3 N', '_normalMatrix')
 
+    frag.add_in('vec2 texCoord')
+    frag.add_in('vec2 nor')
+    frag.add_in('vec4 pos')
+
     frag.write('vec3 voxpos = textureLod(gbuffer_voxpos, texCoord, 0.0).rgb;')
     frag.write('vec3 wnormal = normalize(N * vec3(nor.xy, pos.w));')
-    frag.write('vec4 col = traceDiffure(voxpos, wnormal, voxels);')
-    frag.write('imageStore(voxelsBounce, voxpos, col);')
+    frag.write('vec4 col = traceDiffuse(voxpos, wnormal, voxels);')
+    frag.write('imageStore(voxelsBounce, ivec3(voxpos), col);')
 
-    assets.fs_equal(con_voxel, assets.shader_cons['voxel_bounce_frag'])
+    assets.fs_equal(con_voxel, assets.shader_cons['voxelbounce_frag'])
 
     return con_voxel

--- a/blender/arm/material/make_voxelbounce.py
+++ b/blender/arm/material/make_voxelbounce.py
@@ -22,23 +22,27 @@ else:
 def make(context_id):
     con_voxel = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'always', 'cull_mode': 'none', 'color_write_red': False, 'color_write_green': False, 'color_write_blue': False, 'color_write_alpha': False, 'conservative_raster': True })
 
+    con_voxel.add_elem('tex', 'short2norm')
+
+    vert = con_voxel.make_vert()
     frag = con_voxel.make_frag()
+
+    frag.ins = vert.outs
 
     frag.add_include('compiled.inc')
     frag.add_include('std/conetrace.glsl')
     frag.write_header('#extension GL_ARB_shader_image_load_store : enable')
 
+    vert.add_uniform('mat3 N', '_normalMatrix')
     frag.add_uniform('sampler3D voxels')
     frag.add_uniform('layout(binding = 0, rgba8) image3D voxelsBounce')
     frag.add_uniform('sampler2D gbuffer_voxpos')
-    frag.add_uniform('mat3 N', '_normalMatrix')
 
-    frag.add_in('vec2 texCoord')
-    frag.add_in('vec2 nor')
-    frag.add_in('vec4 pos')
+    vert.add_out('vec2 texCoord')
+    vert.add_out('vec3 wnormal')
+    vert.write('wnormal = normalize(N * vec3(nor.xy, pos.w));')
 
     frag.write('vec3 voxpos = textureLod(gbuffer_voxpos, texCoord, 0.0).rgb;')
-    frag.write('vec3 wnormal = normalize(N * vec3(nor.xy, pos.w));')
     frag.write('vec4 col = traceDiffuse(voxpos, wnormal, voxels);')
     frag.write('imageStore(voxelsBounce, ivec3(voxpos), col);')
 

--- a/blender/arm/material/mat_utils.py
+++ b/blender/arm/material/mat_utils.py
@@ -47,10 +47,10 @@ def get_rpasses(material):
         ar.append('mesh')
         for con in add_mesh_contexts:
             ar.append(con)
-        if is_transluc(material) and not material.arm_discard and rpdat.rp_translucency_state != 'Off' and not material.arm_blending:
+        if is_transluc(material) and not material.arm_discard and rpdat.rp_translucency_state != 'Off' and not material.arm_blending and not (rpdat.rp_voxels == "Voxel GI" and rpdat.arm_voxelgi_refraction):
             ar.append('translucent')
-        if rpdat.rp_voxelao and has_voxels:
-            ar.append('voxel')
+        if rpdat.rp_voxels != "Off" and has_voxels:
+           ar.append('voxel')
         if rpdat.rp_renderer == 'Forward' and rpdat.rp_depthprepass and not material.arm_blending and not material.arm_particle_flag:
             ar.append('depth')
 

--- a/blender/arm/material/mat_utils.py
+++ b/blender/arm/material/mat_utils.py
@@ -51,6 +51,8 @@ def get_rpasses(material):
             ar.append('translucent')
         if rpdat.rp_voxels != "Off" and has_voxels:
            ar.append('voxel')
+           if rpdat.arm_voxelgi_bounces != 1:
+               ar.append('voxel_bounce')
         if rpdat.rp_renderer == 'Forward' and rpdat.rp_depthprepass and not material.arm_blending and not material.arm_particle_flag:
             ar.append('depth')
 

--- a/blender/arm/material/mat_utils.py
+++ b/blender/arm/material/mat_utils.py
@@ -51,8 +51,8 @@ def get_rpasses(material):
             ar.append('translucent')
         if rpdat.rp_voxels != "Off" and has_voxels:
            ar.append('voxel')
-           if rpdat.arm_voxelgi_bounces != 1:
-               ar.append('voxel_bounce')
+           if rpdat.arm_voxelgi_bounces == '2':
+               ar.append('voxelbounce')
         if rpdat.rp_renderer == 'Forward' and rpdat.rp_depthprepass and not material.arm_blending and not material.arm_particle_flag:
             ar.append('depth')
 

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -97,6 +97,7 @@ class ParserState:
         self.out_occlusion: floatstr = '1.0'
         self.out_specular: floatstr = '1.0'
         self.out_opacity: floatstr = '1.0'
+        self.out_ior: floatstr = '1.45'
         self.out_emission_col: vec3str = 'vec3(0.0)'
 
     def reset_outs(self):
@@ -107,12 +108,13 @@ class ParserState:
         self.out_occlusion = '1.0'
         self.out_specular = '1.0'
         self.out_opacity = '1.0'
+        self.out_ior = '1.45'
         self.out_emission_col = 'vec3(0.0)'
 
-    def get_outs(self) -> Tuple[vec3str, floatstr, floatstr, floatstr, floatstr, floatstr, vec3str]:
+    def get_outs(self) -> Tuple[vec3str, floatstr, floatstr, floatstr, floatstr, floatstr, floatstr, vec3str]:
         """Return the shader output values as a tuple."""
         return (self.out_basecol, self.out_roughness, self.out_metallic, self.out_occlusion, self.out_specular,
-                self.out_opacity, self.out_emission_col)
+                self.out_opacity, self.out_ior, self.out_emission_col)
 
     def get_parser_pass_suffix(self) -> str:
         """Return a suffix for the current parser pass that can be appended

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -566,7 +566,7 @@ def update_armory_world():
         for rp in wrd.arm_rplist:  # TODO: deprecated
             if rp.rp_gi != 'Off':
                 rp.rp_gi = 'Off'
-                rp.rp_voxelao = True
+                rp.rp_voxels = rp.rp_gi
 
         # For some breaking changes we need to use a special update
         # routine first before regularly replacing nodes

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -496,11 +496,11 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_ssr_half_res: BoolProperty(name="Half Res", description="Trace in half resolution", default=True, update=update_renderpath)
     #rp_voxelgi_relight: BoolProperty(name="Relight", description="Relight voxels when light is moved", default=True, update=update_renderpath)
     arm_voxelgi_refraction: BoolProperty(name="Trace Refraction", description="Use voxels to render refraction", default=False, update=update_renderpath)
-    #arm_voxelgi_bounces: EnumProperty(
-    #    items=[
-    #    	   ('1', '1', '1'),
-    #           ('2', '2', '2')],
-    #    name="Bounces", description="Trace multiple light bounces", default='1', update=update_renderpath)
+    arm_voxelgi_bounces: EnumProperty(
+        items=[
+        	   ('1', '1', '1'),
+               ('2', '2', '2')],
+        name="Bounces", description="Trace multiple light bounces", default='1', update=update_renderpath)
     arm_voxelgi_dimensions: FloatProperty(name="Dimensions", description="Voxelization bounds",default=16, update=assets.invalidate_compiled_data)
     arm_voxelgi_clipmap_count: IntProperty(name="Clipmap Count", description="Exponential multiplier for voxelization bounds", default=5, update=assets.invalidate_compiled_data)
     arm_voxelgi_temporal: BoolProperty(name="Temporal Filter", description="Use temporal filtering to stabilize voxels", default=False, update=assets.invalidate_shader_cache)

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -64,7 +64,7 @@ def update_preset(self, context):
         rpdat.rp_hdr = True
         rpdat.rp_background = 'World'
         rpdat.rp_stereo = False
-        rpdat.rp_voxelao = False
+        rpdat.rp_voxels = 'Off'
         rpdat.rp_render_to_texture = True
         rpdat.rp_supersampling = '1'
         rpdat.rp_antialiasing = 'SMAA'
@@ -102,7 +102,7 @@ def update_preset(self, context):
         rpdat.rp_hdr = False
         rpdat.rp_background = 'Clear'
         rpdat.rp_stereo = False
-        rpdat.rp_voxelao = False
+        rpdat.rp_voxels = 'Off'
         rpdat.rp_render_to_texture = False
         rpdat.rp_supersampling = '1'
         rpdat.rp_antialiasing = 'Off'
@@ -138,10 +138,11 @@ def update_preset(self, context):
         rpdat.rp_hdr = True
         rpdat.rp_background = 'World'
         rpdat.rp_stereo = False
-        rpdat.rp_voxelao = True
+        rpdat.rp_voxels = 'Voxel GI'
         rpdat.rp_voxelgi_resolution = '128'
         rpdat.arm_voxelgi_revoxelize = False
         rpdat.arm_voxelgi_camera = False
+        rpdat.rp_voxelgi_emission = False
         rpdat.rp_render_to_texture = True
         rpdat.rp_supersampling = '1'
         rpdat.rp_antialiasing = 'TAA'
@@ -181,7 +182,7 @@ def update_preset(self, context):
         rpdat.rp_hdr = False
         rpdat.rp_background = 'Clear'
         rpdat.rp_stereo = False
-        rpdat.rp_voxelao = False
+        rpdat.rp_voxels = 'Off'
         rpdat.rp_render_to_texture = False
         rpdat.rp_supersampling = '1'
         rpdat.rp_antialiasing = 'Off'
@@ -439,13 +440,12 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     rp_stereo: BoolProperty(name="VR", description="Stereo rendering", default=False, update=update_renderpath)
     rp_water: BoolProperty(name="Water", description="Enable water surface pass", default=False, update=update_renderpath)
     rp_pp: BoolProperty(name="Realtime postprocess", description="Realtime postprocess", default=False, update=update_renderpath)
-    rp_gi: EnumProperty( # TODO: remove in 0.8
+    rp_voxels: EnumProperty(
         items=[('Off', 'Off', 'Off'),
-               ('Voxel GI', 'Voxel GI', 'Voxel GI', 'ERROR', 1),
+               ('Voxel GI', 'Voxel GI', 'Voxel GI'),
                ('Voxel AO', 'Voxel AO', 'Voxel AO')
                ],
-        name="Global Illumination", description="Dynamic global illumination", default='Off', update=update_renderpath)
-    rp_voxelao: BoolProperty(name="Voxel AO", description="Voxel-based ambient occlusion", default=False, update=update_renderpath)
+        name="Voxels", description="Dynamic global illumination", default='Off', update=update_renderpath)
     rp_voxelgi_resolution: EnumProperty(
         items=[('32', '32', '32'),
                ('64', '64', '64'),
@@ -494,10 +494,16 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     rp_dynres: BoolProperty(name="Dynamic Resolution", description="Dynamic resolution scaling for performance", default=False, update=update_renderpath)
     rp_chromatic_aberration: BoolProperty(name="Chromatic Aberration", description="Add chromatic aberration (scene fringe)", default=False, update=assets.invalidate_shader_cache)
     arm_ssr_half_res: BoolProperty(name="Half Res", description="Trace in half resolution", default=True, update=update_renderpath)
+    #rp_voxelgi_relight: BoolProperty(name="Relight", description="Relight voxels when light is moved", default=True, update=update_renderpath)
+    arm_voxelgi_refraction: BoolProperty(name="Trace Refraction", description="Use voxels to render refraction", default=False, update=update_renderpath)
+    #arm_voxelgi_bounces: EnumProperty(
+    #    items=[
+    #    	   ('1', '1', '1'),
+    #           ('2', '2', '2')],
+    #    name="Bounces", description="Trace multiple light bounces", default='1', update=update_renderpath)
     arm_voxelgi_dimensions: FloatProperty(name="Dimensions", description="Voxelization bounds",default=16, update=assets.invalidate_compiled_data)
-    arm_voxelgi_revoxelize: BoolProperty(name="Revoxelize", description="Revoxelize scene each frame", default=False, update=assets.invalidate_shader_cache)
+    arm_voxelgi_clipmap_count: IntProperty(name="Clipmap Count", description="Exponential multiplier for voxelization bounds", default=5, update=assets.invalidate_compiled_data)
     arm_voxelgi_temporal: BoolProperty(name="Temporal Filter", description="Use temporal filtering to stabilize voxels", default=False, update=assets.invalidate_shader_cache)
-    arm_voxelgi_camera: BoolProperty(name="Dynamic Camera", description="Use camera as voxelization origin", default=False, update=assets.invalidate_shader_cache)
     arm_voxelgi_shadows: BoolProperty(name="Shadows", description="Use voxels to render shadows", default=False, update=update_renderpath)
     arm_samples_per_pixel: EnumProperty(
         items=[('1', '1', '1'),
@@ -513,7 +519,10 @@ class ArmRPListItem(bpy.types.PropertyGroup):
                ('3', '3', '3'),
                ('1', '1', '1'),
                ],
-        name="Cones", description="Number of cones to trace", default='5', update=assets.invalidate_shader_cache)
+        name="Cones", description="Number of cones to trace", default='9', update=assets.invalidate_shader_cache)
+    arm_voxelgi_diff: FloatProperty(name="Diffuse", description="", default=1.0, update=assets.invalidate_shader_cache)
+    arm_voxelgi_spec: FloatProperty(name="Reflection", description="", default=1.0, update=assets.invalidate_shader_cache)
+    arm_voxelgi_refr: FloatProperty(name="Refraction", description="", default=1.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_occ: FloatProperty(name="Intensity", description="", default=1.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_step: FloatProperty(name="Step", description="Step size", default=1.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_offset: FloatProperty(name="Offset", description="Ray offset", default=1.0, update=assets.invalidate_shader_cache)
@@ -556,7 +565,7 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     )
     arm_motion_blur_intensity: FloatProperty(name="Intensity", default=1.0, update=assets.invalidate_shader_cache)
     arm_ssr_ray_step: FloatProperty(name="Step", default=0.04, update=assets.invalidate_shader_cache)
-    arm_ssr_min_ray_step: FloatProperty(name="Step Min", default=0.05, update=assets.invalidate_shader_cache)
+    arm_ssr_min_ray_step: FloatProperty(name="Min Ray Step", default=0.5, update=assets.invalidate_shader_cache) #Unused
     arm_ssr_search_dist: FloatProperty(name="Search", default=5.0, update=assets.invalidate_shader_cache)
     arm_ssr_falloff_exp: FloatProperty(name="Falloff", default=5.0, update=assets.invalidate_shader_cache)
     arm_ssr_jitter: FloatProperty(name="Jitter", default=0.6, update=assets.invalidate_shader_cache)

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -502,7 +502,6 @@ class ArmRPListItem(bpy.types.PropertyGroup):
                ('2', '2', '2')],
         name="Bounces", description="Trace multiple light bounces", default='1', update=update_renderpath)
     arm_voxelgi_dimensions: FloatProperty(name="Dimensions", description="Voxelization bounds",default=16, update=assets.invalidate_compiled_data)
-    arm_voxelgi_clipmap_count: IntProperty(name="Clipmap Count", description="Exponential multiplier for voxelization bounds", default=5, update=assets.invalidate_compiled_data)
     arm_voxelgi_temporal: BoolProperty(name="Temporal Filter", description="Use temporal filtering to stabilize voxels", default=False, update=assets.invalidate_shader_cache)
     arm_voxelgi_shadows: BoolProperty(name="Shadows", description="Use voxels to render shadows", default=False, update=update_renderpath)
     arm_samples_per_pixel: EnumProperty(

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1716,7 +1716,6 @@ class ARM_PT_RenderPathVoxelsPanel(bpy.types.Panel):
         col.prop(rpdat, 'rp_voxelgi_resolution')
         col.prop(rpdat, 'rp_voxelgi_resolution_z')
         col.prop(rpdat, 'arm_voxelgi_dimensions')
-        col.prop(rpdat, 'arm_voxelgi_clipmap_count', text="Clipmap Count")
         col2.enabled = rpdat.rp_voxels == 'Voxel GI'
         col.prop(rpdat, 'arm_voxelgi_temporal')
         col.label(text="Light")

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1711,7 +1711,7 @@ class ARM_PT_RenderPathVoxelsPanel(bpy.types.Panel):
         col.prop(rpdat, 'arm_voxelgi_shadows', text='Shadows')
         #col2.prop(rpdat, 'rp_voxelgi_relight')
         col2.prop(rpdat, 'arm_voxelgi_refraction', text='Refraction')
-        #col2.prop(rpdat, 'arm_voxelgi_bounces')
+        col2.prop(rpdat, 'arm_voxelgi_bounces')
         col.prop(rpdat, 'arm_voxelgi_cones')
         col.prop(rpdat, 'rp_voxelgi_resolution')
         col.prop(rpdat, 'rp_voxelgi_resolution_z')

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1692,13 +1692,6 @@ class ARM_PT_RenderPathVoxelsPanel(bpy.types.Panel):
     bl_options = {'DEFAULT_CLOSED'}
     bl_parent_id = "ARM_PT_RenderPathPanel"
 
-    def draw_header(self, context):
-        wrd = bpy.data.worlds['Arm']
-        if len(wrd.arm_rplist) <= wrd.arm_rplist_index:
-            return
-        rpdat = wrd.arm_rplist[wrd.arm_rplist_index]
-        self.layout.prop(rpdat, "rp_voxelao", text="")
-
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
@@ -1708,22 +1701,36 @@ class ARM_PT_RenderPathVoxelsPanel(bpy.types.Panel):
             return
         rpdat = wrd.arm_rplist[wrd.arm_rplist_index]
 
-        layout.enabled = rpdat.rp_voxelao
-        layout.prop(rpdat, 'arm_voxelgi_shadows')
-        layout.prop(rpdat, 'arm_voxelgi_cones')
-        layout.prop(rpdat, 'rp_voxelgi_resolution')
-        layout.prop(rpdat, 'rp_voxelgi_resolution_z')
-        layout.prop(rpdat, 'arm_voxelgi_dimensions')
-        layout.prop(rpdat, 'arm_voxelgi_revoxelize')
-        col2 = layout.column()
-        col2.enabled = rpdat.arm_voxelgi_revoxelize
-        col2.prop(rpdat, 'arm_voxelgi_camera')
-        col2.prop(rpdat, 'arm_voxelgi_temporal')
-        layout.prop(rpdat, 'arm_voxelgi_occ')
-        layout.prop(rpdat, 'arm_voxelgi_step')
-        layout.prop(rpdat, 'arm_voxelgi_range')
-        layout.prop(rpdat, 'arm_voxelgi_offset')
-        layout.prop(rpdat, 'arm_voxelgi_aperture')
+        layout.prop(rpdat, 'rp_voxels')
+        col = layout.column()
+        col.enabled = rpdat.rp_voxels != 'Off'
+        col2 = col.column()
+        col2.enabled = rpdat.rp_voxels == 'Voxel GI'
+        col3 = col.column()
+        col3.enabled = rpdat.rp_voxels == 'Voxel AO'
+        col.prop(rpdat, 'arm_voxelgi_shadows', text='Shadows')
+        #col2.prop(rpdat, 'rp_voxelgi_relight')
+        col2.prop(rpdat, 'arm_voxelgi_refraction', text='Refraction')
+        #col2.prop(rpdat, 'arm_voxelgi_bounces')
+        col.prop(rpdat, 'arm_voxelgi_cones')
+        col.prop(rpdat, 'rp_voxelgi_resolution')
+        col.prop(rpdat, 'rp_voxelgi_resolution_z')
+        col.prop(rpdat, 'arm_voxelgi_dimensions')
+        col.prop(rpdat, 'arm_voxelgi_clipmap_count', text="Clipmap Count")
+        col2.enabled = rpdat.rp_voxels == 'Voxel GI'
+        col.prop(rpdat, 'arm_voxelgi_temporal')
+        col.label(text="Light")
+        col2 = col.column()
+        col2.enabled = rpdat.rp_voxels == 'Voxel GI'
+        col2.prop(rpdat, 'arm_voxelgi_diff')
+        col2.prop(rpdat, 'arm_voxelgi_spec')
+        col2.prop(rpdat, 'arm_voxelgi_refr')
+        col.prop(rpdat, 'arm_voxelgi_occ')
+        col.label(text="Ray")
+        col.prop(rpdat, 'arm_voxelgi_step')
+        col.prop(rpdat, 'arm_voxelgi_range')
+        col.prop(rpdat, 'arm_voxelgi_offset')
+        col.prop(rpdat, 'arm_voxelgi_aperture')
 
 class ARM_PT_RenderPathWorldPanel(bpy.types.Panel):
     bl_label = "World"

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -434,7 +434,7 @@ def write_config(resx, resy):
         'rp_ssr': rpdat.rp_ssr != 'Off',
         'rp_bloom': rpdat.rp_bloom != 'Off',
         'rp_motionblur': rpdat.rp_motionblur != 'Off',
-        'rp_gi': rpdat.rp_voxelao,
+        'rp_gi': rpdat.rp_voxels != "Off",
         'rp_dynres': rpdat.rp_dynres
     }
 
@@ -465,9 +465,9 @@ class Main {
     public static inline var projectVersion = '""" + arm.utils.safestr(wrd.arm_project_version) + """';
     public static inline var projectPackage = '""" + arm.utils.safestr(wrd.arm_project_package) + """';""")
 
-        if rpdat.rp_voxelao:
+        if rpdat.rp_voxels == 'Voxel GI' or rpdat.rp_voxels == 'Voxel AO':
             f.write("""
-    public static inline var voxelgiVoxelSize = """ + str(rpdat.arm_voxelgi_dimensions) + " / " + str(rpdat.rp_voxelgi_resolution) + """;
+    public static inline var voxelgiClipmapCount = """ + str(rpdat.arm_voxelgi_clipmap_count) +  """;
     public static inline var voxelgiHalfExtents = """ + str(round(rpdat.arm_voxelgi_dimensions / 2.0)) + """;""")
 
         if rpdat.rp_bloom:
@@ -581,12 +581,22 @@ def write_compiledglsl(defs, make_variants):
             f.write('#define GBUF_IDX_1 1\n')
 
             idx_emission = 2
+            idx_refraction = 2
             if '_gbuffer2' in wrd.world_defs:
                 f.write('#define GBUF_IDX_2 2\n')
                 idx_emission += 1
+                idx_refraction += 1
 
             if '_EmissionShaded' in wrd.world_defs:
                 f.write(f'#define GBUF_IDX_EMISSION {idx_emission}\n')
+                idx_refraction += 1
+
+            if '_VoxelRefract' in wrd.world_defs:
+                f.write(f'#define GBUF_IDX_REFRACTION {idx_refraction}\n')
+
+            if '_gbuffer2' in wrd.world_defs:
+                f.write('#define GBUF_IDX_2 2\n')
+                idx_emission += 1
 
         f.write("""#if defined(HLSL) || defined(METAL)
 #define _InvY
@@ -650,6 +660,7 @@ const float bloomRadius = """ + str(round(rpdat.arm_bloom_radius * 100) / 100) +
         if rpdat.rp_ssr:
             f.write(
 """const float ssrRayStep = """ + str(round(rpdat.arm_ssr_ray_step * 100) / 100) + """;
+
 const float ssrMinRayStep = """ + str(round(rpdat.arm_ssr_min_ray_step * 100) / 100) + """;
 const float ssrSearchDist = """ + str(round(rpdat.arm_ssr_search_dist * 100) / 100) + """;
 const float ssrFalloffExp = """ + str(round(rpdat.arm_ssr_falloff_exp * 100) / 100) + """;
@@ -746,18 +757,23 @@ const float compoDOFFstop = """ + str(round(fstop * 100) / 100) + """;
 const float compoDOFLength = 160.0;
 """) # str(round(bpy.data.cameras[0].lens * 100) / 100)
 
-        if rpdat.rp_voxelao:
+        if rpdat.rp_voxels != 'Off':
             halfext = round(rpdat.arm_voxelgi_dimensions / 2.0)
             f.write(
-"""const ivec3 voxelgiResolution = ivec3(""" + str(rpdat.rp_voxelgi_resolution) + """, """ + str(rpdat.rp_voxelgi_resolution) + """, """ + str(int(int(rpdat.rp_voxelgi_resolution) * float(rpdat.rp_voxelgi_resolution_z))) + """);
-const vec3 voxelgiHalfExtents = vec3(""" + str(halfext) + """, """ + str(halfext) + """, """ + str(round(halfext * float(rpdat.rp_voxelgi_resolution_z))) + """);
+"""const ivec3 voxelgiResolution = ivec3(""" + str(rpdat.rp_voxelgi_resolution) + " + 2.0" + """, """ + str(rpdat.rp_voxelgi_resolution) + " + 2.0" + """, """ + str(int(int(rpdat.rp_voxelgi_resolution) * float(rpdat.rp_voxelgi_resolution_z))) + " + 2.0" + """);
+const vec3 voxelgiHalfExtents = vec3(""" + str(halfext) + " + 2.0" + """, """ + str(halfext) + " + 2.0" + """, """ + str(round(halfext * float(rpdat.rp_voxelgi_resolution_z))) + " + 2.0" + """);
 const float voxelgiOcc = """ + str(round(rpdat.arm_voxelgi_occ * 100) / 100) + """;
 const float voxelgiStep = """ + str(round(rpdat.arm_voxelgi_step * 100) / 100) + """;
 const float voxelgiRange = """ + str(round(rpdat.arm_voxelgi_range * 100) / 100) + """;
 const float voxelgiOffset = """ + str(round(rpdat.arm_voxelgi_offset * 100) / 100) + """;
 const float voxelgiAperture = """ + str(round(rpdat.arm_voxelgi_aperture * 100) / 100) + """;
 """)
-
+        if rpdat.rp_voxels == 'Voxel GI':
+            f.write("""
+const float voxelgiDiff = """ + str(round(rpdat.arm_voxelgi_diff * 100) / 100) + """;
+const float voxelgiRefl = """ + str(round(rpdat.arm_voxelgi_spec * 100) / 100) + """;
+const float voxelgiRefr = """ + str(round(rpdat.arm_voxelgi_refr * 100) / 100) + """;
+""")
         if rpdat.rp_sss:
             f.write(f"const float sssWidth = {rpdat.arm_sss_width / 10.0};\n")
 

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -467,7 +467,6 @@ class Main {
 
         if rpdat.rp_voxels == 'Voxel GI' or rpdat.rp_voxels == 'Voxel AO':
             f.write("""
-    public static inline var voxelgiClipmapCount = """ + str(rpdat.arm_voxelgi_clipmap_count) +  """;
     public static inline var voxelgiHalfExtents = """ + str(round(rpdat.arm_voxelgi_dimensions / 2.0)) + """;""")
 
         if rpdat.rp_bloom:


### PR DESCRIPTION
Here it is !
This pull request is reimplementing the old voxel global illumination module (rebased from 19.02).
Here is a [link to the forum's post](https://forums.armory3d.org/t/voxel-gi-with-clipmaps/5242).

The main change is the use of clipmaps (roughly put, adaptive voxel size) so that we can process distant objects.

I came across a lot of articles and videos showing new voxelization techniques, I tried to read the official pdfs, but they are obscure and designed for scholars. So instead I read other people's code:
https://github.com/turanszkij/WickedEngine
https://github.com/compix/VoxelConeTracingGI

Eventually I'm coming with the most basic voxelization we can get, but it's fast and stable.

True reflections / refractions:
![Capture d’écran du 2023-08-26 11-51-50](https://github.com/armory3d/armory/assets/29781855/9b235d2b-ef75-4b9c-87a9-d459f39deb08)

Distant voxelization:
![Capture d’écran du 2023-08-26 11-36-34](https://github.com/armory3d/armory/assets/29781855/664425f8-00a0-45d0-99cc-f084591771df)
(shitty framerate comes from the terrain being highly subdivided)

There is a major architectural change in the pipeline ; instead of computing the voxels position in the voxelizer and once again prior to passing the value to the conetracer, we write it in a buffer when voxelizing. That way it doesn't change value (because there is a delay) and we avoid artifacts and lod transition seams.

A last bug I couldn't deal with is that when using GI in forward render path, voxels coordinates have a wrong scale.
I'll be working on that again soon, and also implement a second bounce to be able to reflect / refract indirect light and finer illumination.