### PR TITLE
Fix too bright environment and barely visible shadows if irradiance is off

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -233,7 +233,7 @@ void main() {
 		if (g2.b < 0.5) {
 			envl = envl;
 		} else {
-			envl = vec3(1.0);
+			envl = vec3(0.0);
 		}
 	#endif
 
@@ -241,7 +241,7 @@ void main() {
 		envl /= PI;
 	#endif
 #else
-	vec3 envl = vec3(1.0);
+	vec3 envl = vec3(0.0);
 #endif
 
 #ifdef _Rad


### PR DESCRIPTION
When irradiance was turned off (either globally or per material), the environment light that's added to the output fragment color was initialized with 1.0 which resulted in a fully-lit scene. This PR sets it to zero as it seems more natural. The default case with irradiance turned on is not touched by this PR.

Before:
![Screenshot](https://github.com/armory3d/armory/assets/17685000/041f88c1-459a-44d8-ac65-1d2d1f5616f2)

After:
![Screenshot](https://github.com/armory3d/armory/assets/17685000/adc78ddc-4ab3-4abf-9ae5-5a25ddfef7e6)

@e2002e I noticed that you also work with `envl` in your current voxel AO/GI work, please let me know in case this breaks anything for you :)