### PR TITLE
Recast Navigation System Overhaul

### DIFF
--- a/Sources/armory/logicnode/CrowdGoToLocationNode.hx
+++ b/Sources/armory/logicnode/CrowdGoToLocationNode.hx
@@ -1,0 +1,34 @@
+package armory.logicnode;
+
+#if arm_navigation
+import armory.trait.navigation.Navigation;
+#end
+
+import iron.object.Object;
+import iron.math.Vec4;
+
+class CrowdGoToLocationNode extends LogicNode {
+
+	var object: Object;
+	var location: Vec4;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		object = inputs[1].get();
+		location = inputs[2].get();
+
+		assert(Error, object != null, "The object input not be null");
+		assert(Error, location != null, "The location to navigate to must not be null");
+
+#if arm_navigation
+		assert(Error, Navigation.active.navMeshes.length > 0, "No Navigation Mesh Present");
+		var crowdAgent: armory.trait.NavCrowd = object.getTrait(armory.trait.NavCrowd);
+		assert(Error, crowdAgent != null, "Object does not have a NavCrowd trait");
+		crowdAgent.crowdAgentGoto(location);
+#end
+		runOutput(0);
+	}
+}

--- a/Sources/armory/trait/NavCrowd.hx
+++ b/Sources/armory/trait/NavCrowd.hx
@@ -1,10 +1,146 @@
 package armory.trait;
 
+#if arm_navigation
+import iron.math.Quat;
+import iron.math.Vec4;
+import armory.trait.navigation.Navigation;
+#end
 import iron.Trait;
 
 class NavCrowd extends Trait {
 
+	#if !arm_navigation
+	public function new() { super(); }
+	#else
+
+	// Position offset for the agent.
+	@prop
+	public var offset: Vec4 = new Vec4();
+
+	// Radius of the agent.
+	@prop
+	public var radius: Float = 1.0;
+
+	// Height of the agent.
+	@prop
+	public var height: Float = 1.0;
+
+	// Should the agent turn.
+	@prop 
+	var turn: Bool = true;
+
+	// Turn rate in range (0, 1).
+	// 0 = No turn.
+	// 1 = Instant turn without interpolation.
+	@prop
+	public var turnSpeed: Float = 0.1;
+
+	// Threshold to avoid turning at low velocities which might causer jittering.
+	@prop 
+	public var turnVelocityThreshold: Float = 0.1;
+
+	// Maximum speed of the crowd agent
+	@prop
+	public var maxSpeed: Float = 5.0;
+
+	// Maximum acceleration of the agent
+	@prop
+	public var maxAcceleration: Float = 100.0;
+
+	// How separated should the agents be. Effective when crowd separation flag is enabled.
+	@prop
+	public var separationWeight: Float = 1.0;
+
+	// Distance to check for collisions. Typically should be greater than agent radius.
+	@prop
+	public var collisionQueryRange: Float = 2.0;
+
+	// Anticipate turns and modify agent path
+	@prop
+	public var anticipateTurns: Bool = false;
+
+	@prop
+	public var obstacleAvoidance: Bool = false;
+
+	@prop
+	public var crowdSeparation: Bool = false;
+
+	@prop
+	public var optimizeVisibility: Bool = false;
+
+	@prop
+	public var optimizeTopology: Bool = false;
+
+	public var agentReady(default, null) = false;
+	var activeNavMesh: NavMesh = null;
+	var agentID = -1;
+
+	static inline var EPSILON = 0.0001;
+
 	public function new() {
 		super();
+
+		notifyOnUpdate(addAgent);
+		notifyOnRemove(removeAgent);
 	}
+
+	function addAgent() {
+
+		if(Navigation.active.navMeshes.length < 1) return;
+
+		if(! Navigation.active.navMeshes[0].ready) return;
+
+		activeNavMesh = Navigation.active.navMeshes[0];
+
+		var flags: Int = 0;
+		if(anticipateTurns) flags += 1;
+		if(obstacleAvoidance) flags += 2;
+		if(crowdSeparation) flags += 4;
+		if(optimizeVisibility) flags += 8;
+		if(optimizeTopology) flags += 16;
+
+		var position = object.transform.world.getLoc();
+		agentID = activeNavMesh.addCrowdAgent(this, position, radius, height, maxAcceleration, maxSpeed, flags, separationWeight, collisionQueryRange);
+
+		notifyOnUpdate(updateCrowdAgent);
+		removeUpdate(addAgent);
+		agentReady = true;
+	}
+
+	public function crowdAgentGoto(position: Vec4) {
+		if(!agentReady) return;
+
+		activeNavMesh.crowdAgentGoto(agentID, position);
+	}
+
+	public function crowdAgentTeleport(position: Vec4) {
+		if(!agentReady) return;
+
+		activeNavMesh.crowdAgentTeleport(agentID, position);
+	}
+
+	function removeAgent() {
+		activeNavMesh.removeCrowdAgent(agentID);
+	}
+
+	function updateCrowdAgent() {
+		if(!agentReady) return;
+		var pos = activeNavMesh.crowdGetAgentPosition(agentID);
+		pos.add(offset);
+		object.transform.loc.setFrom(pos);
+		if(turn) turnAgent();
+		object.transform.buildMatrix();
+	}
+
+	function turnAgent() {
+		var vel = activeNavMesh.crowdGetAgentVelocity(agentID);
+		vel.z = 0;
+		if(vel.length() < turnVelocityThreshold) return;
+		vel.normalize();
+		var targetRot = new Quat().fromTo(new Vec4(1, 0, 0, 1), vel);
+		var currentRot = new Quat().setFrom(object.transform.rot);
+		var res = new Quat().lerp(currentRot, targetRot, turnSpeed);
+		object.transform.rot = res;
+	}
+	#end
 }

--- a/Sources/armory/trait/NavMesh.hx
+++ b/Sources/armory/trait/NavMesh.hx
@@ -1,83 +1,504 @@
 package armory.trait;
 
 #if arm_navigation
+import recast.Recast.RecastConfigHelper;
+import haxe.ds.Vector;
+import armory.trait.navigation.DebugDrawHelper;
+import kha.arrays.Float32Array;
+import iron.object.Object;
 import armory.trait.navigation.Navigation;
-import haxerecast.Recast;
-#end
 
-import iron.Trait;
 import iron.data.Data;
 import iron.math.Vec4;
+import iron.system.Time;
+import kha.arrays.Uint32Array;
+import iron.object.MeshObject;
+import iron.data.Geometry;
+import iron.data.MeshData;
+#end
+import iron.Trait;
 
 class NavMesh extends Trait {
 
-#if (!arm_navigation)
+	#if !arm_navigation
 	public function new() { super(); }
-#else
+	#else
+
+	@prop
+	public var debugDraw:Bool = false;
 
 	// recast config:
+	/// Also use immidiate children for nav mesh construction.
 	@prop
-	public var cellSize: Float = 0.3; // voxelization cell size 
+	public var combineImmidiateChildren:Bool = true;
+	/// The width of the field along the x-axis. [Limit: >= 0] [Units: vx]
 	@prop
-	public var cellHeight: Float = 0.2; // voxelization cell height
-	@prop
-	public var agentHeight: Float = 2.0; // agent capsule height
-	@prop
-	public var agentRadius: Float = 0.4; // agent capsule radius
-	@prop
-	public var agentMaxClimb: Float = 0.9; // how high steps agents can climb, in voxels
-	@prop
-	public var agentMaxSlope: Float = 45.0; // maximum slope angle, in degrees
+	public var width:Int = 0;
 
-	var recast: Recast = null;
-	var ready = false;
+	/// The height of the field along the z-axis. [Limit: >= 0] [Units: vx]
+	@prop
+	public var height:Int = 0;
+
+	/// Enable for tiled mesh and using temporary obstacles. `tileSize` will be ignored if set to false.
+	@prop
+	public var tiledMesh:Bool = true;
+	
+	/// The width/height size of tile's on the xz-plane. [Limit: >= 0] [Units: vx]
+	@prop
+	public var tileSize:Int = 50;
+	
+	/// The size of the non-navigable border around the heightfield. [Limit: >=0] [Units: vx]
+	@prop
+	public var borderSize:Int = 0;
+
+	/// The xz-plane cell size to use for fields. [Limit: > 0] [Units: wu]
+	@prop
+	public var cellSize:Float = 0.2;
+
+	/// The y-axis cell size to use for fields. [Limit: > 0] [Units: wu]
+	@prop
+	public var cellHeight:Float = 0.3;
+
+	/// The minimum bounds of the field's AABB. [(x, y, z)] [Units: wu]
+	//public var bmin:haxe.ds.Vector<Float>; 
+
+	/// The maximum bounds of the field's AABB. [(x, y, z)] [Units: wu]
+	//public var bmax:haxe.ds.Vector<Float>;
+
+	/// The maximum slope that is considered walkable. [Limits: 0 <= value < 90] [Units: Degrees]
+	@prop
+	public var walkableSlopeAngle:Float = 45.0;
+
+	/// Minimum floor to 'ceiling' height that will still allow the floor area to 
+	/// be considered walkable. [Limit: >= 3] [Units: vx]
+	@prop
+	public var walkableHeight:Int = 3;
+	
+	/// Maximum ledge height that is considered to still be traversable. [Limit: >=0] [Units: vx]
+	@prop
+	public var walkableClimb:Int = 2;
+	
+	/// The distance to erode/shrink the walkable area of the heightfield away from 
+	/// obstructions.  [Limit: >=0] [Units: vx]
+	@prop
+	public var walkableRadius:Int = 1;
+	
+	/// The maximum allowed length for contour edges along the border of the mesh. [Limit: >=0] [Units: vx]
+	@prop
+	public var maxEdgeLen:Int = 12;
+	
+	/// The maximum distance a simplfied contour's border edges should deviate 
+	/// the original raw contour. [Limit: >=0] [Units: vx]
+	@prop
+	public var maxSimplificationError:Float = 1.3;
+	
+	/// The minimum number of cells allowed to form isolated island areas. [Limit: >=0] [Units: vx]
+	@prop
+	public var minRegionArea:Int = 8;
+	
+	/// Any regions with a span count smaller than this value will, if possible, 
+	/// be merged with larger regions. [Limit: >=0] [Units: vx]
+	@prop
+	public var mergeRegionArea:Int = 20;
+	
+	/// The maximum number of vertices allowed for polygons generated during the 
+	/// contour to polygon conversion process. [Limit: >= 3]
+	@prop
+	public var maxVertsPerPoly:Int = 6;
+	
+	/// Sets the sampling distance to use when generating the detail mesh.
+	/// (For height detail only.) [Limits: 0 or >= 0.9] [Units: wu]
+	@prop
+	public var detailSampleDist:Float = 6;
+	
+	/// The maximum distance the detail mesh surface should deviate from heightfield
+	/// data. (For height detail only.) [Limit: >=0] [Units: wu]
+	@prop
+	public var detailSampleMaxError:Float = 1;
+
+	 // maximum number of crowd agents
+	@prop
+	public var maxCrowdAgents: Int = 50;
+
+	 // maximum radius of crowd agents
+	@prop
+	public var maxCrowdAgentRadius: Float = 3.0;
+
+	var recastNavMesh: recast.Recast.NavMesh = null;
+	var recastCrowd: recast.Recast.Crowd = null;
+	public var ready(default, null) = false;
+	
+	var crowdAgentMap: Map<Int, NavCrowd> = new Map();
+
+	var tempObstacleCounter = 0;
+
+	var tempObstacleMap: Map<Int, NavObstacle> = new Map();
+
+	var recastObstacleMap: Map<Int, recast.Recast.DtObstacleRef> = new Map();
+
+	public var navMeshDebugColor: kha.Color = Green;
+
+	var v:Vec4 = new Vec4();
 
 	public function new() {
 		super();
 
-		notifyOnInit(init);
+		notifyOnInit(initNavMesh);
+		notifyOnUpdate(updateNavMesh);
 	}
 
-	function init() {
+	function initNavMesh() {
+		if (ready) return;
 		Navigation.active.navMeshes.push(this);
 
-		// Load navmesh
-		var name = "nav_" + cast(object, iron.object.MeshObject).data.name + ".arm";
-		Data.getBlob(name, function(b: kha.Blob) {
+		if(debugDraw) Navigation.active.debugDrawHelper.setDebugMode(DrawWireframe);
 
-			recast = Navigation.active.recast;
-			recast.OBJDataLoader(b.toString(), function() {
-				var settings = [
-					"cellSize" => cellSize,
-					"cellHeight" => cellHeight,
-					"agentHeight" => agentHeight,
-					"agentRadius" => agentRadius,
-					"agentMaxClimb" => agentMaxClimb,
-					"agentMaxSlope" => agentMaxSlope,
-				];
-				recast.settings(settings);
+		recastNavMesh = new recast.Recast.NavMesh();
+		var recastConfig = new recast.Recast.RcConfig();
 
-				recast.buildSolo();
-				ready = true;
-			});
-		});
+		recastConfig.width = width;
+		recastConfig.height = height;
+		if(tiledMesh) {
+			recastConfig.tileSize = tileSize;
+		}
+		else {
+			recastConfig.tileSize = 0;
+		}
+		recastConfig.borderSize = borderSize;
+		recastConfig.cs = cellSize;
+		recastConfig.ch = cellHeight;
+		recastConfig.walkableSlopeAngle = walkableSlopeAngle;
+		recastConfig.walkableHeight = walkableHeight;
+		recastConfig.walkableClimb = walkableClimb;
+		recastConfig.walkableRadius = walkableRadius;
+		recastConfig.maxEdgeLen = maxEdgeLen;
+		recastConfig.maxSimplificationError = maxSimplificationError;
+		recastConfig.minRegionArea = minRegionArea;
+		recastConfig.mergeRegionArea = mergeRegionArea;
+		recastConfig.maxVertsPerPoly = maxVertsPerPoly;
+		recastConfig.detailSampleDist = detailSampleDist;
+		recastConfig.detailSampleMaxError = detailSampleMaxError;
+
+		var positionsArray = new Array<Float>();
+		var indexArray = new Array<Int>();
+
+		var currentIndexOffset = 0;
+		var reducedMeshData = getVerticesIndicesFromMesh(object, currentIndexOffset);
+		currentIndexOffset = reducedMeshData.maxIndex + 1;
+		positionsArray = positionsArray.concat(reducedMeshData.positions.toArray());
+		indexArray = indexArray.concat(reducedMeshData.indices.toArray());
+
+		if(combineImmidiateChildren) {
+			for(child in object.children) {
+
+				if(child.raw.type != "mesh_object") continue;
+
+				reducedMeshData = getVerticesIndicesFromMesh(child, currentIndexOffset);
+				currentIndexOffset = reducedMeshData.maxIndex + 1;
+
+				positionsArray = positionsArray.concat(reducedMeshData.positions.toArray());
+				indexArray = indexArray.concat(reducedMeshData.indices.toArray());
+			}
+		}
+
+		#if js
+		var positionsVector = Vector.fromArrayCopy(positionsArray);
+		var vecindVector = Vector.fromArrayCopy(indexArray);
+
+		recastNavMesh.build(positionsVector, positionsVector.length, vecindVector, vecindVector.length, recastConfig);
+		#else
+		var posLength = positionsArray.length;
+		var positionsVector = new recast.Recast.RcFloatArray(posLength);
+		for(i in 0...posLength) {
+			positionsVector.set(i, positionsArray[i]);
+		}
+
+		var indexLength = indexArray.length;
+		var vecindVector = new recast.Recast.RcIntArray(indexLength);
+		for(i in 0...indexLength) {
+			vecindVector.set(i, indexArray[i]);
+		}
+
+		recastNavMesh.build(positionsVector.raw, posLength, vecindVector.raw, indexLength, recastConfig);
+		#end
+		notifyOnUpdate(updateNavMesh);
+		ready = true;
+	}
+
+	public function reconstructNavMesh() {
+		removeUpdate(updateNavMesh);
+		if(recastCrowd != null) {
+			for(agent in crowdAgentMap.keys()) {
+				removeCrowdAgent(agent);
+			}
+			recastCrowd.destroy();
+		}
+		for(obstacle in tempObstacleMap.keys()) {
+			removeTempObstacle(obstacle);
+		}
+		ready = false;
+		initNavMesh();
+	}
+
+	public function updateNavMesh() {
+		if(!ready) return;
+		recastNavMesh.update();
 	}
 
 	public function findPath(from: Vec4, to: Vec4, done: Array<Vec4>->Void) {
 		if (!ready) return;
-		recast.findPath(from.x, from.z, from.y, to.x, to.z, to.y, 200, function(path: Array<RecastWaypoint>) {
-			var ar: Array<Vec4> = [];
-			for (p in path) ar.push(new Vec4(p.x, p.z, p.y - cellHeight));
-			done(ar);
-		});
+		var start = RecastConversions.recastVec3FromVec4(from);
+		var end = RecastConversions.recastVec3FromVec4(to);
+		var navPath = recastNavMesh.computePath(start, end);
+
+		var pathVec = new Array<Vec4>();
+		for(i in 0...navPath.getPointCount()) {
+			pathVec.push(RecastConversions.vec4FromRecastVec3(navPath.getPoint(i)));
+		}
+
+		done(pathVec);
 	}
 
-	public function getRandomPoint(done: Vec4->Void) {
+	public function getRandomPointAround(position: Vec4, radius: Float):Vec4 {
+		if (!ready) return null;
+		var randomPoint = recastNavMesh.getRandomPointAround(RecastConversions.recastVec3FromVec4(position), radius);
+		return RecastConversions.vec4FromRecastVec3(randomPoint);
+	}
+
+	public function initCrowd(maxAgents: Int, maxAgentRadius: Float) {
 		if (!ready) return;
-		recast.getRandomPoint(function(x: Float, y: Float, z: Float) {
-			done(new Vec4(x, z, -y));
-		});
+		recastCrowd = new recast.Recast.Crowd(maxAgents, maxAgentRadius, recastNavMesh.getNavMesh());
+		notifyOnUpdate(crowdUpdate);
 	}
 
-#end
+	public function addCrowdAgent(agent: NavCrowd, position: Vec4, radius: Float, height: Float, maxAcceleration: Float, maxSpeed: Float, updateFlags: Int = 7, separationWeight: Float = 1.0, collisionQueryRange: Float = 1.0): Int {
+		if(!ready) return -1;
+		if(recastCrowd == null) initCrowd(maxCrowdAgents, maxCrowdAgentRadius);
+		var crowdAgentParams = new recast.Recast.DtCrowdAgentParams();
+		crowdAgentParams.radius = radius;
+		crowdAgentParams.height = height;
+		crowdAgentParams.maxAcceleration = maxAcceleration;
+		crowdAgentParams.maxSpeed = maxSpeed;
+		crowdAgentParams.separationWeight = separationWeight;
+		crowdAgentParams.collisionQueryRange = collisionQueryRange;
+		crowdAgentParams.updateFlags = updateFlags;
+		crowdAgentParams.pathOptimizationRange=0;
+		var crowdAgentID = recastCrowd.addAgent(RecastConversions.recastVec3FromVec4(position), crowdAgentParams);
+		crowdAgentMap.set(crowdAgentID, agent);
+		return crowdAgentID;
+	}
+
+	public function removeCrowdAgent(agentID: Int) {
+		if(!ready) return;
+		if(recastCrowd == null) return;
+		crowdAgentMap.remove(agentID);
+		recastCrowd.removeAgent(agentID);
+	}
+
+	public function crowdUpdate() {
+		if(!ready) return;
+		if(recastCrowd == null) return;
+		recastCrowd.update(Time.delta);
+	}
+
+	public function crowdGetAgentPosition(agentID: Int):Vec4 {
+		if(!ready) return null;
+		if(recastCrowd == null) return null;
+		var pos = recastCrowd.getAgentPosition(agentID);
+		var armPos = RecastConversions.vec4FromRecastVec3(pos);
+		#if hl
+		pos.delete();
+		#end
+		return armPos;
+	}
+
+	public function crowdGetAgentVelocity(agentID: Int):Vec4 {
+		if(!ready) return null;
+		if(recastCrowd == null) return null;
+		var vel = recastCrowd.getAgentVelocity(agentID);
+		var armVel = RecastConversions.vec4FromRecastVec3(vel);
+		#if hl
+		vel.delete();
+		#end
+		return armVel;
+	}
+
+	public function crowdAgentGoto(agentID: Int, destination: Vec4) {
+		if(!ready) return;
+		if(recastCrowd == null) return;
+		recastCrowd.agentGoto(agentID, RecastConversions.recastVec3FromVec4(destination));
+	}
+
+	public function crowdAgentTeleport(agentID: Int, destination: Vec4) {
+		if(!ready) return;
+		if(recastCrowd == null) return;
+		recastCrowd.agentTeleport(agentID, RecastConversions.recastVec3FromVec4(destination));
+	}
+
+	public function addCylinderObstacle(navObstacle: NavObstacle, position: Vec4, radius: Float, height: Float): Int {
+		if(!ready) return -1;
+		if(!tiledMesh) return -1;
+		var pos = RecastConversions.recastVec3FromVec4(position);
+		var obstacle = recastNavMesh.addCylinderObstacle(pos, radius, height);
+		var obstacleID = tempObstacleCounter;
+		tempObstacleMap.set(obstacleID, navObstacle);
+		recastObstacleMap.set(obstacleID, obstacle);
+		tempObstacleCounter++;
+		return obstacleID;
+	}
+
+	public function addBoxObstacle(navObstacle: NavObstacle, position: Vec4, dimensions: Vec4, angle: Float): Int {
+		if(!ready) return -1;
+		if(!tiledMesh) return -1;
+		var pos = RecastConversions.recastVec3FromVec4(position);
+		var dim = RecastConversions.recastVec3FromVec4(dimensions);
+		var obstacle = recastNavMesh.addBoxObstacle(pos, dim, angle);
+		var obstacleID = tempObstacleCounter;
+		tempObstacleMap.set(obstacleID, navObstacle);
+		recastObstacleMap.set(obstacleID, obstacle);
+		tempObstacleCounter++;
+		return obstacleID;
+	}
+
+	public function removeTempObstacle(obstacleID: Int) {
+		if(!ready) return;
+		if(!tiledMesh) return;
+		tempObstacleMap.remove(obstacleID);
+		var obstacleRef = recastObstacleMap.get(obstacleID);
+		recastNavMesh.removeObstacle(obstacleRef);
+		recastObstacleMap.remove(obstacleID);
+	}
+
+	function fromI16(ar: kha.arrays.Int16Array, scalePos: Float): haxe.ds.Vector<Float> {
+		var vals = new haxe.ds.Vector<Float>(Std.int(ar.length / 4) * 3);
+		for (i in 0...Std.int(vals.length / 3)) {
+			vals[i * 3    ] = (ar[i * 4    ] / 32767) * scalePos;
+			vals[i * 3 + 1] = (ar[i * 4 + 1] / 32767) * scalePos;
+			vals[i * 3 + 2] = (ar[i * 4 + 2] / 32767) * scalePos;
+		}
+		return vals;
+	}
+
+	function fromU32(ars: Array<kha.arrays.Uint32Array>): haxe.ds.Vector<Int> {
+		var len = 0;
+		for (ar in ars) len += ar.length;
+		var vals = new haxe.ds.Vector<Int>(len);
+		var i = 0;
+		for (ar in ars) {
+			for (j in 0...ar.length) {
+				vals[i] = ar[j];
+				i++;
+			}
+		}
+		return vals;
+	}
+
+	function generateVertexIndexMap(ind: haxe.ds.Vector<Int>, vert: haxe.ds.Vector<Int>):Map<Int, Array<Int>> {
+		var vertexIndexMap = new Map();
+		for (i in 0...ind.length) {
+			var currentVertex = vert[i];
+			var currentIndex = ind[i];
+
+			var mapping = vertexIndexMap.get(currentVertex);
+			if (mapping == null) {
+				vertexIndexMap.set(currentVertex, [currentIndex]);
+			}
+			else {
+				if(! mapping.contains(currentIndex)) mapping.push(currentIndex);
+			}
+		}
+		return vertexIndexMap;
+	}
+
+	function getVerticesIndicesFromMesh(object: Object, indexOffset:Int = 0): MeshData {
+
+		var vertexIndexMap: Map<Int, Array<Int>>;
+
+		var mo = cast(object, MeshObject);
+		var geom = mo.data.geom;
+		var rawData = mo.data.raw;
+		var vertexMap: Array<Uint32Array> = [];
+		for (ind in rawData.index_arrays) {
+			if (ind.vertex_map == null) return null;
+			vertexMap.push(ind.vertex_map);
+		}
+
+		var vecind = fromU32(geom.indices);
+		var vertexMapArray = fromU32(vertexMap);
+
+		vertexIndexMap = generateVertexIndexMap(vecind, vertexMapArray);
+
+		// Parented object - clear parent location
+		if (object.parent != null && object.parent.name != "") {
+			object.transform.loc.x += object.parent.transform.worldx();
+			object.transform.loc.y += object.parent.transform.worldy();
+			object.transform.loc.z += object.parent.transform.worldz();
+			object.transform.localOnly = true;
+			object.transform.buildMatrix();
+		}
+
+		var positions = fromI16(geom.positions.values, mo.data.scalePos);
+		for (i in 0...Std.int(positions.length / 3)) {
+			v.set(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2]);
+			v.applyQuat(object.transform.rot);
+			v.x *= object.transform.scale.x;
+			v.y *= object.transform.scale.y;
+			v.z *= object.transform.scale.z;
+			v.addf(object.transform.worldx(), object.transform.worldy(), object.transform.worldz());
+			positions[i * 3    ] = v.x;
+			positions[i * 3 + 1] = v.y;
+			positions[i * 3 + 2] = v.z;
+		}
+
+
+		var vertsLength = 0;
+		for (key in vertexIndexMap.keys()) vertsLength++;
+		var positionsVector: haxe.ds.Vector<Float> = new haxe.ds.Vector<Float>(vertsLength * 3);
+		for (key in 0...vertsLength) {
+			var i = vertexIndexMap.get(key)[0];
+			// Y and Z are interchanged in Recast
+			positionsVector.set(key * 3    , positions[i * 3    ]);
+			positionsVector.set(key * 3 + 1, positions[i * 3 + 2]);
+			positionsVector.set(key * 3 + 2, positions[i * 3 + 1]);
+		}
+
+		var vecindVector: haxe.ds.Vector<Int> = new haxe.ds.Vector<Int>(vertexMapArray.length);
+		var maxIndex = 0;
+		for (i in 0...vecindVector.length){
+			var idx = vertexMapArray.get(i);
+			var idxOffset = idx + indexOffset;
+			vecindVector.set(i, idxOffset);
+
+			if(maxIndex < idxOffset) maxIndex = idxOffset;
+		}
+
+		return { positions: positionsVector, indices: vecindVector, maxIndex: maxIndex};
+
+	}
+
+	public function drawDebugMesh(helper: DebugDrawHelper) {
+		var recastDebugNavMesh = recastNavMesh.getDebugNavMesh();
+		var triangleCount = recastDebugNavMesh.getTriangleCount();
+		for(index in 0...triangleCount) {
+			var triangle = recastDebugNavMesh.getTriangle(index);
+			var point0 = RecastConversions.vec4FromRecastVec3(triangle.getPoint(0));
+			var point1 = RecastConversions.vec4FromRecastVec3(triangle.getPoint(1));
+			var point2 = RecastConversions.vec4FromRecastVec3(triangle.getPoint(2));
+
+			helper.drawLine(point0, point1, navMeshDebugColor);
+			helper.drawLine(point1, point2, navMeshDebugColor);
+			helper.drawLine(point2, point0, navMeshDebugColor);
+
+		}
+		#if hl
+		recastDebugNavMesh.delete();
+		#end
+	}
+	#end
+}
+
+typedef MeshData = {
+	var positions: haxe.ds.Vector<Float>;
+	var indices: haxe.ds.Vector<Int>;
+	var maxIndex:Int;
 }

--- a/Sources/armory/trait/NavObstacle.hx
+++ b/Sources/armory/trait/NavObstacle.hx
@@ -1,0 +1,60 @@
+package armory.trait;
+
+#if arm_navigation
+import iron.math.Vec4;
+import armory.trait.navigation.Navigation;
+#end
+import iron.Trait;
+
+class NavObstacle extends Trait {
+
+	#if !arm_navigation
+	public function new() { super(); }
+	#else
+
+	@prop
+	public var radius: Float = 1.0;
+
+	@prop
+	public var height: Float = 1.0;
+
+	var obstacleID: Int = -1;
+
+	public var obstacleReady (default, null) = false;
+
+	var activeNavMesh: NavMesh = null;
+
+	var initialPosition: Vec4 = new Vec4();
+
+	public function new() {
+		super();
+		notifyOnUpdate(addObstacle);
+		notifyOnRemove(removeObstacle);
+	}
+
+	function addObstacle() {
+
+		if(Navigation.active.navMeshes.length < 1) return;
+
+		if(! Navigation.active.navMeshes[0].ready) return;
+
+		activeNavMesh = Navigation.active.navMeshes[0];
+
+		initialPosition = object.transform.world.getLoc();
+		obstacleID = activeNavMesh.addCylinderObstacle(this, initialPosition, radius, height);
+
+		notifyOnUpdate(updateObstaclePosition);
+		removeUpdate(addObstacle);
+		obstacleReady = true;
+	}
+
+	function removeObstacle() {
+		activeNavMesh.removeTempObstacle(obstacleID);
+	}
+
+	function updateObstaclePosition() {
+		object.transform.loc.setFrom(initialPosition);
+		object.transform.buildMatrix();
+	}
+	#end
+}

--- a/Sources/armory/trait/navigation/DebugDrawHelper.hx
+++ b/Sources/armory/trait/navigation/DebugDrawHelper.hx
@@ -1,0 +1,102 @@
+package armory.trait.navigation;
+
+import kha.FastFloat;
+import kha.System;
+
+import iron.math.Vec4;
+
+#if arm_ui
+import armory.ui.Canvas;
+#end
+
+#if arm_navigation
+class DebugDrawHelper {
+	final navigation: Navigation;
+	final lines: Array<LineData> = [];
+
+	var debugMode: Navigation.DebugDrawMode = NoDebug;
+
+	public function new(navigation: Navigation) {
+		this.navigation = navigation;
+
+		iron.App.notifyOnRender2D(onRender);
+	}
+
+	public function drawLine(from: Vec4, to: Vec4, color: kha.Color) {
+
+		final fromScreenSpace = worldToScreenFast(new Vec4().setFrom(from));
+		final toScreenSpace =  worldToScreenFast(new Vec4().setFrom(to));
+
+		// For now don't draw lines if any point is outside of clip space z,
+		// investigate how to clamp lines to clip space borders
+		if (fromScreenSpace.w == 1 && toScreenSpace.w == 1) {
+			lines.push({
+				fromX: fromScreenSpace.x,
+				fromY: fromScreenSpace.y,
+				toX: toScreenSpace.x,
+				toY: toScreenSpace.y,
+				color: color
+			});
+		}
+	}
+
+	public function setDebugMode(debugMode: Navigation.DebugDrawMode) {
+		this.debugMode = debugMode;
+	}
+
+	public function getDebugMode(): Navigation.DebugDrawMode {
+		return debugMode;
+	}
+
+	function onRender(g: kha.graphics2.Graphics) {
+		
+		if (getDebugMode() == NoDebug) {
+			return;
+		}
+
+		for(navMesh in Navigation.active.navMeshes) {
+			navMesh.drawDebugMesh(this);
+		}
+
+		g.opacity = 1.0;
+
+		for (line in lines) {
+			g.color = line.color;
+			g.drawLine(line.fromX, line.fromY, line.toX, line.toY, 1.0);
+		}
+		lines.resize(0);
+	}
+
+	/**
+		Transform a world coordinate vector into screen space and store the
+		result in the input vector's x and y coordinates. The w coordinate is
+		set to 0 if the input vector is outside the active camera's far and near
+		planes, and 1 otherwise.
+	**/
+	inline function worldToScreenFast(loc: Vec4): Vec4 {
+		final cam = iron.Scene.active.camera;
+		loc.w = 1.0;
+		loc.applyproj(cam.VP);
+
+		if (loc.z < -1 || loc.z > 1) {
+			loc.w = 0.0;
+		}
+		else {
+			loc.x = (loc.x + 1) * 0.5 * System.windowWidth();
+			loc.y = (1 - loc.y) * 0.5 * System.windowHeight();
+			loc.w = 1.0;
+		}
+
+		return loc;
+	}
+}
+
+@:structInit
+class LineData {
+	public var fromX: FastFloat;
+	public var fromY: FastFloat;
+	public var toX: FastFloat;
+	public var toY: FastFloat;
+	public var color: kha.Color;
+}
+#end

--- a/Sources/armory/trait/navigation/Navigation.hx
+++ b/Sources/armory/trait/navigation/Navigation.hx
@@ -1,26 +1,47 @@
 package armory.trait.navigation;
 
 #if arm_navigation
-import haxerecast.Recast;
+import iron.math.Vec4;
+
 import armory.trait.NavMesh;
-#end
 
 class Navigation extends iron.Trait {
-
-#if (!arm_navigation)
-	public function new() { super(); }
-#else
 
 	public static var active: Navigation = null;
 
 	public var navMeshes: Array<NavMesh> = [];
-	public var recast: Recast;
+	//public var recast: Recast;
+
+	public var debugDrawHelper: DebugDrawHelper = null;
 
 	public function new() {
 		super();
 		active = this;
+		initDebugDrawing();
 
-		recast = new Recast();
 	}
-#end
+
+	function initDebugDrawing() {
+		debugDrawHelper = new DebugDrawHelper(this);
+	}
 }
+
+enum abstract DebugDrawMode(Int) from Int to Int {
+	/** All debug flags off. **/
+	var NoDebug = 0;
+
+	/** Draw wireframes of the NavMesh. **/
+	var DrawWireframe = 1;
+}
+
+class RecastConversions {
+	public static function recastVec3FromVec4(vec: Vec4): recast.Recast.Vec3{
+		return new recast.Recast.Vec3(vec.x, vec.z, vec.y);
+	}
+
+	public static function vec4FromRecastVec3(vec: recast.Recast.Vec3): Vec4 {
+		return new Vec4(vec.x, vec.z, vec.y);
+	}
+
+}
+#end

--- a/blender/arm/logicnode/navmesh/LN_crowd_go_to_location.py
+++ b/blender/arm/logicnode/navmesh/LN_crowd_go_to_location.py
@@ -1,0 +1,20 @@
+from arm.logicnode.arm_nodes import *
+
+class GoToLocationNode(ArmLogicTreeNode):
+    """Makes a NavCrowd agent go to location.
+
+    @input In: Start navigation.
+    @input Object: The object to navigate. Object must have `NavCrowd` trait applied.
+    @input Location: Closest point on the navmesh to navigate to.
+    """
+    bl_idname = 'LNCrowdGoToLocationNode'
+    bl_label = 'Crowd Go to Location'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmVectorSocket', 'Location')
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -868,11 +868,8 @@ def draw_traits_panel(layout: bpy.types.UILayout, obj: Union[bpy.types.Object, b
 
             # Bundled scripts
             else:
-                if item.class_name_prop == 'NavMesh':
-                    row.operator("arm.generate_navmesh", icon="UV_VERTEXSEL")
-                else:
-                    row.enabled = item.class_name_prop != ''
-                    row.operator("arm.edit_bundled_script", icon_value=ICON_HAXE).is_object = is_object
+                row.enabled = item.class_name_prop != ''
+                row.operator("arm.edit_bundled_script", icon_value=ICON_HAXE).is_object = is_object
 
             refresh_op = "arm.refresh_object_scripts" if is_object else "arm.refresh_scripts"
             row.operator(refresh_op, text="Refresh", icon="FILE_REFRESH")

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -159,8 +159,15 @@ project.addSources('Sources');
             assets.add_khafile_def('arm_navigation')
             if not os.path.exists('Libraries/haxerecast'):
                 khafile.write(add_armory_library(sdk_path + '/lib/', 'haxerecast', rel_path=do_relpath_sdk))
-            if state.target.startswith('krom') or state.target == 'html5':
-                recastjs_path = sdk_path + '/lib/haxerecast/js/recast/recast.js'
+            if state.target.startswith('krom'):
+                recastjs_path = sdk_path + '/lib/haxerecast/recastjs/recast.wasm.js'
+                recastjs_path = recastjs_path.replace('\\', '/').replace('//', '/')
+                khafile.write(add_assets(recastjs_path, rel_path=do_relpath_sdk))
+                recastjs_wasm_path = sdk_path + '/lib/haxerecast/recastjs/recast.wasm.wasm'
+                recastjs_wasm_path = recastjs_wasm_path.replace('\\', '/').replace('//', '/')
+                khafile.write(add_assets(recastjs_wasm_path, rel_path=do_relpath_sdk))
+            elif state.target == 'html5' or state.target == 'node':
+                recastjs_path = sdk_path + '/lib/haxerecast/recastjs/recast.js'
                 recastjs_path = recastjs_path.replace('\\', '/').replace('//', '/')
                 khafile.write(add_assets(recastjs_path, rel_path=do_relpath_sdk))
 


### PR DESCRIPTION
## Overview:
This PR is a complete overhaul of the recast navigation system that solves a few issues and introduces many new features.

## New Features and Fixes:

### Dynamic generation of Navmesh: 
The navigation mesh is generated at runtime unlike before, where it had to be exported as an `.obj` file and then created from from file. The new version creates the navigation mesh with object geometry info from iron. This also comes with an option to include immediate child meshes into the navmesh build.

### Crowd System:
Previously, the `NavAgents` would not have any awareness of the other agents. This caused agents to not collide with each other and intersect. The newly implemented crowds system solves this issue. Now the `NavCrowd` agents will be aware of the neighbors and try to remain separated while navigating to the goal. This does not remove the `NavAgent` trait. It is still usable for basic path finding without the crowds system.

### Temporary Obstacles:
The new module includes an option to create `tiled navmesh`. This enables for the possibility of adding and removing temporary obstacles with a cylindrical or cuboidal shape. The navigation `NavAgents` and `NavCrowd` agents obey the obstacles and dont pass through them. This opens new possibilities for a dynamic navmesh based games. The PR also includes a Logic Node to add cylindrical obstacles.

### Runtime Debug View:
Navigation mesh generated can be viewed at runtime if the `debug view` option is enabled for the navmesh.

### Support for Haxe HL targets:
This PR also includes support for navigation system on all HL targets. Only JS targets were supported before.

## Breaking Changes:
Since the new navigation system is a complete overhaul. there are a few breaking changes.

* The `NavMesh` and `NavAgent` bundled traits must be removed, re-added and re-configured if already being used in a game.
* There is no `Preview` of the built navmesh in Blender. Unlike before, the navmesh is generated at runtime. So this option of preview in Blender is removed. However, to make up for this, runtime debug view of navmesh is supported.

## Dependencies:
The new recast navigation system requires https://github.com/QuantumCoderQC/haxerecast instead of the currently used https://github.com/armory3d/haxerecast. These repositories do not share a common history.

## Demo:
Here is a small demo of the new recast system with temporary obstacles and navigation crowds system:
https://quantumcoderqc.github.io/RecastNavigationDemo/html5/index.html

Thanks to everyone on discord for their feedback and testing. Thanks to @ 1k8 for testing on Linux HL.