### PR TITLE
Fix rendering of two sided materials in some render paths

### DIFF
--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -151,6 +151,9 @@ def make_base(con_mesh, parse_opacity):
     make_attrib.write_norpos(con_mesh, vert)
     frag.write_attrib('vec3 n = normalize(wnormal);')
 
+    if mat_state.material.arm_two_sided:
+        frag.write('if (!gl_FrontFacing) n *= -1;')  # Flip normal when drawing back-face
+
     if not is_displacement and not vattr_written:
         make_attrib.write_vertpos(vert)
 
@@ -239,9 +242,6 @@ def make_deferred(con_mesh, rpasses):
 
     # Pack gbuffer
     frag.add_include('std/gbuffer.glsl')
-
-    if mat_state.material.arm_two_sided:
-        frag.write('if (!gl_FrontFacing) n *= -1;') # Flip normal when drawing back-face
 
     frag.write('n /= (abs(n.x) + abs(n.y) + abs(n.z));')
     frag.write('n.xy = n.z >= 0.0 ? n.xy : octahedronWrap(n.xy);')
@@ -341,6 +341,9 @@ def make_forward_mobile(con_mesh):
         vert.add_out('vec3 wnormal')
         make_attrib.write_norpos(con_mesh, vert)
         frag.write_attrib('vec3 n = normalize(wnormal);')
+
+    if mat_state.material.arm_two_sided:
+        frag.write('if (!gl_FrontFacing) n *= -1;')  # Flip normal when drawing back-face
 
     make_attrib.write_vertpos(vert)
 


### PR DESCRIPTION
Forward render paths (the "regular" one and mobile) didn't correctly handle two-sided materials. This also caused problems in projects using the deferred RP because translucent materials use forward rendering.

Thanks to @ BrahRah on Discord for the [report](https://discord.com/channels/486771218599510021/487613529990365184/1174777894631911535)!

Before (screenshot by @ BrahRah):
![Screenshot_2023-11-16_192723](https://github.com/armory3d/armory/assets/17685000/916ac113-31c0-434c-bea9-1a291933699e)

After:
![grafik](https://github.com/armory3d/armory/assets/17685000/0da2195c-0f78-4d64-97dd-ae0465069176)

 