### PR TITLE
Logic node for regular expression

### DIFF
--- a/Sources/armory/logicnode/RegularExpressionNode.hx
+++ b/Sources/armory/logicnode/RegularExpressionNode.hx
@@ -1,0 +1,41 @@
+package armory.logicnode;
+
+class RegularExpressionNode extends LogicNode {
+
+	public var property0: String;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var RegExp: EReg = new EReg(inputs[0].get(), inputs[1].get());
+		var str: String = inputs[2].get();
+
+		switch (property0) {
+			case "Match":
+				var mch: Bool = RegExp.match(str);
+				
+				if (from == 0) 
+					return mch;
+
+				var mched: Array<String> = [];
+				
+				if (mch){
+					var lng: Int = inputs[0].get().split('(').length;
+					for(i in 1...lng) mched.push(RegExp.matched(i));
+				}
+					
+				return mched;
+
+			case "Split":
+				return RegExp.split(str);
+			case "Replace":
+				return RegExp.replace(str, inputs[3].get());
+
+		}
+	
+		return null;
+
+	}
+}

--- a/blender/arm/logicnode/miscellaneous/LN_regular_expression.py
+++ b/blender/arm/logicnode/miscellaneous/LN_regular_expression.py
@@ -1,0 +1,74 @@
+from arm.logicnode.arm_nodes import *
+
+class RegularExpressionNode(ArmLogicTreeNode):
+    """
+    The first argument is a string with a regular expression pattern, the second one is a string with flags.
+
+    @input RegExp Pattern: regular expression patterns such as
+
+        . any character
+        * repeat zero-or-more
+        + repeat one-or-more
+        ? optional zero-or-one
+        [A-Z0-9] character ranges
+        [^\r\n\t] character not-in-range
+        (...) parenthesis to match groups of characters
+        ^ beginning of the string (beginning of a line in multiline matching mode)
+        $ end of the string (end of a line in multiline matching mode)
+        | "OR" statement.
+
+
+    @input RegExp Flags: possible flags are the following
+
+        i case insensitive matching
+        g global replace or split, see below
+        m multiline matching, ^ and $ represent the beginning and end of a line
+        s the dot . will also match newlines (not supported by C# and JavaScript versions before ES2018)
+        u use UTF-8 matching (Neko and C++ targets only)
+
+    @input String: String to match, split or replace
+    @input Replace: String to use when replace 
+
+    @ouput Match: boolean result comparing the regular expression pattern with the string
+    @output Matched: array containing list of matched patterns
+    @output Split: array string of string splits using the pattern
+    @output Replace: new string with the pattern replaced
+
+    """
+    bl_idname = 'LNRegularExpressionNode'
+    bl_label = 'Regular Expression'
+
+    arm_version = 1
+
+    def remove_extra_inputs(self, context):
+        while len(self.outputs) > 0:
+            self.outputs.remove(self.outputs[-1])
+        if len(self.inputs) != 3:
+            self.inputs.remove(self.inputs[-1])
+        if self.property0 == 'Match':
+            self.add_output('ArmBoolSocket', 'Match')
+            self.add_output('ArmNodeSocketArray', 'Matched', is_var=False)
+        if self.property0 == 'Split':
+            self.add_output('ArmNodeSocketArray', 'Split', is_var=False)
+        if self.property0 == 'Replace':
+            self.add_input('ArmStringSocket', 'Replace')
+            self.add_output('ArmStringSocket', 'String')
+
+    property0: HaxeEnumProperty(
+        'property0',
+        items = [('Match', 'Match', 'A regular expression is used to compare a string. Use () in the pattern to retrieve Matched groups'),
+                ('Split', 'Split', 'A regular expression can also be used to split a string into several substrings'),
+                ('Replace', 'Replace', 'A regular expression can also be used to replace a part of the string')],
+        name='', default='Match', update=remove_extra_inputs)
+
+    def arm_init(self, context):
+
+        self.add_input('ArmStringSocket', 'RegExp Pattern')
+        self.add_input('ArmStringSocket', 'RegExp Flags')
+        self.add_input('ArmStringSocket', 'String')
+        
+        self.add_output('ArmBoolSocket', 'Match')
+        self.add_output('ArmNodeSocketArray', 'Matched', is_var=False)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')


### PR DESCRIPTION
This node allows regular expression: match (if true it also returns matched patterns),  split and replace. By using regular expressions instead of strings it brings a flexible way of dealing with cases when this kind of operations require some level of flexibility.  

I added some usage documentation in the logic node description.

![image](https://github.com/armory3d/armory/assets/32546729/8188348a-5543-4953-b337-d05209df287d)
![image](https://github.com/armory3d/armory/assets/32546729/aabaee42-296c-4021-893d-b6712726a547)
![image](https://github.com/armory3d/armory/assets/32546729/f712cb25-b68b-4b00-978f-2116317f4545)
