### PR TITLE
Fix compilation when using shadow map atlas of size 32768

### DIFF
--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -751,6 +751,8 @@ class ShadowMapAtlas {
 			return 8192;
 			#elseif (rp_shadowmap_atlas_max_size == 16384)
 			return 16384;
+			#elseif (rp_shadowmap_atlas_max_size == 32768)
+			return 32768;
 			#end
 		#else
 		switch (type) {
@@ -765,6 +767,8 @@ class ShadowMapAtlas {
 				return 8192;
 				#elseif (rp_shadowmap_atlas_max_size_point == 16384)
 				return 16384;
+				#elseif (rp_shadowmap_atlas_max_size_point == 32768)
+				return 32768;
 				#end
 			}
 			case "spot": {
@@ -780,6 +784,8 @@ class ShadowMapAtlas {
 				return 8192;
 				#elseif (rp_shadowmap_atlas_max_size_spot == 16384)
 				return 16384;
+				#elseif (rp_shadowmap_atlas_max_size_spot == 32768)
+				return 32768;
 				#end
 			}
 			case "sun": {
@@ -795,6 +801,8 @@ class ShadowMapAtlas {
 				return 8192;
 				#elseif (rp_shadowmap_atlas_max_size_sun == 16384)
 				return 16384;
+				#elseif (rp_shadowmap_atlas_max_size_sun == 32768)
+				return 32768;
 				#end
 			}
 			default: {
@@ -810,9 +818,10 @@ class ShadowMapAtlas {
 				return 8192;
 				#elseif (rp_shadowmap_atlas_max_size == 16384)
 				return 16384;
+				#elseif (rp_shadowmap_atlas_max_size == 32768)
+				return 32768;
 				#end
 			}
-
 		}
 		#end
 	}


### PR DESCRIPTION
The Armory UI allows for shadow map sizes up to 32768, but the corresponding Haxe code didn't. Thanks to @ TriVoxel on Discord for reporting this :)