### PR TITLE
optimized MathExpression

### DIFF
--- a/blender/arm/logicnode/math/LN_math_expression.py
+++ b/blender/arm/logicnode/math/LN_math_expression.py
@@ -5,185 +5,76 @@ class MathExpressionNode(ArmLogicTreeNode):
     """Mathematical operations on values."""
     bl_idname = 'LNMathExpressionNode'
     bl_label = 'Math Expression'
-    arm_version = 1
-    min_inputs = 2
-    max_inputs = 10
+    arm_version = 2
+
+    num_params: IntProperty(default=2, min=0)
 
     @staticmethod
     def get_variable_name(index):
-        return {
-            0: 'a',
-            1: 'b',
-            2: 'c',
-            3: 'd',
-            4: 'e',
-            5: 'x',
-            6: 'y',
-            7: 'h',
-            8: 'i',
-            9: 'k'
-        }.get(index, 'a')
-
-    @staticmethod
-    def get_clear_exp(value):
-        return re.sub(r'[\-\+\*\/\(\)\^\%abcdexyhik0123456789. ]', '', value).strip()
-
-    @staticmethod
-    def get_invalid_characters(value):
-        value = value.replace(' ', '')
-        len_v = len(value)
-        arg = ['a', 'b', 'c', 'd', 'e', 'x', 'y', 'h', 'i', 'k']
-        for i in range(len_v):
-            s = value[i]
-            if s == '.':
-                if ((i - 1) < 0) or ((i + 1) >= len_v) or (not value[i - 1].isnumeric()) or (not value[i + 1].isnumeric()):
-                    return False
-            oper = ['+', '-', '*', '/', '%', '^']
-            if s == '(':
-                if (i > 0) and ((value[i - 1] not in oper) and (value[i - 1] != '(')):
-                    return False
-                if (i < (len_v - 1)) and ((value[i + 1] not in arg) and (not value[i + 1].isnumeric()) and (value[i + 1] != '(')):
-                    return False
-            if s == ')':
-                if (i > 0) and ((value[i - 1] not in arg) and (not value[i - 1].isnumeric()) and (value[i - 1] != ')')):
-                    return False
-                if (i < (len_v - 1)) and (not value[i + 1].isnumeric()) and ((value[i + 1] not in oper) and (value[i + 1] != ')')):
-                    return False
-            if s in oper:
-                if ((i > 0) and (value[i - 1] in oper)) or ((i < (len_v - 1)) and (value[i + 1] in oper)):
-                    return False
-        last_sym = value[len_v - 1]
-        if (not last_sym.isnumeric()) and (last_sym not in arg) and (last_sym != ')'):
-            return False
-        return True
-
-    @staticmethod
-    def check_variable(self, value):
-        variables = re.sub(r'[\-\+\*\/\(\)\^\%0123456789. ]', '', value).strip()
-        for vr in variables:
-            check = False
-            for inp_key in self.inputs.keys():
-                if (vr == inp_key):
-                    check = True
-                    break
-            if not check:
-                return False
-        return True
-
-    @staticmethod
-    def matches(line, opendelim='(', closedelim=')'):
-        stack = []
-        for m in re.finditer(r'[{}{}]'.format(opendelim, closedelim), line):
-            pos = m.start()
-            if line[pos-1] == '\\':
-                # Skip escape sequence
-                continue
-            c = line[pos]
-            if c == opendelim:
-                stack.append(pos+1)
-            elif c == closedelim:
-                if len(stack) > 0:
-                    prevpos = stack.pop()
-                    yield (True, prevpos, pos, len(stack))
-                else:
-                    # Error
-                    yield (False, 0, 0, 0)
-                    pass
-        if len(stack) > 0:
-            for pos in stack:
-                yield (False, 0, 0, 0)
-
-    @staticmethod
-    def isPartCorrect(s):
-        if len(s.replace('p', '').replace(' ', '').split()) == 0:
-            return True
-        REGEX = re.compile(r"(([abcdexyhikp]|\d+)[\+\-\/\*\^\%]){1,}([abcdexyhikp]|\d+)(=([abcdexyhikp]|\d+))?")
-        result = False
-        if REGEX.match(s):
-            result = True
-        return result
-
-    @staticmethod
-    def isCorrect(self, s):
-        result = True
-        if s.find("(") >=0 or s.find(")") >= 0:
-            for correct, openpos, closepos, level in self.matches(s):
-                if correct:
-                    part = s[openpos:closepos]
-                    if part.find("(") == -1 and part.find(")") == -1:
-                        if not self.isPartCorrect(part):
-                            result = False
-                            break
-                    part = s[openpos-1:closepos+1]
-                    replaced = s.replace(part, "p")
-                    if replaced.find("(") >=0 or replaced.find(")") >= 0:
-                        if not self.isCorrect(self, replaced):
-                            result = False
-                            break
-                    else:
-                        if not self.isPartCorrect(replaced):
-                            result = False
-                            break
-                else:
-                    result = False
-                    break
-        else:
-            result = self.isPartCorrect(s)
-        return result
-
-    def set_exp_error(self, value):
-        self['exp_error'] = value
-
-    def get_exp_error(self):
-        return self.get('exp_error', False)
+        return chr( range(ord('a'), ord('z')+1)[index] )
 
     def set_exp(self, value):
-        value = value.lower()
-        self['property0'] = value
-        # Check errors
-        val_error = False
-        if len(self.get_clear_exp(value)) > 0:
-            val_error = True
-        elif not self.get_invalid_characters(value):
-            val_error = True
-        elif not self.check_variable(self, value):
-            val_error = True
-        elif not self.isCorrect(self, value.replace(' ', '')):
-            val_error = True
-        self.set_exp_error(val_error)
+        self['property2'] = value
+        # TODO: Check expression for errors
+        self['exp_error'] = False
 
     def get_exp(self):
-        return self.get('property0', 'a + b')
+        return self.get('property2', 'a + b')
 
-    property0: HaxeStringProperty('property0', name='', description='Expression (operation: +, -, *, /, ^, (, ), %)', set=set_exp, get=get_exp)
-    property1: HaxeBoolProperty('property1', name='Clamp', default=False)
+    property0: HaxeBoolProperty('property0', name='Clamp Result', default=False)
+    property1: HaxeIntProperty('property1', name='Number of Params', default=2)
+    property2: HaxeStringProperty('property2', name='', description='Math Expression: +, -, *, /, ^, %, (, ), log(a, b), ln(a), abs(a), max(a,b), min(a,b), sin(a), cos(a), tan(a), cot(a), asin(a), acos(a), atan(a), atan2(a,b), pi(), e()', set=set_exp, get=get_exp)
 
     def __init__(self):
-        array_nodes[str(id(self))] = self
+        super(MathExpressionNode, self).__init__()
+        self.register_id()
+
 
     def arm_init(self, context):
+        
+        # OUTPUTS:
+        self.add_output('ArmFloatSocket', 'Result')
+        
+        # two default parameters at start
         self.add_input('ArmFloatSocket', self.get_variable_name(0), default_value=0.0)
         self.add_input('ArmFloatSocket', self.get_variable_name(1), default_value=0.0)
-        self.add_output('ArmFloatSocket', 'Result')
+
+    def add_sockets(self):
+        if self.num_params < 26:
+            self.add_input('ArmFloatSocket', self.get_variable_name(self.num_params), default_value=0.0)
+            self.num_params += 1
+            self['property1'] = self.num_params
+
+    def remove_sockets(self):
+        if self.num_params > 0:
+            self.inputs.remove(self.inputs.values()[-1])
+            self.num_params -= 1
+            self['property1'] = self.num_params
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'property1')
-        # Expression
+        # Clamp Property
+        layout.prop(self, 'property0')
+
+        # Expression Property
         row = layout.row(align=True)
         column = row.column(align=True)
-        column.alert = self.get_exp_error()
-        column.prop(self, 'property0', icon='FORCE_HARMONIC')
-        # Buttons
+        # TODO:
+        #column.alert = self['exp_error']
+        column.prop(self, 'property2', icon='FORCE_HARMONIC')
+
+        # Button ADD parameter
         row = layout.row(align=True)
         column = row.column(align=True)
-        op = column.operator('arm.node_add_input', text='Add Value', icon='PLUS', emboss=True)
-        if len(self.inputs) == 10:
+        op = column.operator('arm.node_call_func', text='Add Param', icon='PLUS', emboss=True)
+        op.node_index = self.get_id_str()
+        op.callback_name = 'add_sockets'
+        if self.num_params == 26:
             column.enabled = False
-        op.node_index = str(id(self))
-        op.socket_type = 'ArmFloatSocket'
-        op.name_format = self.get_variable_name(len(self.inputs))
+
+        # Button REMOVE parameter
         column = row.column(align=True)
-        op = column.operator('arm.node_remove_input', text='', icon='X', emboss=True)
-        op.node_index = str(id(self))
-        if len(self.inputs) == 2:
+        op = column.operator('arm.node_call_func', text='', icon='X', emboss=True)
+        op.node_index = self.get_id_str()
+        op.callback_name = 'remove_sockets'
+        if self.num_params == 0:
             column.enabled = False


### PR DESCRIPTION
The formula-parsing runs now into its property-setter only ones (not each time like before while fetching result from socket).
Also some additional optimizations is there to not have to create allways new params (it directly changes its single values now).

Into python part it's working now for all kind of math-functions.
I am also removed the old error-parsing inside of code!
Sorry that i am not good enough to make syntax-parsing into python, anyway ...
if there is something wrong into math-expr.,
it still traces error-msg by haxe on console.
( Tryed also to extract out the parsing-part of formula-lib [300 lines .hx]
  and the haxe->python transpiled code was really huge [1400 lines]...
  it works ~^ but maybe not good to maintain ~^ )

Here some testfiles: https://github.com/maitag/armory-3d-land/tree/main/mathExpression/testing
Seems its same as fast (or faster;:) at now as by doing with multiple math nodes (^_^)
