### PR TITLE
SetNameNode: update animation armature action references for armature name changes

### DIFF
--- a/Sources/armory/logicnode/SetNameNode.hx
+++ b/Sources/armory/logicnode/SetNameNode.hx
@@ -14,6 +14,12 @@ class SetNameNode extends LogicNode {
 
 		if (object == null) return;
 
+		#if arm_skin
+		for(a in iron.Scene.active.animations)
+			if(a.armature != null && a.armature.name == object.name)
+				a.armature.name = name;
+		#end
+
 		object.name = name;
 
 		runOutput(0);


### PR DESCRIPTION
Currently the set name for armature objects loses the animation armature actions references when the armature name is changed. So for example play action node from stops working because the new armature name does not have any reference although is all the same with a different name. I added that part to the script in order to keep consistency.

The other alternative is not to allow the setName for armature objects, because there isn't a node that updates the animations armature actions reference.