### PR TITLE
Play sound node: fix sound load and retrigger

### DIFF
--- a/Sources/armory/logicnode/PlaySoundRawNode.hx
+++ b/Sources/armory/logicnode/PlaySoundRawNode.hx
@@ -27,7 +27,7 @@ class PlaySoundRawNode extends LogicNode {
 	override function run(from: Int) {
 		switch (from) {
 			case Play:
-				if (sound == null) {
+				if (property6 == 'Sound' ? sound == null : true) {
 					iron.data.Data.getSound(property6 == 'Sound' ? property0 : inputs[5].get(), function(s: kha.Sound) {
 						this.sound = s;
 					});
@@ -36,6 +36,8 @@ class PlaySoundRawNode extends LogicNode {
 				// Resume
 				if (channel != null) {
 					if (property2) channel.stop();
+					if (property6 == 'Sound Name')
+						channel = iron.system.Audio.play(sound, property1, property5);
 					channel.play();
 					channel.volume = inputs[4].get();
 				}


### PR DESCRIPTION
I missed these lines of code when sound is loaded again and retriggered.

Otherwise the node always plays the same initial sound even though the sound name is changed.

Sorry.