### PR TITLE
Ssgi

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -295,11 +295,11 @@ void main() {
 	fragColor.rgb = envl;
 
 #ifdef _SSAO
-	// #ifdef _RTGI
-	// fragColor.rgb *= textureLod(ssaotex, texCoord, 0.0).rgb;
-	// #else
+	#ifdef _RTGI
+	fragColor.rgb *= textureLod(ssaotex, texCoord, 0.0).rgb;
+	#else
 	fragColor.rgb *= textureLod(ssaotex, texCoord, 0.0).r;
-	// #endif
+	#endif
 #endif
 
 #ifdef _EmissionShadeless

--- a/Shaders/ssgi_blur_pass/ssgi_blur_pass.frag.glsl
+++ b/Shaders/ssgi_blur_pass/ssgi_blur_pass.frag.glsl
@@ -9,7 +9,7 @@ uniform sampler2D gbuffer0;
 uniform vec2 dirInv; // texStep
 
 in vec2 texCoord;
-out float fragColor;
+out vec4 fragColor;
 
 const float blurWeights[5] = float[] (0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
 // const float blurWeights[10] = float[] (0.132572, 0.125472, 0.106373, 0.08078, 0.05495, 0.033482, 0.018275, 0.008934, 0.003912, 0.001535);
@@ -18,29 +18,37 @@ const float discardThreshold = 0.95;
 float doBlur(const float blurWeight, const int pos, const vec3 nor, const vec2 texCoord) {
 	const float posadd = pos + 0.5;
 
-	vec3 nor2 = getNor(textureLod(gbuffer0, texCoord + pos * dirInv, 0.0).rg);
+	vec3 nor2 = getNor(texture(gbuffer0, texCoord + pos * dirInv).rg);
 	float influenceFactor = step(discardThreshold, dot(nor2, nor));
-	float col = textureLod(tex, texCoord + posadd * dirInv, 0.0).r;
+	vec4 col = texture(tex, texCoord + posadd * dirInv);
 	fragColor += col * blurWeight * influenceFactor;
 	float weight = blurWeight * influenceFactor;
-	
-	nor2 = getNor(textureLod(gbuffer0, texCoord - pos * dirInv, 0.0).rg);
+
+	nor2 = getNor(texture(gbuffer0, texCoord - pos * dirInv).rg);
 	influenceFactor = step(discardThreshold, dot(nor2, nor));
-	col = textureLod(tex, texCoord - posadd * dirInv, 0.0).r;
+	col = texture(tex, texCoord - posadd * dirInv);
 	fragColor += col * blurWeight * influenceFactor;
 	weight += blurWeight * influenceFactor;
-	
+
 	return weight;
 }
 
 void main() {
-	vec3 nor = getNor(textureLod(gbuffer0, texCoord, 0.0).rg);
-	
-	fragColor = textureLod(tex, texCoord, 0.0).r * blurWeights[0];
-	float weight = blurWeights[0];
-	for (int i = 1; i < 5; i++) {
-		weight += doBlur(blurWeights[i], i, nor, texCoord);
-	}
+	vec3 nor = getNor(texture(gbuffer0, texCoord).rg);
 
-	fragColor = fragColor / weight;
+	fragColor = texture(tex, texCoord) * blurWeights[0];
+	float weight = blurWeights[0];
+	// for (int i = 1; i < 10; i++) {
+		weight += doBlur(blurWeights[1], 1, nor, texCoord);
+		weight += doBlur(blurWeights[2], 2, nor, texCoord);
+		weight += doBlur(blurWeights[3], 3, nor, texCoord);
+		weight += doBlur(blurWeights[4], 4, nor, texCoord);
+		// weight += doBlur(blurWeights[5], 5, nor, texCoord);
+		// weight += doBlur(blurWeights[6], 6, nor, texCoord);
+		// weight += doBlur(blurWeights[7], 7, nor, texCoord);
+		// weight += doBlur(blurWeights[8], 8, nor, texCoord);
+		// weight += doBlur(blurWeights[9], 9, nor, texCoord);
+	// }
+
+	fragColor = vec4(fragColor / weight);
 }

--- a/Shaders/ssgi_blur_pass/ssgi_blur_pass.json
+++ b/Shaders/ssgi_blur_pass/ssgi_blur_pass.json
@@ -2,6 +2,7 @@
 	"contexts": [
 		{
 			"name": "ssgi_blur_pass_x",
+			"color_write_alpha": false,
 			"depth_write": false,
 			"compare_mode": "always",
 			"cull_mode": "none",
@@ -17,6 +18,7 @@
 		},
 		{
 			"name": "ssgi_blur_pass_y",
+			"color_write_alpha": false,
 			"depth_write": false,
 			"compare_mode": "always",
 			"cull_mode": "none",
@@ -32,6 +34,7 @@
 		},
 		{
 			"name": "ssgi_blur_pass_y_blend",
+			"color_write_alpha": false,
 			"depth_write": false,
 			"compare_mode": "always",
 			"cull_mode": "none",
@@ -51,6 +54,7 @@
 
 		{
 			"name": "ssgi_blur_pass_y_blend_add",
+			"color_write_alpha": false,
 			"depth_write": false,
 			"compare_mode": "always",
 			"cull_mode": "none",

--- a/Shaders/ssgi_pass/ssgi_pass.frag.glsl
+++ b/Shaders/ssgi_pass/ssgi_pass.frag.glsl
@@ -59,6 +59,7 @@ float getDeltaDepth(vec3 hitCoord) {
 	return p.z - hitCoord.z;
 }
 
+#ifdef _RTGI
 vec2 binarySearch(vec3 dir) {
 	float ddepth;
 	for (int i = 0; i < numBinarySearchSteps; i++) {
@@ -70,6 +71,7 @@ vec2 binarySearch(vec3 dir) {
 	if (abs(ddepth) > 1.0) return vec2(-1.0);
 	return getProjectedCoord(hitCoord);
 }
+#endif
 
 void rayCast(vec3 dir) {
 	coord = vec2(-1.0);
@@ -81,7 +83,9 @@ void rayCast(vec3 dir) {
 		float delta = getDeltaDepth(hitCoord);
 		if (delta > 0.0 && delta < 1.0) {
 			dist = distance(vpos, hitCoord);
+			#ifdef _RTGI
 			coord = binarySearch(dir);
+			#endif
 			break;
 		}
 	}

--- a/Shaders/ssgi_pass/ssgi_pass.frag.glsl
+++ b/Shaders/ssgi_pass/ssgi_pass.frag.glsl
@@ -32,7 +32,7 @@ out float fragColor;
 #endif
 
 vec3 hitCoord;
-vec2 coord;
+vec2 coord = vec2(0.0);
 float depth;
 #ifdef _RTGI
 vec3 col = vec3(0.0);
@@ -40,6 +40,8 @@ vec3 col = vec3(0.0);
 float col = 0.0;
 #endif
 vec3 vpos;
+
+int rays = 0;
 
 vec2 getProjectedCoord(vec3 hitCoord) {
 	vec4 projectedCoord = P * vec4(hitCoord, 1.0);
@@ -58,18 +60,6 @@ float getDeltaDepth(vec3 hitCoord) {
 	return p.z - hitCoord.z;
 }
 
-vec2 binarySearch(vec3 dir) {
-	float ddepth;
-	for (int i = 0; i < 7; i++) {
-		dir *= 0.5;
-		hitCoord -= dir;
-		ddepth = getDeltaDepth(hitCoord);
-		if (ddepth < 0.0) hitCoord += dir;
-	}
-	if (abs(ddepth) > 1.0) return vec2(0.0);
-	return getProjectedCoord(hitCoord);
-}
-
 void rayCast(vec3 dir) {
 	hitCoord = vpos;
 	dir *= ssgiRayStep;
@@ -83,8 +73,8 @@ void rayCast(vec3 dir) {
 		}
 	}
 	#ifdef _RTGI
-	if (dist > 0.0 && dist < 1.0) {
-		//coord = binarySearch(dir);
+	if (dist < 1.0) // ray has hit
+	{
 		col += textureLod(gbuffer1, coord, 0.0).rgb * dist;
 	}
 	else col += 1.0;

--- a/Shaders/ssr_pass/ssr_pass.frag.glsl
+++ b/Shaders/ssr_pass/ssr_pass.frag.glsl
@@ -52,11 +52,10 @@ vec4 binarySearch(vec3 dir) {
 		ddepth = getDeltaDepth(hitCoord);
 		if (ddepth < 0.0) hitCoord += dir;
 	}
-	// Ugly discard of hits too far away
 	#ifdef _CPostprocess
-		if (abs(ddepth) > PPComp9.z / 500) return vec4(0.0);
+		if (abs(ddepth) > 1.0) return vec4(0.0);
 	#else
-		if (abs(ddepth) > ssrSearchDist / 500) return vec4(0.0);
+		if (abs(ddepth) > 1.0) return vec4(0.0);
 	#endif
 	return vec4(getProjectedCoord(hitCoord), 0.0, 1.0);
 }

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -282,9 +282,13 @@ def build():
             if rpdat.rp_ssgi == 'SSAO':
                 assets.add_shader_pass('ssao_pass')
                 assets.add_shader_pass('blur_edge_pass')
-            else:
-                assets.add_shader_pass('ssgi_pass')
+            elif rpdat.rp_ssgi == 'RTAO':
                 assets.add_shader_pass('blur_edge_pass')
+                assets.add_shader_pass('ssgi_pass')
+            else:
+                assets.add_shader_pass('ssgi_blur_pass')
+                assets.add_shader_pass('ssgi_pass')
+
             if rpdat.arm_ssgi_half_res:
                 assets.add_khafile_def('rp_ssgi_half')
 

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -530,9 +530,9 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_water_reflect: FloatProperty(name="Reflect", default=1.0, update=assets.invalidate_shader_cache)
     arm_ssgi_strength: FloatProperty(name="Strength", default=1.0, update=assets.invalidate_shader_cache)
     arm_ssgi_radius: FloatProperty(name="Radius", default=1.0, update=assets.invalidate_shader_cache)
-    arm_ssgi_step: FloatProperty(name="Step", default=0.01, update=assets.invalidate_shader_cache)
-    arm_ssgi_max_steps: IntProperty(name="Max Steps", default=8, update=assets.invalidate_shader_cache)
-    arm_ssgi_search_dist: FloatProperty(name="Search distance", default=5.0, update=assets.invalidate_shader_cache)
+    arm_ssgi_step: FloatProperty(name="Step", default=0.03, update=assets.invalidate_shader_cache)
+    #arm_ssgi_max_steps: IntProperty(name="Max Steps", default=8, update=assets.invalidate_shader_cache)
+    arm_ssgi_search_dist: FloatProperty(name="Search distance", default=1.0, update=assets.invalidate_shader_cache)
     arm_ssgi_rays: EnumProperty(
         items=[('9', '9', '9'),
                ('5', '5', '5'),

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -384,8 +384,8 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     rp_ssgi: EnumProperty(
         items=[('Off', 'No AO', 'Off'),
                ('SSAO', 'SSAO', 'Screen space ambient occlusion'),
-               ('RTAO', 'RTAO', 'Ray-traced ambient occlusion')
-               # ('RTGI', 'RTGI', 'Ray-traced global illumination')
+               ('RTAO', 'RTAO', 'Ray-traced ambient occlusion'),
+               ('RTGI', 'RTGI', 'Ray-traced global illumination')
                ],
         name="SSGI", description="Screen space global illumination", default='SSAO', update=update_renderpath)
     rp_bloom: BoolProperty(name="Bloom", description="Bloom processing", default=False, update=update_renderpath)
@@ -530,7 +530,7 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_water_reflect: FloatProperty(name="Reflect", default=1.0, update=assets.invalidate_shader_cache)
     arm_ssgi_strength: FloatProperty(name="Strength", default=1.0, update=assets.invalidate_shader_cache)
     arm_ssgi_radius: FloatProperty(name="Radius", default=1.0, update=assets.invalidate_shader_cache)
-    arm_ssgi_step: FloatProperty(name="Step", default=2.0, update=assets.invalidate_shader_cache)
+    arm_ssgi_step: FloatProperty(name="Step", default=0.01, update=assets.invalidate_shader_cache)
     arm_ssgi_max_steps: IntProperty(name="Max Steps", default=8, update=assets.invalidate_shader_cache)
     arm_ssgi_rays: EnumProperty(
         items=[('9', '9', '9'),

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -532,6 +532,7 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_ssgi_radius: FloatProperty(name="Radius", default=1.0, update=assets.invalidate_shader_cache)
     arm_ssgi_step: FloatProperty(name="Step", default=0.01, update=assets.invalidate_shader_cache)
     arm_ssgi_max_steps: IntProperty(name="Max Steps", default=8, update=assets.invalidate_shader_cache)
+    arm_ssgi_search_dist: FloatProperty(name="Search distance", default=5.0, update=assets.invalidate_shader_cache)
     arm_ssgi_rays: EnumProperty(
         items=[('9', '9', '9'),
                ('5', '5', '5'),

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1816,7 +1816,8 @@ class ARM_PT_RenderPathPostProcessPanel(bpy.types.Panel):
         sub.prop(rpdat, 'arm_ssgi_radius')
         sub.prop(rpdat, 'arm_ssgi_strength')
         sub.prop(rpdat, 'arm_ssgi_step')
-        sub.prop(rpdat, 'arm_ssgi_max_steps')
+        #sub.prop(rpdat, 'arm_ssgi_max_steps')
+        sub.prop(rpdat, 'arm_ssgi_search_dist')
         layout.separator()
 
         row = layout.row()

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1815,6 +1815,7 @@ class ARM_PT_RenderPathPostProcessPanel(bpy.types.Panel):
         sub.prop(rpdat, 'arm_ssgi_rays')
         sub.prop(rpdat, 'arm_ssgi_radius')
         sub.prop(rpdat, 'arm_ssgi_strength')
+        sub.prop(rpdat, 'arm_ssgi_step')
         sub.prop(rpdat, 'arm_ssgi_max_steps')
         layout.separator()
 

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -632,7 +632,7 @@ const float ssaoScale = """ + ("2.0" if rpdat.arm_ssgi_half_res else "20.0") + "
         if rpdat.rp_ssgi == 'RTGI' or rpdat.rp_ssgi == 'RTAO':
             f.write(
 """const int ssgiMaxSteps = """ + str(rpdat.arm_ssgi_max_steps) + """;
-const float ssgiRayStep = 0.005 * """ + str(round(rpdat.arm_ssgi_step * 100) / 100) + """;
+const float ssgiRayStep = """ + str(round(rpdat.arm_ssgi_step * 100) / 100) + """;
 const float ssgiStrength = """ + str(round(rpdat.arm_ssgi_strength * 100) / 100) + """;
 """)
 

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -630,10 +630,9 @@ const float ssaoScale = """ + ("2.0" if rpdat.arm_ssgi_half_res else "20.0") + "
 """)
 
         if rpdat.rp_ssgi == 'RTGI' or rpdat.rp_ssgi == 'RTAO':
-#const int ssgiMaxSteps = """ + str(rpdat.arm_ssgi_max_steps) + """;
             f.write("""
 const float ssgiSearchDist = """ + str(rpdat.arm_ssgi_search_dist) + """;
-const float ssgiRayStep = """ + str(round(rpdat.arm_ssgi_step * 1000) / 1000) + """;
+const float ssgiRayStep = """ + str(round(rpdat.arm_ssgi_step * 100) / 100) + """;
 const float ssgiStrength = """ + str(round(rpdat.arm_ssgi_strength * 100) / 100) + """;
 """)
 

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -630,9 +630,10 @@ const float ssaoScale = """ + ("2.0" if rpdat.arm_ssgi_half_res else "20.0") + "
 """)
 
         if rpdat.rp_ssgi == 'RTGI' or rpdat.rp_ssgi == 'RTAO':
-            f.write(
-"""const int ssgiMaxSteps = """ + str(rpdat.arm_ssgi_max_steps) + """;
-const float ssgiRayStep = """ + str(round(rpdat.arm_ssgi_step * 100) / 100) + """;
+#const int ssgiMaxSteps = """ + str(rpdat.arm_ssgi_max_steps) + """;
+            f.write("""
+const float ssgiSearchDist = """ + str(rpdat.arm_ssgi_search_dist) + """;
+const float ssgiRayStep = """ + str(round(rpdat.arm_ssgi_step * 1000) / 1000) + """;
 const float ssgiStrength = """ + str(round(rpdat.arm_ssgi_strength * 100) / 100) + """;
 """)
 


### PR DESCRIPTION
This pull request introduces changes to the rtao shader and reimplements rtgi from version 19.02.
Changes are:
- no tweak to ssgiRayStep value
- base distance factor of 1.0
- maxSteps option is remove in favor of step & search dist which are used to compute the maxStep like in ssr.
- no changes are made to fragColor during rayCasting, we store the final value in a variable and will afterward assign to fragColor and divide / multiply according to the number of cones.
- rtgi uses another blur shader because the rtao / ssao one just work on one channel (I retrieved the old code's shader).
- rtgi uses it's own render target (RGBA32).