### PR TITLE
Allow building with ZUI disabled

### DIFF
--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -498,10 +498,11 @@ class Main {
             f.write("""
         armory.system.Starter.numAssets = """ + str(len(asset_references)) + """;
         armory.system.Starter.drawLoading = """ + loadscreen_class + """.render;""")
-        if wrd.arm_canvas_img_scaling_quality == 'low':
-            f.write(f"armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.Low;")
-        elif wrd.arm_canvas_img_scaling_quality == 'high':
-            f.write(f"armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.High;")
+        if wrd.arm_ui == 'Enabled':
+            if wrd.arm_canvas_img_scaling_quality == 'low':
+                f.write(f"armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.Low;")
+            elif wrd.arm_canvas_img_scaling_quality == 'high':
+                f.write(f"armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.High;")
         f.write("""
         armory.system.Starter.main(
             '""" + arm.utils.safestr(scene_name) + scene_ext + """',


### PR DESCRIPTION
The following lines were added even when there is no scene canvas, debugging disabled, and ZUI disabled --
armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.Low;  
causing Type not found : zui.Zui