### PR TITLE
Armory Traits UI: Remove Traits and Print Scene Traits

### DIFF
--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -739,6 +739,10 @@ class ARM_OT_RemoveTraitsFromActiveObjects(bpy.types.Operator):
     bl_idname = 'arm.remove_traits_from_active_objects'
     bl_description = 'Removes all traits from all selected objects'
 
+    @classmethod
+    def poll(cls, context):
+        return len(context.selected_objects) > 0
+
     def execute(self, context):
         for obj in bpy.context.selected_objects:
             obj.arm_traitlist.clear()

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -734,6 +734,24 @@ class ARM_PT_SceneTraitPanel(bpy.types.Panel):
         obj = bpy.context.scene
         draw_traits_panel(self.layout, obj, is_object=False)
 
+class ARM_OT_RemoveTraitsFromActiveObjects(bpy.types.Operator):
+    bl_label = 'Remove Traits From Active Objects'
+    bl_idname = 'arm.remove_traits_from_active_objects'
+    bl_description = 'Removes all traits from all active objects'
+
+    def execute(self, context):
+        for obj in bpy.context.selected_objects:
+            lst = obj.arm_traitlist
+            while(len(lst) > 0):
+                lst.remove(0)
+            obj.arm_traitlist_index = 0
+
+        for obj in bpy.context.selected_objects:
+            print(obj.name, obj.arm_traitlist_index)
+
+        return {"FINISHED"}
+    
+
 class ARM_OT_CopyTraitsFromActive(bpy.types.Operator):
     bl_label = 'Copy Traits from Active Object'
     bl_idname = 'arm.copy_traits_to_active'
@@ -814,6 +832,7 @@ class ARM_MT_context_menu(Menu):
         layout = self.layout
 
         layout.operator("arm.copy_traits_to_active", icon='PASTEDOWN')
+        layout.operator("arm.remove_traits_from_active_objects", icon='REMOVE')
         layout.operator("arm.print_traits", icon='CONSOLE')
 
 def draw_traits_panel(layout: bpy.types.UILayout, obj: Union[bpy.types.Object, bpy.types.Scene], is_object: bool) -> None:
@@ -977,6 +996,7 @@ __REG_CLASSES = (
     ARM_PT_SceneTraitPanel,
     ARM_OT_CopyTraitsFromActive,
     ARM_MT_context_menu,
+    ARM_OT_RemoveTraitsFromActiveObjects
 )
 __reg_classes, unregister = bpy.utils.register_classes_factory(__REG_CLASSES)
 

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -746,9 +746,6 @@ class ARM_OT_RemoveTraitsFromActiveObjects(bpy.types.Operator):
                 lst.remove(0)
             obj.arm_traitlist_index = 0
 
-        for obj in bpy.context.selected_objects:
-            print(obj.name, obj.arm_traitlist_index)
-
         return {"FINISHED"}
     
 

--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -735,15 +735,13 @@ class ARM_PT_SceneTraitPanel(bpy.types.Panel):
         draw_traits_panel(self.layout, obj, is_object=False)
 
 class ARM_OT_RemoveTraitsFromActiveObjects(bpy.types.Operator):
-    bl_label = 'Remove Traits From Active Objects'
+    bl_label = 'Remove Traits From Selected Objects'
     bl_idname = 'arm.remove_traits_from_active_objects'
-    bl_description = 'Removes all traits from all active objects'
+    bl_description = 'Removes all traits from all selected objects'
 
     def execute(self, context):
         for obj in bpy.context.selected_objects:
-            lst = obj.arm_traitlist
-            while(len(lst) > 0):
-                lst.remove(0)
+            obj.arm_traitlist.clear()
             obj.arm_traitlist_index = 0
 
         return {"FINISHED"}

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -2284,6 +2284,19 @@ class ArmPrintTraitsButton(bpy.types.Operator):
     def execute(self, context):
         for s in bpy.data.scenes:
             print('Scene: {0}'.format(s.name))
+            for t in s.arm_traitlist:
+                if not t.enabled_prop:
+                    continue
+                tname = "undefined"
+                if t.type_prop == 'Haxe Script' or "Bundled":
+                    tname = t.class_name_prop
+                if t.type_prop == 'Logic Nodes':
+                    tname = t.node_tree_prop.name
+                if t.type_prop == 'UI Canvas':
+                    tname = t.canvas_name_prop
+                if t.type_prop == 'WebAssembly':
+                    tname = t.webassembly_prop
+                print('Scene Trait: {0} ("{1}")'.format(s.name, tname))
             for o in s.objects:
                 for t in o.arm_traitlist:
                     if not t.enabled_prop:
@@ -2297,7 +2310,7 @@ class ArmPrintTraitsButton(bpy.types.Operator):
                         tname = t.canvas_name_prop
                     if t.type_prop == 'WebAssembly':
                         tname = t.webassembly_prop
-                    print('Trait: {0} ("{1}")'.format(o.name, tname))
+                    print('Object Trait: {0} ("{1}")'.format(o.name, tname))
         return{'FINISHED'}
 
 class ARM_PT_MaterialNodePanel(bpy.types.Panel):

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -2278,7 +2278,7 @@ class ARM_PT_TilesheetPanel(bpy.types.Panel):
 
 class ArmPrintTraitsButton(bpy.types.Operator):
     bl_idname = 'arm.print_traits'
-    bl_label = 'Print All Scenes Traits'
+    bl_label = 'Print All Traits'
     bl_description = 'Returns all traits in current blend'
 
     def execute(self, context):
@@ -2310,7 +2310,7 @@ class ArmPrintTraitsButton(bpy.types.Operator):
                         tname = t.canvas_name_prop
                     if t.type_prop == 'WebAssembly':
                         tname = t.webassembly_prop
-                    print('Object Trait: {0} ("{1}")'.format(o.name, tname))
+                    print(' Object Trait: {0} ("{1}")'.format(o.name, tname))
         return{'FINISHED'}
 
 class ARM_PT_MaterialNodePanel(bpy.types.Panel):


### PR DESCRIPTION
This is my first attempt to modify armory ui. I appreciate comments if you notice something is missing or it could be improved. I did my best with what I know.

I added an operator that removes all traits from active objects: 

![image](https://github.com/armory3d/armory/assets/32546729/ea7e73c3-86c7-411f-ba86-58efbb18537d)

Additionally I added to the operator **Print All Scenes Traits** the information of the Scene traits (@ rpaladin, I hope you find this ok). Before it only printed the object traits.

![image](https://github.com/armory3d/armory/assets/32546729/90c45bb0-a063-4b48-ba76-dc18a5becd0d)