### PR TITLE
Fix INF values in cloud shader (causing bloom flickering)

### DIFF
--- a/blender/arm/make_world.py
+++ b/blender/arm/make_world.py
@@ -311,6 +311,7 @@ def frag_write_clouds(world: bpy.types.World, frag: Shader):
     frag.add_const('float', 'cloudsSteps', str(round(world.arm_clouds_steps * 100) / 100))
 
     frag.add_function('''float remap(float old_val, float old_min, float old_max, float new_min, float new_max) {
+\tif (old_max == old_min) return 0.0;
 \treturn new_min + (((old_val - old_min) / (old_max - old_min)) * (new_max - new_min));
 }''')
 


### PR DESCRIPTION
This PR fixes a potential division by zero in the clouds shader code, which would result in INF/NaN values that in turn would cause white screen flickers when bloom was enabled.

I don't really like this solution because it is just a symptomatic fix (that probably causes branching) to make things work again. The actual problem is the code responsible for weather "dilation" which, if the cloud coverage goes to zero, approaches a dirac delta. Unfortunately, the papers and other sources I can find on this topic all skip over this little detail as if this wasn't a problem for them.

I experimented with other ways of simulating cloud coverage, and while the results looked at least acceptable, they were pretty different so I didn't think they were a good replacement for the current look. I also experimented with a gradual fade-out for very small clouds (= approaching the dirac delta) which I guess is a good solution, but I wasn't sure whether 0 * INF is defined to be always 0 or whether this is undefined behaviour. I will continue experimenting when I get some more time, but for now this fix will at least prevent the flickering :)

Thanks to Discord user @ Vlamso for the [report](https://discord.com/channels/486771218599510021/487613529990365184/1195330060425646110).