### PR TITLE
Fix context for remove traits operator

### DIFF
--- a/blender/arm/props_traits.py
+++ b/blender/arm/props_traits.py
@@ -741,7 +741,7 @@ class ARM_OT_RemoveTraitsFromActiveObjects(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return len(context.selected_objects) > 0
+        return context.mode != 'SCENE' and len(context.selected_objects) > 0
 
     def execute(self, context):
         for obj in bpy.context.selected_objects:


### PR DESCRIPTION
Originally mentioned in my code review for #2971

Not quite sure why the PR was merged before the proposed change was implemented.