### PR TITLE
Make VISUAL NODES API same as HAXE API --> Static methods on nodes so that nodes API can be used in HAXE

### DIFF
--- a/Sources/armory/logicnode/GetLocationNode.hx
+++ b/Sources/armory/logicnode/GetLocationNode.hx
@@ -12,20 +12,26 @@ class GetLocationNode extends LogicNode {
 		var object: Object = inputs[0].get();
 		var relative: Bool = inputs[1].get();
 
+		return GetObjectLocation(  object, relative );
+	}
+
+	//STATIC CLASS
+	public static function GetObjectLocation(  object : Object, relative : Bool  ) {
+	
 		if (object == null) return null;
-
+	
 		var loc = object.transform.world.getLoc();
-
+	
 		if (relative && object.parent != null) {
 			loc.sub(object.parent.transform.world.getLoc()); // Add parent location influence
-
+	
 			// Convert loc to parent local space
-			var dotX = loc.dot(object.parent.transform.right());
-			var dotY = loc.dot(object.parent.transform.look());
-			var dotZ = loc.dot(object.parent.transform.up());
+			var dotX:Float = loc.dot(object.parent.transform.right());
+			var dotY:Float = loc.dot(object.parent.transform.look());
+			var dotZ:Float = loc.dot(object.parent.transform.up());
 			loc.set(dotX, dotY, dotZ);
 		}
-
+	
 		return loc;
 	}
 }


### PR DESCRIPTION
# The idea of this is to self-document the HAXE API with the nodes API, this way it is simpler to use the Armory functionalities within Haxe.

![Captura_de_pantalla_2024-02-13_103613](https://github.com/armory3d/armory/assets/12847027/42e4f5e2-9a2a-42b0-93b8-1fbdd42e364e)
![Captura de pantalla 2024-02-14 083151](https://github.com/armory3d/armory/assets/12847027/5f915d3c-7fd6-4547-beb3-6807cbc6882d)

## It is 100% possible to do this with all nodes
works correctly on linux and windows.

https://github.com/armory3d/armory/assets/12847027/46dae46a-6d49-46b3-8c52-820f2faefed0


You have to tell me if you want or don't want to implement it... if you want I can contribute with this.


discussion on discord
[https://discord.com/channels/486771218599510021/1206956471364100168](url)