### PR TITLE
Add DebugConsole.isDebugConsoleHovered (+ node integration)

### DIFF
--- a/Sources/armory/logicnode/GetDebugConsoleSettings.hx
+++ b/Sources/armory/logicnode/GetDebugConsoleSettings.hx
@@ -1,5 +1,8 @@
 package armory.logicnode;
+
+#if arm_debug
 import armory.trait.internal.DebugConsole;
+#end
 
 class GetDebugConsoleSettings extends LogicNode {
 
@@ -8,19 +11,22 @@ class GetDebugConsoleSettings extends LogicNode {
 	}
 
 	override function get(from: Int): Dynamic {
-		#if arm_debug
 		switch(from) {
-			case 0: return armory.trait.internal.DebugConsole.getVisible();
-			case 1: return armory.trait.internal.DebugConsole.getScale();
-			case 2: {
-				switch (armory.trait.internal.DebugConsole.getPosition()) {
-				case PositionStateEnum.Left: return "Left";
-				case PositionStateEnum.Center: return "Center";
-				case PositionStateEnum.Right: return "Right";
+			case 0: return #if arm_debug true #else false #end;
+			case 1: return #if arm_debug DebugConsole.getVisible() #else false #end;
+			case 2: return #if arm_debug DebugConsole.isDebugConsoleHovered #else false #end;
+			case 3: return #if arm_debug DebugConsole.getScale() #else 1.0 #end;
+			case 4:
+				#if arm_debug
+				switch (DebugConsole.getPosition()) {
+					case PositionStateEnum.Left: return "Left";
+					case PositionStateEnum.Center: return "Center";
+					case PositionStateEnum.Right: return "Right";
 				}
-			}
+				#else
+				return "";
+				#end
 		}
-		#end
 		return null;
 	}
 }

--- a/Sources/armory/logicnode/GetMouseStartedNode.hx
+++ b/Sources/armory/logicnode/GetMouseStartedNode.hx
@@ -2,7 +2,13 @@ package armory.logicnode;
 
 import iron.system.Input;
 
+#if arm_debug
+import armory.trait.internal.DebugConsole;
+#end
+
 class GetMouseStartedNode extends LogicNode {
+
+	public var property0: Bool;
 
 	var m = Input.getMouse();
 	var buttonStarted: Null<String>;
@@ -13,6 +19,10 @@ class GetMouseStartedNode extends LogicNode {
 
 	override function run(from: Int) {
 		buttonStarted = null;
+
+		#if arm_debug
+			if (!property0 && DebugConsole.isDebugConsoleHovered) return;
+		#end
 
 		for (b in Mouse.buttons) {
 			if (m.started(b)) {

--- a/Sources/armory/logicnode/MergedMouseNode.hx
+++ b/Sources/armory/logicnode/MergedMouseNode.hx
@@ -1,9 +1,14 @@
 package armory.logicnode;
 
+#if arm_debug
+import armory.trait.internal.DebugConsole;
+#end
+
 class MergedMouseNode extends LogicNode {
 
 	public var property0: String;
 	public var property1: String;
+	public var property2: Bool;
 
 	public function new(tree: LogicTree) {
 		super(tree);
@@ -12,6 +17,10 @@ class MergedMouseNode extends LogicNode {
 	}
 
 	function update() {
+		#if arm_debug
+			if (!property2 && DebugConsole.isDebugConsoleHovered && property0 != "moved") return;
+		#end
+
 		var mouse = iron.system.Input.getMouse();
 		var b = false;
 		switch (property0) {
@@ -28,6 +37,10 @@ class MergedMouseNode extends LogicNode {
 	}
 
 	override function get(from: Int): Dynamic {
+		#if arm_debug
+			if (!property2 && DebugConsole.isDebugConsoleHovered && property0 != "moved") return false;
+		#end
+
 		var mouse = iron.system.Input.getMouse();
 		switch (property0) {
 		case "started":

--- a/blender/arm/logicnode/input/LN_get_mouse_started.py
+++ b/blender/arm/logicnode/input/LN_get_mouse_started.py
@@ -1,13 +1,36 @@
 from arm.logicnode.arm_nodes import *
 
+
 class GetMouseStartedNode(ArmLogicTreeNode):
     """."""
     bl_idname = 'LNGetMouseStartedNode'
     bl_label = 'Get Mouse Started'
-    arm_version = 1
+    arm_version = 2
+
+    property0: HaxeBoolProperty(
+        'property0',
+        name='Include Debug Console',
+        description=(
+            'If disabled, this node does not react to mouse press events'
+            ' over the debug console area. Enable this option to catch those events'
+        )
+    )
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
 
         self.add_output('ArmNodeSocketAction', 'Out')
         self.add_output('ArmStringSocket', 'Button')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement(
+            'LNGetMouseStartedNode', self.arm_version, 'LNGetMouseStartedNode', 2,
+            in_socket_mapping={0: 0}, out_socket_mapping={0: 0, 1: 1},
+            property_defaults={'property0': True}
+        )

--- a/blender/arm/logicnode/miscellaneous/LN_get_debug_console_settings.py
+++ b/blender/arm/logicnode/miscellaneous/LN_get_debug_console_settings.py
@@ -1,12 +1,36 @@
 from arm.logicnode.arm_nodes import *
 
+
 class GetDebugConsoleSettings(ArmLogicTreeNode):
-    """Returns the debug console settings."""
+    """Return properties of the debug console.
+
+    @output Enabled: Whether the debug console is enabled.
+    @output Visible: Whether the debug console is visible,
+        or `false` if the debug console is disabled.
+    @output Hovered: Whether the debug console is hovered by the mouse cursor,
+        or `false` if the debug console is disabled.
+    @output UI Scale: The scaling factor of the debug console user interface,
+        or `1.0` if the debug console is disabled.
+    @output Position: The initial position of the debug console.
+        Possible values if the debug console is enabled: `"Left"`, `"Center"`, `"Right"`.
+        If the debug console is disabled, the returned value is an empty string `""`.
+    """
     bl_idname = 'LNGetDebugConsoleSettings'
     bl_label = 'Get Debug Console Settings'
-    arm_version = 1
+    arm_version = 2
 
     def arm_init(self, context):
+        self.add_output('ArmBoolSocket', 'Enabled')
         self.add_output('ArmBoolSocket', 'Visible')
-        self.add_output('ArmFloatSocket', 'Scale')
+        self.add_output('ArmBoolSocket', 'Hovered')
+        self.add_output('ArmFloatSocket', 'UI Scale')
         self.add_output('ArmStringSocket', 'Position')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement(
+            'LNGetDebugConsoleSettings', self.arm_version, 'LNGetDebugConsoleSettings', 2,
+            in_socket_mapping={}, out_socket_mapping={0: 1, 1: 3, 2: 4}
+        )


### PR DESCRIPTION
This PR adds the debug console attribute `DebugConsole.isDebugConsoleHovered` that can be read to check whether the mouse was hovered over any debug console window in the last frame, e.g. to avoid interacting with the game when clicking on the debug console. The same attribute is available via the `Hovered` output of the `Get Debug Console Settings` node.

In addition to that, the mouse nodes now have a "shortcut" property that, if disabled (default), disables the nodes when the mouse is hovered over the console. Please let me know if you want the default to be the other way around. Nodes updated from older versions automatically enable this option to preserve the exact behaviour from before.