### PR TITLE
Fix forward clusters

### DIFF
--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -53,7 +53,7 @@
 			uniform sampler2DShadow shadowMapAtlasSpot;
 			#endif
 			#else
-			uniform sampler2DShadow shadowMapSpot[maxLightsCluster];
+			uniform sampler2DShadow shadowMapSpot[4];
 			#endif
 			uniform mat4 LWVPSpotArray[maxLightsCluster];
 		#endif

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -78,8 +78,8 @@ def write(vert: shader.Shader, frag: shader.Shader):
     if '_Spot' in wrd.world_defs:
         frag.write('\t, lightsArray[li * 3 + 2].y != 0.0')
         frag.write('\t, lightsArray[li * 3 + 2].y') # spot size (cutoff)
-        frag.write('\t, lightsArraySpot[li].w') # spot blend (exponent)
-        frag.write('\t, lightsArraySpot[li].xyz') # spotDir
+        frag.write('\t, lightsArraySpot[li * 2].w') # spot blend (exponent)
+        frag.write('\t, lightsArraySpot[li * 2].xyz') # spotDir
         frag.write('\t, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w)') # scale
         frag.write('\t, lightsArraySpot[li * 2 + 1].xyz') # right
     if '_VoxelShadow' in wrd.world_defs and '_VoxelAOvar' in wrd.world_defs:

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -57,8 +57,7 @@ def write(vert: shader.Shader, frag: shader.Shader):
                     frag.add_uniform('sampler2DShadow shadowMapAtlas', top=True)
             else:
                 frag.add_uniform('sampler2DShadow shadowMapSpot[4]', included=True)
-            # FIXME: type is actually mat4, but otherwise it will not be set as floats when writing the shaders' json files
-            frag.add_uniform('vec4 LWVPSpotArray[maxLightsCluster]', link='_biasLightWorldViewProjectionMatrixSpotArray', included=True)
+            frag.add_uniform('mat4 LWVPSpotArray[maxLightsCluster]', link='_biasLightWorldViewProjectionMatrixSpotArray', included=True)
 
     frag.write('for (int i = 0; i < min(numLights, maxLightsCluster); i++) {')
     frag.write('int li = int(texelFetch(clustersData, ivec2(clusterI, i + 1), 0).r * 255);')

--- a/blender/arm/material/shader.py
+++ b/blender/arm/material/shader.py
@@ -284,6 +284,9 @@ class Shader:
             elif ar[0] == 'vec4' and '[' in ar[1]:
                 ar[0] = 'floats'
                 ar[1] = ar[1].split('[', 1)[0]
+            elif ar[0] == 'mat4' and '[' in ar[1]:
+                ar[0] = 'floats'
+                ar[1] = ar[1].split('[', 1)[0]
             self.context.add_constant(ar[0], ar[1], link=link, default_value=default_value, is_arm_mat_param=is_arm_mat_param)
         if top:
             if not included and s not in self.uniforms_top:


### PR DESCRIPTION
There was some multiplication vector that you forgot to add to forward make_clusters.py
This breaks the clusters in forward, this pull request fixes it.
I also made the spotclusters array a mat4 since that's what it it. Just adding a clause in shaders.py allows it.