### PR TITLE
Add TCanvas.visible attribute to hide entire canvas

### DIFF
--- a/Sources/armory/trait/internal/CanvasScript.hx
+++ b/Sources/armory/trait/internal/CanvasScript.hx
@@ -44,7 +44,7 @@ class CanvasScript extends Trait {
 				}
 
 				iron.data.Data.getFont(font, function(defaultFont: kha.Font) {
-					var c: TCanvas = haxe.Json.parse(blob.toString());
+					var c: TCanvas = Canvas.parseCanvasFromBlob(blob);
 					if (c.theme == null) c.theme = Canvas.themes[0].NAME;
 					cui = new Zui({font: defaultFont, theme: Canvas.getTheme(c.theme)});
 
@@ -140,12 +140,26 @@ class CanvasScript extends Trait {
 		return cui.ops.scaleFactor;
 	}
 
+	@:deprecated("Please use setCanvasVisible() instead")
+	public inline function setCanvasVisibility(visible: Bool) {
+		setCanvasVisible(visible);
+	}
+
 	/**
-		Set visibility of canvas
-		@param visible Whether canvas should be visible or not
+		Set whether the active canvas is visible.
+
+		Note that elements of invisible canvases are not rendered and computed,
+		so it is not possible to interact with those elements on the screen.
 	**/
-	public function setCanvasVisibility(visible: Bool){
-		for (e in canvas.elements) e.visible = visible;
+	public inline function setCanvasVisible(visible: Bool) {
+		canvas.visible = visible;
+	}
+
+	/**
+		Get whether the active canvas is visible.
+	**/
+	public inline function getCanvasVisible(): Bool {
+		return canvas.visible;
 	}
 
 	/**

--- a/Sources/armory/ui/Canvas.hx
+++ b/Sources/armory/ui/Canvas.hx
@@ -22,10 +22,12 @@ class Canvas {
 
 	public static function draw(ui: Zui, canvas: TCanvas, g: kha.graphics2.Graphics): Array<String> {
 
+		events.resize(0);
+
+		if (!canvas.visible) return events;
+
 		screenW = kha.System.windowWidth();
 		screenH = kha.System.windowHeight();
-
-		events.resize(0);
 
 		_ui = ui;
 
@@ -313,6 +315,21 @@ class Canvas {
 		if (rotated) ui.g.popTransformation();
 	}
 
+	/**
+		Parse the content of the given blob object and return a `TCanvas` object
+		from it.
+	**/
+	public static function parseCanvasFromBlob(blob: kha.Blob): TCanvas {
+		final raw: haxe.DynamicAccess<Dynamic> = haxe.Json.parse(blob.toString());
+
+		// Ensure TCanvas has all attributes even for older files
+		if (!raw.exists("visible")) {
+			raw.set("visible", true);
+		}
+
+		return (raw: Dynamic);
+	}
+
 	static inline function getText(canvas: TCanvas, e: TElement): String {
 		return e.text;
 	}
@@ -414,6 +431,7 @@ typedef TCanvas = {
 	var height: Int;
 	var elements: Array<TElement>;
 	var theme: String;
+	var visible: Bool;
 	@:optional var assets: Array<TAsset>;
 	@:optional var locales: Array<TLocale>;
 }


### PR DESCRIPTION
Previously, hiding a canvas with `CanvasScript.setCanvasVisibility()` would hide all canvas elements individually which would overwrite all configured element "visibilities". So if parts of the UI were hidden and then the entire canvas was hidden, the custom visibility configuration would have to be done again after the canvas was made visible again. Now, there is a dedicated attribute for canvases that doesn't touch element state.

Also, I guess the new approach can make a performance difference if you have tens of thousands of UI elements, for whatever reason ¯\_(ツ)_/¯