### PR TITLE
Print exception if player cannot be started

### DIFF
--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -11,6 +11,7 @@ from string import Template
 import subprocess
 import threading
 import time
+import traceback
 from typing import Callable
 import webbrowser
 
@@ -677,8 +678,9 @@ def build_success():
                     cmd.append('--nosound')
         try:
             state.proc_play = run_proc(cmd, play_done)
-        except:
-            log.warn('Failed to start player')
+        except Exception:
+            traceback.print_exc()
+            log.warn('Failed to start player, command and exception have been printed to console above')
             if wrd.arm_runtime == 'Browser':
                 webbrowser.open(url)
 

--- a/blender/arm/make.py
+++ b/blender/arm/make.py
@@ -629,7 +629,7 @@ def build_success():
                 else:
                     tplstr = Template(envcmd).safe_substitute({
                         'host': host,
-                        'port': prefs.html5_server_port, 
+                        'port': prefs.html5_server_port,
                         'width': width,
                         'height': height,
                         'url': url,


### PR DESCRIPTION
So far there was no way to see the reason why launching the player command failed. The command mentioned in the warning message is already printed in `run_proc()`, so there is no extra print statement in the added code.