### PR TITLE
Fix node update routines for Gate and Array Float nodes

### DIFF
--- a/blender/arm/logicnode/array/LN_array_float.py
+++ b/blender/arm/logicnode/array/LN_array_float.py
@@ -44,7 +44,18 @@ class FloatArrayNode(ArmLogicVariableNodeMixin, ArmLogicTreeNode):
             inp.default_value_raw = master_node.inputs[i].get_default_value()
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 2):
+        if self.arm_version < 0 or self.arm_version > 2:
             raise LookupError()
-            
-        return NodeReplacement.Identity(self)
+
+        newnode = node_tree.nodes.new(FloatArrayNode.bl_idname)
+        for inp_old in self.inputs:
+            inp_new = newnode.add_input('ArmFloatSocket', inp_old.name)
+            inp_new.hide = self.arm_logic_id != ''
+            inp_new.enabled = self.arm_logic_id != ''
+            inp_new.default_value_raw = inp_old.get_default_value()
+            NodeReplacement.replace_input_socket(node_tree, inp_old, inp_new)
+
+        NodeReplacement.replace_output_socket(node_tree, self.outputs[0], newnode.outputs[0])
+        NodeReplacement.replace_output_socket(node_tree, self.outputs[1], newnode.outputs[1])
+
+        return newnode

--- a/blender/arm/logicnode/logic/LN_gate.py
+++ b/blender/arm/logicnode/logic/LN_gate.py
@@ -68,11 +68,10 @@ class GateNode(ArmLogicTreeNode):
                 column.enabled = False
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
-        if self.arm_version not in (0, 2):
-            raise LookupError()
-            
         if self.arm_version == 1 or self.arm_version == 2:
             return NodeReplacement(
-                'LNGateNode', self.arm_version, 'LNGateNode', 2,
+                'LNGateNode', self.arm_version, 'LNGateNode', 3,
                 in_socket_mapping={0:0, 1:1, 2:2}, out_socket_mapping={0:0, 1:1}
             )
+        else:
+            raise LookupError()


### PR DESCRIPTION
Both nodes had wrong out-of-range checks for version numbers, the Gate node did update to an old version, and the Array Float node did not copy any input sockets.