### PR TITLE
Refactor HTTP Request Node

### DIFF
--- a/Sources/armory/logicnode/NetworkHttpRequestNode.hx
+++ b/Sources/armory/logicnode/NetworkHttpRequestNode.hx
@@ -3,103 +3,103 @@ import iron.object.Object;
 
 
 class NetworkHttpRequestNode extends LogicNode {
-    public var property0: String;
-    public var callbackType: Int;
-    public var statusInt: Int;
-    public var response: Dynamic;
-    public var errorOut: String;
-    public var headers: Map<String,String>;
-    public var parameters: Map<String,String>;
+	public var property0: String;
+	public var callbackType: Int;
+	public var statusInt: Int;
+	public var response: Dynamic;
+	public var errorOut: String;
+	public var headers: Map<String,String>;
+	public var parameters: Map<String,String>;
 
-    public function new(tree:LogicTree) {
-        super(tree);
-    }
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
 
-    override function run(from:Int) {
+	override function run(from:Int) {
 
-        var url = inputs[1].get();
+		var url = inputs[1].get();
 
-        if(url == null){return;}
+		if(url == null){return;}
 
-        headers = inputs[2].get();
-        parameters = inputs[3].get();
-        var printErrors: Bool = inputs[4].get();
+		headers = inputs[2].get();
+		parameters = inputs[3].get();
+		var printErrors: Bool = inputs[4].get();
 
-        var request = new haxe.Http(url);
+		var request = new haxe.Http(url);
 		#if js
-        request.async = true;
+		request.async = true;
 		#end
-        if(headers != null){
-            for (k in headers.keys()) {
-                request.addHeader( k, headers[k]);
-            }
-        }
-        if(parameters != null){
-            for (k in parameters.keys()) {
-                request.addParameter( k, parameters[k]);
-            }
-        }
+		if(headers != null){
+			for (k in headers.keys()) {
+				request.addHeader( k, headers[k]);
+			}
+		}
+		if(parameters != null){
+			for (k in parameters.keys()) {
+				request.addParameter( k, parameters[k]);
+			}
+		}
 
-        request.onStatus = function(status:Int) { 
-            callbackType = 1;
-            statusInt = status;
-            runOutput(0);
-        }
+		request.onStatus = function(status:Int) { 
+			callbackType = 1;
+			statusInt = status;
+			runOutput(0);
+		}
 
-        request.onBytes = function(data:haxe.io.Bytes) {
-            callbackType = 2;
-            response = data;
-            runOutput(0);
-        }
+		request.onBytes = function(data:haxe.io.Bytes) {
+			callbackType = 2;
+			response = data;
+			runOutput(0);
+		}
 
-        request.onData = function(data:String) {
-            callbackType = 3;
-            response = data;
-            runOutput(0);
-        }
+		request.onData = function(data:String) {
+			callbackType = 3;
+			response = data;
+			runOutput(0);
+		}
 
-        request.onError = function(error:String){ 
-            callbackType = 4;
-            errorOut = error;
-            if(printErrors) {
-                trace ("Error: " + error );
-            }
-            runOutput(0);
-        }
-        
-        try {
-            if(property0 == "post") {
-                var bytes = inputs[6].get();
-                if(bytes == true){
-                    var data:haxe.io.Bytes = inputs[5].get();
-                    request.setPostBytes(data);
-                    request.request(true);
-                }else{
-                    var data:Dynamic = inputs[5].get();
-                    request.setPostData(data.toString());
-                    request.request(true);
-                }
-            } else {
-                request.request(false);
-            }
-        } catch( e : Dynamic ) {
-            trace("Could not complete request: " + e);
-        }
+		request.onError = function(error:String){ 
+			callbackType = 4;
+			errorOut = error;
+			if(printErrors) {
+				trace ("Error: " + error );
+			}
+			runOutput(0);
+		}
 
-        callbackType = 0;
-        runOutput(0);
+		try {
+			if(property0 == "post") {
+				var bytes = inputs[6].get();
+				if(bytes == true){
+					var data:haxe.io.Bytes = inputs[5].get();
+					request.setPostBytes(data);
+					request.request(true);
+				}else{
+					var data:Dynamic = inputs[5].get();
+					request.setPostData(data.toString());
+					request.request(true);
+				}
+			} else {
+				request.request(false);
+			}
+		} catch( e : Dynamic ) {
+			trace("Could not complete request: " + e);
+		}
 
-    }
+		callbackType = 0;
+		runOutput(0);
 
-    override function get(from: Int): Dynamic {
+	}
 
-        return switch (from) {
-            case 1: callbackType;
-            case 2: statusInt;
-            case 3: response;
-            case 4: errorOut;
-            default: throw "Unreachable";
-        }
+	override function get(from: Int): Dynamic {
 
-    }
+		return switch (from) {
+			case 1: callbackType;
+			case 2: statusInt;
+			case 3: response;
+			case 4: errorOut;
+			default: throw "Unreachable";
+		}
+
+	}
 }

--- a/Sources/armory/logicnode/NetworkHttpRequestNode.hx
+++ b/Sources/armory/logicnode/NetworkHttpRequestNode.hx
@@ -63,13 +63,13 @@ class NetworkHttpRequestNode extends LogicNode {
         
         try {
             if(property0 == "post") {
-                var bytes = inputs[2].get();
+                var bytes = inputs[3].get();
                 if(bytes == true){
-                    var data:haxe.io.Bytes = inputs[3].get();
+                    var data:haxe.io.Bytes = inputs[2].get();
                     request.setPostBytes(data);
                     request.request(true);
                 }else{
-                    var data:Dynamic = inputs[3].get();
+                    var data:Dynamic = inputs[2].get();
                     request.setPostData(data.toString());
                     request.request(true);
                 }

--- a/blender/arm/logicnode/network/LN_network_http_request.py
+++ b/blender/arm/logicnode/network/LN_network_http_request.py
@@ -2,10 +2,47 @@ from arm.logicnode.arm_nodes import *
 
 
 class NetworkHttpRequestNode(ArmLogicTreeNode):
-    """Network Http Request"""
+    """Network HTTP Request.
+
+    @option Get/ Post: Use HTTP GET or POST methods.
+
+    @input In: Action input.
+
+    @input Url: Url as string.
+
+    @input Headers: Headers as a Haxe map.
+
+    @input Parameters: Parameters for the request as Haxe map.
+
+    @seeNode Create Map
+
+    @input Print Error: Print Error in console.
+
+    @input Data: Data to send. Any type.
+
+    @input Bytes: Is the data sent as bytes or as a string.
+
+    @output Out: Multi-functional output. Type of output given by `Callback Type`.
+
+    @output Callback Type: Type of output.
+    0 = Node Executed
+    1 = Status Callback
+    2 = Bytes Data Response Callback
+    3 = String Data Response Callback
+    4 = Error String Callback
+
+    @utput Status: Status value
+
+    @utput Response: Response value
+
+    @output Error: Error
+    """
+
     bl_idname = 'LNNetworkHttpRequestNode'
     bl_label = 'Http Request'
-    arm_version = 1
+    arm_version = 2
+
+    default_inputs_count = 5
 
 
     @staticmethod
@@ -26,32 +63,19 @@ class NetworkHttpRequestNode(ArmLogicTreeNode):
         select_current = self.get_enum_id_value(self, 'property0', value)
         select_prev = self.property0
 
-        if select_prev != select_current:
-
-            for i in self.inputs:
-                self.inputs.remove(i)
-            for i in self.outputs:
-                self.outputs.remove(i)
+        if select_prev == select_current:
+            return
 
         if (self.get_count_in(select_current) == 0):
-            self.add_input('ArmNodeSocketAction', 'In')
-            self.add_input('ArmStringSocket', 'Url')
-            self.add_input('ArmDynamicSocket', 'Headers')
-            self.add_input('ArmDynamicSocket', 'Parameters')
-            self.add_output('ArmNodeSocketAction', 'Out')
-            self.add_output('ArmIntSocket', 'Status')
-            self.add_output('ArmDynamicSocket', 'Response')
+            idx = 0
+            for inp in self.inputs:
+                if idx >= self.default_inputs_count:
+                    self.inputs.remove(inp)
+                idx += 1
             self['property0'] = value
         else:
-            self.add_input('ArmNodeSocketAction', 'In')
-            self.add_input('ArmStringSocket', 'Url')
             self.add_input('ArmDynamicSocket', 'Data')
             self.add_input('ArmBoolSocket', 'Bytes')
-            self.add_input('ArmDynamicSocket', 'Headers')
-            self.add_input('ArmDynamicSocket', 'Parameters')
-            self.add_output('ArmNodeSocketAction', 'Out')
-            self.add_output('ArmIntSocket', 'Status')
-            self.add_output('ArmDynamicSocket', 'Response')
             self['property0'] = value
  
 
@@ -69,10 +93,22 @@ class NetworkHttpRequestNode(ArmLogicTreeNode):
         self.add_input('ArmStringSocket', 'Url')
         self.add_input('ArmDynamicSocket', 'Headers')
         self.add_input('ArmDynamicSocket', 'Parameters')
+        self.add_input('ArmBoolSocket', 'Print Error')
 
         self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('ArmIntSocket', 'Callback Type')
         self.add_output('ArmIntSocket', 'Status')
         self.add_output('ArmDynamicSocket', 'Response')
+        self.add_output('ArmStringSocket', 'Error')
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'property0')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement(
+            'LNNetworkHttpRequestNode', self.arm_version, 'LNNetworkHttpRequestNode', 2,
+            in_socket_mapping = {0:0, 1:1}, out_socket_mapping={0:0}
+        )


### PR DESCRIPTION
This PR refactors HTTP Request node. Fixes some incorrect indices used and exposes more options. Also introduced a `Callback Type` output indicating the type of callback at the `Out` output.

```
Callback Type: Type of output.
    0 = Node Executed
    1 = Status Callback
    2 = Bytes Data Response Callback
    3 = String Data Response Callback
    4 = Error String Callback
```

Node now looks like:
![image](https://github.com/armory3d/armory/assets/55564981/cd47d95b-6853-4882-a43b-a56273ea133b)

**Usage**: May be used with `Select Output` Node to perform actions depending on callback type.

![image](https://github.com/armory3d/armory/assets/55564981/0dd867c4-f1af-4cb4-920f-bac010664114)


