### PR TITLE
added a new logic node called HideActiveCanvas

### DIFF
--- a/Sources/armory/logicnode/HideActiveCanvas.hx
+++ b/Sources/armory/logicnode/HideActiveCanvas.hx
@@ -1,0 +1,21 @@
+package armory.logicnode;
+import armory.trait.internal.CanvasScript;
+
+class HideActiveCanvas extends LogicNode 
+{
+
+    public function new(tree:LogicTree) 
+    {
+        super(tree);
+    }
+
+    override function run(from: Int) 
+    {
+        //get bool from socket
+        var value = inputs[1].get(); 
+        CanvasScript.getActiveCanvas().setCanvasVisibility(value);
+
+        // Execute next action linked to this node, this activates the output socket at position/index 0
+        runOutput(0);
+    }
+}

--- a/blender/arm/logicnode/canvas/LN_HideActiveCanvas.py
+++ b/blender/arm/logicnode/canvas/LN_HideActiveCanvas.py
@@ -1,0 +1,13 @@
+from arm.logicnode.arm_nodes import *
+
+class HideActiveCanvas(ArmLogicTreeNode):
+    """HideActiveCanvas"""
+    bl_idname = 'LNHideActiveCanvas'
+    bl_label = 'Hide Active Canvas'
+    bl_description = 'This node Hides and shows the whole Active Canvas'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_output('ArmNodeSocketAction', 'Out')
+        self.inputs.new('ArmBoolSocket', 'HideCanvas')


### PR DESCRIPTION
This node hides and unhides the whole active canvas not just certain elements of the canvas. Thus users can easily enable and disable menus for example. I also highly suggest that the LN_set_canvas_visible and LN_get_canvas_visible node are renamed into something like canvas_element_visible. As the node does not actually set the whole canvas visible just parts of it.