### PR TITLE
World to Screen Space: Camera option

### DIFF
--- a/Sources/armory/logicnode/WorldToScreenSpaceNode.hx
+++ b/Sources/armory/logicnode/WorldToScreenSpaceNode.hx
@@ -3,11 +3,13 @@ package armory.logicnode;
 import iron.math.Vec4;
 import iron.math.Vec2;
 import iron.App;
+import iron.object.CameraObject;
 
 class WorldToScreenSpaceNode extends LogicNode {
 
 	public var property0: String;
 	var v = new Vec4();
+	var cam: CameraObject;
 
 	public function new(tree: LogicTree) {
 		super(tree);
@@ -17,7 +19,11 @@ class WorldToScreenSpaceNode extends LogicNode {
 		var v1: Vec4 = inputs[0].get();
 		if (v1 == null) return null;
 
-		var cam = iron.Scene.active.camera;
+		if(property0 == 'Active Camera') 
+			cam = iron.Scene.active.camera;
+		else 
+			cam = inputs[1].get();
+		
 		v.setFrom(v1);
 		v.applyproj(cam.V);
 		v.applyproj(cam.P);

--- a/blender/arm/logicnode/math/LN_world_to_screen_space.py
+++ b/blender/arm/logicnode/math/LN_world_to_screen_space.py
@@ -1,13 +1,35 @@
 from arm.logicnode.arm_nodes import *
 
 class WorldToScreenSpaceNode(ArmLogicTreeNode):
-    """Transforms the given world coordinates into screen coordinates."""
+    """Transforms the given world coordinates into screen coordinates,
+    using the active camera or a selected camera."""
     bl_idname = 'LNWorldToScreenSpaceNode'
     bl_label = 'World to Screen Space'
     arm_section = 'matrix'
-    arm_version = 1
+    arm_version = 2
+
+   def remove_extra_inputs(self, context):
+        while len(self.inputs) > 1:
+            self.inputs.remove(self.inputs[-1])
+        if self.property0 == 'Selected Camera':
+            self.add_input('ArmNodeSocketObject', 'Camera')
+
+    property0: HaxeEnumProperty(
+    'property0',
+    items = [('Active Camera', 'Active Camera', 'Active Camera'),
+             ('Selected Camera', 'Selected Camera', 'Selected Camera')],
+    name='', default='Active Camera', update=remove_extra_inputs)
 
     def arm_init(self, context):
         self.add_input('ArmVectorSocket', 'World')
 
         self.add_output('ArmVectorSocket', 'Screen')
+    
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+            
+        return NodeReplacement.Identity(self)


### PR DESCRIPTION
I usually use this node with Raycast and Draw nodes, but not always with the active camera. The actual node by default only uses the active camera always. I propose to add a property to choose between the **Active Camera** and a **Selected Camera**. This property is set to **Active Camera** by default, so unless its value is changed it will continue to produce the same result as the actual node, but it will allow to use a different camera if needed.

![image](https://github.com/armory3d/armory/assets/32546729/26895b49-3b82-4168-9fca-3d544167bc27)
![image](https://github.com/armory3d/armory/assets/32546729/296bc2b3-eac1-46d4-9472-1ea0bcb224fe)
