### PR TITLE
SSS fixes

### DIFF
--- a/Shaders/custom_mat_presets/custom_mat_deferred.frag.glsl
+++ b/Shaders/custom_mat_presets/custom_mat_deferred.frag.glsl
@@ -42,6 +42,10 @@ void main() {
 	vec3 emissionCol = vec3(0.0);
 	float ior = 1.450;
 	float opacity = 1.0;
+	vec3 subsurfaceCol = vec3(0.0);
+	vec3 subsurfaceWeights = vec3(0.0);
+	float subsurfaceIor = 1.45;
+	float subsurfaceScale = 0.0;
 
 	// Store in gbuffer (see layout table above)
 	fragColor[GBUF_IDX_0] = vec4(n.xy, roughness, packFloatInt16(metallic, materialId));
@@ -54,4 +58,9 @@ void main() {
 	#ifdef _SSRefraction
 		fragColor[GBUF_IDX_REFRACTION] = vec4(ior, opacity, 0.0, 0.0);
 	#endif
+
+	#ifdef _SSS
+		fragColor[GBUF_IDX_SUBSURFACE_1] = vec4(subsurfaceCol, 1.0);
+		fragColor[GBUF_IDX_SUBSURFACE_2] = vec4(subsurfaceWeights, packFloat2(subsurfaceIor, subsurfaceScale));
+	#end
 }

--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -444,13 +444,10 @@ void main() {
 		#ifdef _SSRS
 		, gbufferD, invVP, eye
 		#endif
+		#ifdef _SSS
+		, matid, lightPlane
+		#endif
 	);
-
-	#ifdef _Spot
-	#ifdef _SSS
-	if (matid == 2) fragColor.rgb += fragColor.rgb * SSSSTransmittance(LWVPSpot0, p, n, normalize(pointPos - p), lightPlane.y, shadowMapSpot[0]);
-	#endif
-	#endif
 
 #endif
 
@@ -503,6 +500,9 @@ void main() {
 			#endif
 			#ifdef _SSRS
 			, gbufferD, invVP, eye
+			#endif
+			#ifdef _SSS
+			, matid, lightPlane
 			#endif
 		);
 	}

--- a/Shaders/deferred_light/deferred_light.json
+++ b/Shaders/deferred_light/deferred_light.json
@@ -12,11 +12,6 @@
 					"link": "_cameraPosition"
 				},
 				{
-					"name": "voxelBlend",
-					"link": "_voxelBlend",
-					"ifdef": ["_VoxelTemporal"]
-				},
-				{
 					"name": "eyeLook",
 					"link": "_cameraLook"
 				},

--- a/Shaders/ssrefr_pass/ssrefr_pass.frag.glsl
+++ b/Shaders/ssrefr_pass/ssrefr_pass.frag.glsl
@@ -6,8 +6,8 @@
 
 uniform sampler2D tex;
 uniform sampler2D tex1;
-uniform sampler2D gbufferD;
 uniform sampler2D gbuffer0;
+uniform sampler2D gbufferD;
 uniform sampler2D gbufferD1;
 uniform sampler2D gbuffer_refraction; // ior\opacity
 uniform mat4 P;

--- a/Shaders/sss_pass/sss_pass.frag.glsl
+++ b/Shaders/sss_pass/sss_pass.frag.glsl
@@ -1,45 +1,14 @@
-//
-// Copyright (C) 2012 Jorge Jimenez (jorge@iryoku.com)
-// Copyright (C) 2012 Diego Gutierrez (diegog@unizar.es)
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-// 
-//    1. Redistributions of source code must retain the above copyright notice,
-//       this list of conditions and the following disclaimer.
-//
-//    2. Redistributions in binary form must reproduce the following disclaimer
-//       in the documentation and/or other materials provided with the 
-//       distribution:
-//
-//       "Uses Separable SSS. Copyright (C) 2012 by Jorge Jimenez and Diego
-//        Gutierrez."
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS 
-// IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
-// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS OR CONTRIBUTORS 
-// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
-// POSSIBILITY OF SUCH DAMAGE.
-//
-// The views and conclusions contained in the software and documentation are 
-// those of the authors and should not be interpreted as representing official
-// policies, either expressed or implied, of the copyright holders.
-//
-
 #version 450
 
 #include "compiled.inc"
+#include "std/gbuffer.glsl"
 
 uniform sampler2D gbufferD;
 uniform sampler2D gbuffer0;
 uniform sampler2D tex;
+uniform sampler2D gbuffer_refraction;
+uniform sampler2D gbuffer_subsurface_1;
+uniform sampler2D gbuffer_subsurface_2;
 
 uniform vec2 dir;
 uniform vec2 cameraProj;
@@ -47,72 +16,77 @@ uniform vec2 cameraProj;
 in vec2 texCoord;
 out vec4 fragColor;
 
-const float SSSS_FOVY = 45.0;
+// Gaussian function for blur weights
+float gaussian(float x, float sigma) {
+    return exp(-0.5 * (x * x) / (sigma * sigma)) / (sigma * sqrt(2.0 * 3.141592653589793));
+}
 
-// Separable SSS Reflectance
-// const float sssWidth = 0.005;
-vec4 SSSSBlur() {
-	// Quality = 0
-	const int SSSS_N_SAMPLES  = 11;
-	vec4 kernel[SSSS_N_SAMPLES];		
-	kernel[0] = vec4(0.560479, 0.669086, 0.784728, 0);
-	kernel[1] = vec4(0.00471691, 0.000184771, 5.07566e-005, -2);
-	kernel[2] = vec4(0.0192831, 0.00282018, 0.00084214, -1.28);
-	kernel[3] = vec4(0.03639, 0.0130999, 0.00643685, -0.72);
-	kernel[4] = vec4(0.0821904, 0.0358608, 0.0209261, -0.32);
-	kernel[5] = vec4(0.0771802, 0.113491, 0.0793803, -0.08);
-	kernel[6] = vec4(0.0771802, 0.113491, 0.0793803, 0.08);
-	kernel[7] = vec4(0.0821904, 0.0358608, 0.0209261, 0.32);
-	kernel[8] = vec4(0.03639, 0.0130999, 0.00643685, 0.72);
-	kernel[9] = vec4(0.0192831, 0.00282018, 0.00084214, 1.28);
-	kernel[10] = vec4(0.00471691, 0.000184771, 5.07565e-005, 2);
-	
-	vec4 colorM = textureLod(tex, texCoord, 0.0);
+// Function to perform SSS blur
+vec4 SSSSBlur(vec3 subsurface_color, vec3 subsurface_radius, float ior) {
+    const int SSSS_N_SAMPLES = 11;
+    vec4 kernel[SSSS_N_SAMPLES];
+    float sigma = 0.2;
+    float totalWeight = 0.0;
 
-	// Fetch linear depth of current pixel
-	float depth = textureLod(gbufferD, texCoord, 0.0).r;
-	float depthM = cameraProj.y / (depth - cameraProj.x);
+    // Generate Gaussian weights and initialize kernel
+    for (int i = 0; i < SSSS_N_SAMPLES; i++) {
+        float x = (float(i) - float(SSSS_N_SAMPLES / 2)) / float(SSSS_N_SAMPLES / 2);
+        kernel[i] = vec4(subsurface_color, 0.0); // Initialize with subsurface radius
+        kernel[i].w = gaussian(x, sigma); // Gaussian weight
+        totalWeight += kernel[i].w;
+    }
 
-	// Calculate the sssWidth scale (1.0 for a unit plane sitting on the projection window)
-	float distanceToProjectionWindow = 1.0 / tan(0.5 * radians(SSSS_FOVY));
-	float scale = distanceToProjectionWindow / depthM;
+    // Normalize weights and scale RGB with radius
+    for (int i = 0; i < SSSS_N_SAMPLES; i++) {
+        kernel[i].rgb *= subsurface_radius;
+        kernel[i].w /= totalWeight;
+    }
 
-	// Calculate the final step to fetch the surrounding pixels
-	vec2 finalStep = sssWidth * scale * dir;
-	// finalStep *= 1.0;//SSSS_STREGTH_SOURCE; // Modulate it using the alpha channel.
-	finalStep *= 1.0 / 3.0; // Divide by 3 as the kernels range from -3 to 3.
-	
-	finalStep *= 0.05; //
+    vec4 colorM = textureLod(tex, texCoord, 0.0);
 
-	// Accumulate the center sample:
-	vec4 colorBlurred = colorM;
-	colorBlurred.rgb *= kernel[0].rgb;
+    // Fetch linear depth of current pixel
+    float depth = textureLod(gbufferD, texCoord, 0.0).r * 2.0 - 1.0;
+    float depthM = cameraProj.y / (depth - cameraProj.x);
 
-	// Accumulate the other samples
-	for (int i = 1; i < SSSS_N_SAMPLES; i++) {
-		// Fetch color and depth for current sample
-		vec2 offset = texCoord + kernel[i].a * finalStep;
-		vec4 color = textureLod(tex, offset, 0.0);
-		// #if SSSS_FOLLOW_SURFACE == 1
-		// If the difference in depth is huge, we lerp color back to "colorM":
-		// float depth = textureLod(depthTex, offset, 0.0).r;
-		// float s = SSSSSaturate(300.0f * distanceToProjectionWindow *
-							//    sssWidth * abs(depthM - depth));
-		// color.rgb = SSSSLerp(color.rgb, colorM.rgb, s);
-		// #endif
-		// Accumulate
-		colorBlurred.rgb += kernel[i].rgb * color.rgb;
-	}
+    float stepSize = cameraProj.y / depthM;
+    stepSize /= (SSSS_N_SAMPLES - 1);
 
-	return colorBlurred;
+    // Accumulate the center sample:
+    vec4 colorBlurred = colorM * kernel[SSSS_N_SAMPLES / 2];
+
+    // Accumulate the other samples with offset
+    for (int i = 0; i < SSSS_N_SAMPLES; i++) {
+        if (i != SSSS_N_SAMPLES / 2) {
+            float offsetScale = (float(i) - float(SSSS_N_SAMPLES / 2)) / float(SSSS_N_SAMPLES / 2);
+            vec2 offset = texCoord + offsetScale * dir * stepSize;
+            vec4 color = textureLod(tex, offset, 0.0);
+            colorBlurred.rgb += kernel[i].w * kernel[i].xyz * color.rgb;
+        }
+    }
+
+    return colorBlurred;
 }
 
 void main() {
-	// SSS only masked objects
-	if (textureLod(gbuffer0, texCoord, 0.0).a == 2.0) {
-		fragColor = clamp(SSSSBlur(), 0.0, 1.0);
-	}
-	else {
-		fragColor = textureLod(tex, texCoord, 0.0);
-	}
+    float metallic;
+    uint matid;
+    unpackFloatInt16(textureLod(gbuffer0, texCoord, 0.0).a, metallic, matid);
+
+	float opacity = textureLod(gbuffer_refraction, texCoord, 0.0).y;
+    vec4 finalColor = textureLod(tex, texCoord, 0.0); // Default to background texture
+
+    if (matid == 2) {
+        vec3 subsurface_color = textureLod(gbuffer_subsurface_1, texCoord, 0.0).rgb;
+        vec4 subsurface_data = textureLod(gbuffer_subsurface_2, texCoord, 0.0);
+        vec3 subsurface_radius = subsurface_data.rgb;
+        vec2 ior_scale = unpackFloat2(subsurface_data.a);
+
+        // Perform SSS blur and clamp result
+        vec4 sssColor = clamp(SSSSBlur(subsurface_color, subsurface_radius, ior_scale.x), 0.0, 1.0);
+
+        // Blend SSS color with background
+        finalColor = mix(finalColor, sssColor, ior_scale.y);
+    }
+
+    fragColor = finalColor;
 }

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -22,6 +22,9 @@
 #ifdef _Spot
 #include "std/light_common.glsl"
 #endif
+#ifdef _SSS
+#include "std/sss.glsl"
+#endif
 
 #ifdef _ShadowMap
 	#ifdef _SinglePoint
@@ -100,6 +103,9 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	#ifdef _SSRS
 		, sampler2D gbufferD, mat4 invVP, vec3 eye
 	#endif
+	#ifdef _SSS
+		, uint matid, vec2 lightPlane
+	#endif
 	) {
 	vec3 ld = lp - p;
 	vec3 l = normalize(ld);
@@ -147,23 +153,38 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 			#ifdef _SinglePoint
 			vec4 lPos = LWVPSpot[0] * vec4(p + n * bias * 10, 1.0);
 			direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+			#ifdef _SSS
+			if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[0], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[0]);
+			#endif
 			#endif
 			#ifdef _Clusters
 			if (index == 0) {
 				vec4 lPos = LWVPSpot[0] * vec4(p + n * bias * 10, 1.0);
 				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+				#ifdef _SSS
+				if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[0], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[0]);
+				#endif
 			}
 			else if (index == 1) {
 				vec4 lPos = LWVPSpot[1] * vec4(p + n * bias * 10, 1.0);
 				direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
+				#ifdef _SSS
+				if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[1], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[1]);
+				#endif
 			}
 			else if (index == 2) {
 				vec4 lPos = LWVPSpot[2] * vec4(p + n * bias * 10, 1.0);
 				direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
+				#ifdef _SSS
+				if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[2], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[2]);
+				#endif
 			}
 			else if (index == 3) {
 				vec4 lPos = LWVPSpot[3] * vec4(p + n * bias * 10, 1.0);
 				direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
+				#ifdef _SSS
+				if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[3], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[3]);
+				#endif
 			}
 			#endif
 		}
@@ -180,6 +201,9 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 				#ifdef _SinglePoint
 				vec4 lPos = LWVPSpot[0] * vec4(p + n * bias * 10, 1.0);
 				direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+				#ifdef _SSS
+				if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[0], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[0]);
+				#endif
 				#endif
 				#ifdef _Clusters
 					vec4 lPos = LWVPSpotArray[index] * vec4(p + n * bias * 10, 1.0);
@@ -192,11 +216,34 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 							#endif
 							, lPos.xyz / lPos.w, bias
 						);
+						#ifdef _SSS
+						if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpotArray[index], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[index]);
+						#endif
 					#else
-							 if (index == 0) direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
-						else if (index == 1) direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
-						else if (index == 2) direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
-						else if (index == 3) direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
+							 if (index == 0) {
+								 direct *= shadowTest(shadowMapSpot[0], lPos.xyz / lPos.w, bias);
+								 #ifdef _SSS
+								 if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[0], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[0]);
+								 #endif
+							 }
+						else if (index == 1) {
+							direct *= shadowTest(shadowMapSpot[1], lPos.xyz / lPos.w, bias);
+							#ifdef _SSS
+							if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[1], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[1]);
+							#endif
+						}
+						else if (index == 2) {
+							direct *= shadowTest(shadowMapSpot[2], lPos.xyz / lPos.w, bias);
+							#ifdef _SSS
+							if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[2], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[2]);
+							#endif
+						}
+						else if (index == 3) {
+							direct *= shadowTest(shadowMapSpot[3], lPos.xyz / lPos.w, bias);
+							#ifdef _SSS
+							if (matid == 2) direct += direct * SSSSTransmittance(LWVPSpot[3], p, n, normalize(lPos.xyz - p), lightPlane.y, shadowMapSpot[3]);
+							#endif
+						}
 					#endif
 				#endif
 			}
@@ -214,6 +261,9 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 			#ifdef _SinglePoint
 			#ifndef _Spot
 			direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+			#ifdef _SSS
+			if (matid == 2) direct += direct * SSSSTransmittanceCube(shadowMapPoint[0], p, n, -l, lightPlane.y, 1.0);
+			#endif
 			#endif
 			#endif
 			#ifdef _Clusters
@@ -226,11 +276,34 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 					#endif
 					, ld, -l, bias, lightProj, n, index
 				);
+				#ifdef _SSS
+				if (matid == 2) direct += direct * SSSSTransmittanceCube(shadowMapPoint[index], p, n, -l, lightPlane.y, 1.0);
+				#endif
 				#else
-					 if (index == 0) direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
-				else if (index == 1) direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
-				else if (index == 2) direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
-				else if (index == 3) direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
+					 if (index == 0) {
+						 direct *= PCFCube(shadowMapPoint[0], ld, -l, bias, lightProj, n);
+						 #ifdef _SSS
+						 if (matid == 2) direct += direct * SSSSTransmittanceCube(shadowMapPoint[0], p, n, -l, lightPlane.y, 1.0);
+						 #endif
+					 }
+				else if (index == 1) {
+					direct *= PCFCube(shadowMapPoint[1], ld, -l, bias, lightProj, n);
+					#ifdef _SSS
+					if (matid == 2) direct += direct * SSSSTransmittanceCube(shadowMapPoint[1], p, n, -l, lightPlane.y, 1.0);
+					#endif
+				}
+				else if (index == 2) {
+					direct *= PCFCube(shadowMapPoint[2], ld, -l, bias, lightProj, n);
+					#ifdef _SSS
+					if (matid == 2) direct += direct * SSSSTransmittanceCube(shadowMapPoint[2], p, n, -l, lightPlane.y, 1.0);
+					#endif
+				}
+				else if (index == 3) {
+					direct *= PCFCube(shadowMapPoint[3], ld, -l, bias, lightProj, n);
+					#ifdef _SSS
+					if (matid == 2) direct += direct * SSSSTransmittanceCube(shadowMapPoint[3], p, n, -l, lightPlane.y, 1.0);
+					#endif
+				}
 				#endif
 			#endif
 		}

--- a/Shaders/voxel_temporal/voxel_temporal.comp.glsl
+++ b/Shaders/voxel_temporal/voxel_temporal.comp.glsl
@@ -236,8 +236,8 @@ void main() {
 			radiance = basecol;
 
 			vec4 trace = traceDiffuse(wposition, wnormal, voxelsSampler, clipmaps);
-			vec3 indirect = trace.rgb + envl.rgb * (1.0 - trace.a);
-			radiance.rgb *= light.rgb + indirect.rgb;
+			vec3 indirect = envl.rgb * (1.0 - trace.a);
+			radiance.rgb *= light.rgb + indirect.rgb + trace.rgb;
 			radiance.rgb += emission.rgb;
 
 			#else

--- a/blender/arm/make_renderpath.py
+++ b/blender/arm/make_renderpath.py
@@ -469,4 +469,6 @@ def get_num_gbuffer_rts_deferred()-> int:
     for flag in ('_gbuffer2', '_EmissionShaded', '_SSRefraction'):
         if flag in wrd.world_defs:
             num += 1
+    if '_SSS' in wrd.world_defs:
+        num += 2
     return num

--- a/blender/arm/material/cycles.py
+++ b/blender/arm/material/cycles.py
@@ -113,7 +113,7 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
         curshader = state.frag
         state.curshader = curshader
 
-        out_basecol, out_roughness, out_metallic, out_occlusion, out_specular, out_opacity, out_ior, out_emission_col = parse_shader_input(node.inputs[0])
+        out_basecol, out_roughness, out_metallic, out_occlusion, out_specular, out_opacity, out_ior, out_emission_col, out_subsurface_col, out_subsurface_radius, out_subsurface_ior, out_subsurface = parse_shader_input(node.inputs[0])
         if parse_surface:
             curshader.write(f'basecol = {out_basecol};')
             curshader.write(f'roughness = {out_roughness};')
@@ -121,6 +121,10 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
             curshader.write(f'occlusion = {out_occlusion};')
             curshader.write(f'specular = {out_specular};')
             curshader.write(f'emissionCol = {out_emission_col};')
+            curshader.write(f'subsurfaceCol = {out_subsurface_col};')
+            curshader.write(f'subsurfaceWeights = {out_subsurface_radius};')
+            curshader.write(f'subsurfaceIor = {out_subsurface_ior};')
+            curshader.write(f'subsurfaceScale = {out_subsurface};')
 
             if mat_state.emission_type == mat_state.EmissionType.SHADELESS:
                 if '_EmissionShadeless' not in wrd.world_defs:
@@ -131,8 +135,8 @@ def parse_material_output(node: bpy.types.Node, custom_particle_node: bpy.types.
                     arm.assets.add_khafile_def('rp_gbuffer_emission')
 
         if parse_opacity:
-            curshader.write('opacity = {0};'.format(out_opacity))
             curshader.write('ior = {0};'.format(out_ior))
+            curshader.write('opacity = {0};'.format(out_opacity))
 
     # Volume
     # parse_volume_input(node.inputs[1])

--- a/blender/arm/material/cycles_nodes/nodes_shader.py
+++ b/blender/arm/material/cycles_nodes/nodes_shader.py
@@ -35,11 +35,11 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
     state.curshader.write('{0}float {1} = 1.0 - {2};'.format(prefix, fac_inv_var, fac_var))
 
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
-    bc1, rough1, met1, occ1, spec1, opac1, ior1, emi1 = c.parse_shader_input(node.inputs[1])
+    bc1, rough1, met1, occ1, spec1, opac1, ior1, emi1, subcol1, subrad1, subior1, sub1 = c.parse_shader_input(node.inputs[1])
     ek1 = mat_state.emission_type
 
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
-    bc2, rough2, met2, occ2, spec2, opac2, ior2, emi2 = c.parse_shader_input(node.inputs[2])
+    bc2, rough2, met2, occ2, spec2, opac2, ior2, emi2, subcol2, subrad2, subior2, sub2 = c.parse_shader_input(node.inputs[2])
     ek2 = mat_state.emission_type
 
     if state.parse_surface:
@@ -49,6 +49,10 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
         state.out_occlusion = '({0} * {3} + {1} * {2})'.format(occ1, occ2, fac_var, fac_inv_var)
         state.out_specular = '({0} * {3} + {1} * {2})'.format(spec1, spec2, fac_var, fac_inv_var)
         state.out_emission_col = '({0} * {3} + {1} * {2})'.format(emi1, emi2, fac_var, fac_inv_var)
+        state.out_subsurface_col = '({0} * {3} + {1} * {2})'.format(subcol1, subcol2, fac_var, fac_inv_var)
+        state.out_subsurface_radius = '({0} * {3} + {1} * {2})'.format(subrad1, subrad2, fac_var, fac_inv_var)
+        state.out_subsurface_ior = '({0} * {3} + {1} * {2})'.format(subior1, subior2, fac_var, fac_inv_var)
+        state.out_subsurface = '({0} * {3} + {1} * {2})'.format(sub1, sub2, fac_var, fac_inv_var)
         mat_state.emission_type = mat_state.EmissionType.get_effective_combination(ek1, ek2)
     if state.parse_opacity:
         state.out_opacity = '({0} * {3} + {1} * {2})'.format(opac1, opac2, fac_var, fac_inv_var)
@@ -56,11 +60,11 @@ def parse_mixshader(node: bpy.types.ShaderNodeMixShader, out_socket: NodeSocket,
 
 def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket, state: ParserState) -> None:
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
-    bc1, rough1, met1, occ1, spec1, opac1, ior1, emi1 = c.parse_shader_input(node.inputs[0])
+    bc1, rough1, met1, occ1, spec1, opac1, ior1, emi1, subcol1, subrad1, subior1, sub1 = c.parse_shader_input(node.inputs[0])
     ek1 = mat_state.emission_type
 
     mat_state.emission_type = mat_state.EmissionType.NO_EMISSION
-    bc2, rough2, met2, occ2, spec2, opac2, ior2, emi2 = c.parse_shader_input(node.inputs[1])
+    bc2, rough2, met2, occ2, spec2, opac2, ior2, emi2, subcol2, subrad2, subior2, sub2 = c.parse_shader_input(node.inputs[1])
     ek2 = mat_state.emission_type
 
     if state.parse_surface:
@@ -69,7 +73,11 @@ def parse_addshader(node: bpy.types.ShaderNodeAddShader, out_socket: NodeSocket,
         state.out_metallic = '({0} * 0.5 + {1} * 0.5)'.format(met1, met2)
         state.out_occlusion = '({0} * 0.5 + {1} * 0.5)'.format(occ1, occ2)
         state.out_specular = '({0} * 0.5 + {1} * 0.5)'.format(spec1, spec2)
-        state.out_emission_col = '({0} + {1})'.format(emi1, emi2)
+        state.out_emission_col = '({0} * 0.5 + {1} * 0.5)'.format(emi1, emi2)
+        state.out_subsurface_col = '({0} * 0.5 + {1} * 0.5)'.format(subcol1, subcol2)
+        state.out_subsurface_radius = '({0} * 0.5 + {1} * 0.5)'.format(subrad1, subrad2)
+        state.out_subsurface_ior = '({0} * 0.5 + {1} * 0.5)'.format(subior1, subior2)
+        state.out_subsurface = '({0} * 0.5 + {1} * 0.5)'.format(sub1, sub2)
         mat_state.emission_type = mat_state.EmissionType.get_effective_combination(ek1, ek2)
     if state.parse_opacity:
         state.out_opacity = '({0} * 0.5 + {1} * 0.5)'.format(opac1, opac2)
@@ -79,9 +87,10 @@ def parse_bsdfprincipled(node: bpy.types.ShaderNodeBsdfPrincipled, out_socket: N
     if state.parse_surface:
         c.write_normal(node.inputs[22])
         state.out_basecol = c.parse_vector_input(node.inputs[0])
-        # subsurface = c.parse_vector_input(node.inputs[1])
-        # subsurface_radius = c.parse_vector_input(node.inputs[2])
-        # subsurface_color = c.parse_vector_input(node.inputs[3])
+        state.out_subsurface = c.parse_value_input(node.inputs[1])
+        state.out_subsurface_radius = c.parse_vector_input(node.inputs[2])
+        state.out_subsurface_col = c.parse_vector_input(node.inputs[3])
+        state.out_subsurface_ior = c.parse_value_input(node.inputs[4])
         state.out_metallic = c.parse_value_input(node.inputs[6])
         state.out_specular = c.parse_value_input(node.inputs[7])
         # specular_tint = c.parse_vector_input(node.inputs[6])
@@ -107,8 +116,7 @@ def parse_bsdfprincipled(node: bpy.types.ShaderNodeBsdfPrincipled, out_socket: N
         # tangent = c.parse_vector_input(node.inputs[22])
     if state.parse_opacity:
         state.out_ior = c.parse_value_input(node.inputs[16])
-        if len(node.inputs) >= 21:
-            state.out_opacity = c.parse_value_input(node.inputs[21])
+        state.out_opacity = c.parse_value_input(node.inputs[21])
 
 def parse_bsdfdiffuse(node: bpy.types.ShaderNodeBsdfDiffuse, out_socket: NodeSocket, state: ParserState) -> None:
     if state.parse_surface:
@@ -180,6 +188,7 @@ def parse_bsdfrefraction(node: bpy.types.ShaderNodeBsdfRefraction, out_socket: N
     if state.parse_opacity:
         state.out_opacity = '0.0'
         state.out_ior = c.parse_value_input(node.inputs[2])
+
 
 def parse_subsurfacescattering(node: bpy.types.ShaderNodeSubsurfaceScattering, out_socket: NodeSocket, state: ParserState) -> None:
     if state.parse_surface:

--- a/blender/arm/material/make.py
+++ b/blender/arm/material/make.py
@@ -137,6 +137,21 @@ def parse(material: Material, mat_data, mat_users: Dict[Material, List[Object]],
 
         elif rp == 'translucent' or rp == 'refraction':
             c['bind_constants'].append({'name': 'receiveShadow', 'boolValue': material.arm_receive_shadow})
+
+            if material.arm_material_id != 0:
+                c['bind_constants'].append({'name': 'materialID', 'intValue': material.arm_material_id})
+
+                if material.arm_material_id == 2:
+                    wrd.world_defs += '_Hair'
+
+            elif rpdat.rp_sss_state != 'Off':
+                const = {'name': 'materialID'}
+                if needs_sss:
+                    const['intValue'] = 2
+                    sss_used = True
+                else:
+                    const['intValue'] = 0
+                c['bind_constants'].append(const)
         
         elif rp == 'shadowmap':
             if wrd.arm_batch_materials:

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -87,9 +87,11 @@ def write(vert: shader.Shader, frag: shader.Shader):
             frag.write(', voxels')
             frag.write(', voxelsSDF')
             frag.write(', clipmaps')
-        
     if '_MicroShadowing' in wrd.world_defs and not is_mobile:
         frag.write('\t, occlusion')
+    if '_SSS' in wrd.world_defs:
+        frag.add_uniform("vec2 lightPlane", "_lightPlane")
+        frag.write(', matid, lightPlane')
     frag.write(');')
 
     frag.write('}') # for numLights

--- a/blender/arm/material/make_refract.py
+++ b/blender/arm/material/make_refract.py
@@ -3,6 +3,7 @@ import bpy
 import arm
 import arm.material.cycles as cycles
 import arm.material.mat_state as mat_state
+import arm.material.mat_utils as mat_utils
 import arm.material.make_mesh as make_mesh
 import arm.material.make_finalize as make_finalize
 import arm.assets as assets
@@ -18,8 +19,9 @@ else:
 
 
 def make(context_id):
+    is_displacement = mat_utils.disp_linked(mat_state.output_node)
+    wrd = bpy.data.worlds['Arm']
     con_refract = mat_state.data.add_context({ 'name': context_id, 'depth_write': True, 'compare_mode': 'less', 'cull_mode': 'clockwise' })
-
     make_mesh.make_forward_base(con_refract, parse_opacity=True, transluc_pass=True)
 
     vert = con_refract.vert
@@ -27,19 +29,75 @@ def make(context_id):
     tese = con_refract.tese
 
     frag.add_include('std/gbuffer.glsl')
-    frag.add_out('vec4 fragColor[3]')
+    frag.add_out('vec4 fragColor[GBUF_SIZE]')
+
+    if '_gbuffer2' in wrd.world_defs:
+        if '_Veloc' in wrd.world_defs:
+            if tese is None:
+                vert.add_uniform('mat4 prevWVP', link='_prevWorldViewProjectionMatrix')
+                vert.add_out('vec4 wvpposition')
+                vert.add_out('vec4 prevwvpposition')
+                vert.write('wvpposition = gl_Position;')
+                if is_displacement:
+                    vert.add_uniform('mat4 invW', link='_inverseWorldMatrix')
+                    vert.write('prevwvpposition = prevWVP * (invW * vec4(wposition, 1.0));')
+                else:
+                    vert.write('prevwvpposition = prevWVP * spos;')
+            else:
+                tese.add_out('vec4 wvpposition')
+                tese.add_out('vec4 prevwvpposition')
+                tese.write('wvpposition = gl_Position;')
+                if is_displacement:
+                    tese.add_uniform('mat4 invW', link='_inverseWorldMatrix')
+                    tese.add_uniform('mat4 prevWVP', '_prevWorldViewProjectionMatrix')
+                    tese.write('prevwvpposition = prevWVP * (invW * vec4(wposition, 1.0));')
+                else:
+                    vert.add_uniform('mat4 prevW', link='_prevWorldMatrix')
+                    vert.add_out('vec3 prevwposition')
+                    vert.write('prevwposition = vec4(prevW * spos).xyz;')
+                    tese.add_uniform('mat4 prevVP', '_prevViewProjectionMatrix')
+                    make_tess.interpolate(tese, 'prevwposition', 3)
+                    tese.write('prevwvpposition = prevVP * vec4(prevwposition, 1.0);')
 
     # Remove fragColor = ...;
     frag.main = frag.main[:frag.main.rfind('fragColor')]
     frag.write('\n')
 
-    wrd = bpy.data.worlds['Arm']
 
     frag.write('n /= (abs(n.x) + abs(n.y) + abs(n.z));')
     frag.write('n.xy = n.z >= 0.0 ? n.xy : octahedronWrap(n.xy);')
-    frag.write('fragColor[0] = vec4(direct + indirect, packFloat2(occlusion, specular));')
-    frag.write('fragColor[1] = vec4(n.xy, roughness, metallic);')
-    frag.write('fragColor[2] = vec4(ior, opacity, 0.0, 0.0);')
+
+    is_shadeless = mat_state.emission_type == mat_state.EmissionType.SHADELESS
+    if is_shadeless or '_SSS' in wrd.world_defs or '_Hair' in wrd.world_defs:
+        if is_shadeless:
+            frag.write('basecol = emissionCol;')
+        if '_SSS' in wrd.world_defs or '_Hair' in wrd.world_defs:
+            frag.write('fragColor[GBUF_IDX_SUBSURFACE_1] = vec4(subsurfaceCol, 1.0);')
+            frag.write('fragColor[GBUF_IDX_SUBSURFACE_2] = vec4(subsurfaceWeights, packFloat2(subsurfaceIor, subsurfaceScale));')
+    else:
+        frag.write('const uint matid = 0;')
+
+    frag.write('fragColor[GBUF_IDX_0] = vec4(n.xy, roughness, packFloatInt16(metallic, matid));')
+    frag.write('fragColor[GBUF_IDX_1] = vec4(direct + indirect, packFloat2(occlusion, specular));')
+
+    if '_gbuffer2' in wrd.world_defs:
+        if '_Veloc' in wrd.world_defs:
+            frag.write('vec2 posa = (wvpposition.xy / wvpposition.w) * 0.5 + 0.5;')
+            frag.write('vec2 posb = (prevwvpposition.xy / prevwvpposition.w) * 0.5 + 0.5;')
+            frag.write('fragColor[GBUF_IDX_2].rg = vec2(posa - posb);')
+            frag.write('fragColor[GBUF_IDX_2].b = 0.0;')
+
+        if mat_state.material.arm_ignore_irradiance:
+            frag.write('fragColor[GBUF_IDX_2].b = 1.0;')
+
+    # Even if the material doesn't use emission we need to write to the
+    # emission buffer (if used) to prevent undefined behaviour
+    frag.write('#ifdef _EmissionShaded')
+    frag.write('fragColor[GBUF_IDX_EMISSION] = vec4(emissionCol, 0.0);')  #Alpha channel is unused at the moment
+    frag.write('#endif')
+
+    frag.write('fragColor[GBUF_IDX_REFRACTION] = vec4(ior, opacity, 0.0, 0.0);')
+
     make_finalize.make(con_refract)
 
     # assets.vs_equal(con_refract, assets.shader_cons['transluc_vert']) # shader_cons has no transluc yet

--- a/blender/arm/material/make_voxel.py
+++ b/blender/arm/material/make_voxel.py
@@ -83,6 +83,10 @@ def make_gi(context_id):
     frag.write('float occlusion;') #
     frag.write('float specular;') #
     frag.write('vec3 emissionCol = vec3(0.0);')
+    frag.write('vec3 subsurfaceCol = vec3(0.0);')
+    frag.write('vec3 subsurfaceWeights = vec3(0.0);')
+    frag.write('float subsurfaceIor = 1.450;')
+    frag.write('float subsurfaceScale = 0.0;')
     parse_opacity = rpdat.arm_voxelgi_refraction
     if parse_opacity:
         frag.write('float opacity;')

--- a/blender/arm/material/parser_state.py
+++ b/blender/arm/material/parser_state.py
@@ -99,6 +99,10 @@ class ParserState:
         self.out_opacity: floatstr = '1.0'
         self.out_ior: floatstr = '1.450'
         self.out_emission_col: vec3str = 'vec3(0.0)'
+        self.out_subsurface_col: vec3str = 'vec3(0.0)'
+        self.out_subsurface_radius: vec3str = 'vec3(0.0)'
+        self.out_subsurface_ior: floatstr = '1.45'
+        self.out_subsurface: floatstr = '0.0'
 
     def reset_outs(self):
         """Reset the shader output values to their default values."""
@@ -110,11 +114,15 @@ class ParserState:
         self.out_opacity = '1.0'
         self.out_ior = '1.450'
         self.out_emission_col = 'vec3(0.0)'
+        self.out_subsurface_col: vec3str = 'vec3(0.0)'
+        self.out_subsurface_radius: vec3str = 'vec3(0.0)'
+        self.out_subsurface_ior: floatstr = '1.45'
+        self.out_subsurface: floatstr = '0.0'
 
-    def get_outs(self) -> Tuple[vec3str, floatstr, floatstr, floatstr, floatstr, floatstr, floatstr, vec3str]:
+    def get_outs(self) -> Tuple[vec3str, floatstr, floatstr, floatstr, floatstr, floatstr, floatstr, vec3str, vec3str, vec3str, floatstr]:
         """Return the shader output values as a tuple."""
         return (self.out_basecol, self.out_roughness, self.out_metallic, self.out_occlusion, self.out_specular,
-                self.out_opacity, self.out_ior, self.out_emission_col)
+                self.out_opacity, self.out_ior, self.out_emission_col, self.out_subsurface_col, self.out_subsurface_radius, self.out_subsurface_ior, self.out_subsurface)
 
 
     def get_parser_pass_suffix(self) -> str:

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -445,25 +445,6 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     rp_stereo: BoolProperty(name="VR", description="Stereo rendering", default=False, update=update_renderpath)
     rp_water: BoolProperty(name="Water", description="Enable water surface pass", default=False, update=update_renderpath)
     rp_pp: BoolProperty(name="Realtime postprocess", description="Realtime postprocess", default=False, update=update_renderpath)
-    rp_gi: EnumProperty( # TODO: remove in 0.8
-        items=[('Off', 'Off', 'Off'),
-               ('Voxel GI', 'Voxel GI', 'Voxel GI', 'ERROR', 1),
-               ('Voxel AO', 'Voxel AO', 'Voxel AO')
-               ],
-        name="Global Illumination", description="Dynamic global illumination", default='Off', update=update_renderpath)
-    rp_voxelao: BoolProperty(name="Voxel AO", description="Voxel-based ambient occlusion", default=False, update=update_renderpath)
-    rp_voxelgi_resolution: EnumProperty(
-        items=[('32', '32', '32'),
-               ('64', '64', '64'),
-               ('128', '128', '128'),
-               ('256', '256', '256'),
-               ('512', '512', '512')],
-        name="Resolution", description="3D texture resolution", default='128', update=update_renderpath)
-    rp_voxelgi_resolution_z: EnumProperty(
-        items=[('1.0', '1.0', '1.0'),
-              ('0.5', '0.5', '0.5'),
-               ('0.25', '0.25', '0.25')],
-        name="Resolution Z", description="3D texture z resolution multiplier", default='1.0', update=update_renderpath)
     arm_clouds: BoolProperty(name="Clouds", description="Enable clouds pass", default=False, update=assets.invalidate_shader_cache)
     arm_ssrs: BoolProperty(name="SSRS", description="Screen-space ray-traced shadows", default=False, update=assets.invalidate_shader_cache)
     arm_micro_shadowing: BoolProperty(name="Micro Shadowing", description="Use the shaders' occlusion parameter to compute micro shadowing for the scene's sun lamp. This option is not available for render paths using mobile or solid material models", default=False, update=assets.invalidate_shader_cache)
@@ -507,7 +488,8 @@ class ArmRPListItem(bpy.types.PropertyGroup):
                ],
         name="Voxels", description="Dynamic global illumination", default='Off', update=update_renderpath)
     rp_voxelgi_resolution: EnumProperty(
-        items=[('32', '32', '32'),
+        items=[('16', '16', '16'),
+               ('32', '32', '32'),
                ('64', '64', '64'),
                ('128', '128', '128'),
                ('256', '256', '256'),

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1493,7 +1493,7 @@ class ARM_PT_RenderPathRendererPanel(bpy.types.Panel):
         layout.prop(rpdat, 'rp_sss_state')
         col = layout.column()
         col.enabled = rpdat.rp_sss_state != 'Off'
-        col.prop(rpdat, 'arm_sss_width')
+        #col.prop(rpdat, 'arm_sss_width')
         layout.prop(rpdat, 'arm_rp_displacement')
         if rpdat.arm_rp_displacement == 'Tessellation':
             layout.label(text='Mesh')

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -592,17 +592,25 @@ def write_compiledglsl(defs, make_variants):
 
             idx_emission = 2
             idx_refraction = 2
+            idx_subsurface = 2
             if '_gbuffer2' in wrd.world_defs:
                 f.write('#define GBUF_IDX_2 2\n')
                 idx_emission += 1
                 idx_refraction += 1
+                idx_subsurface += 1
 
             if '_EmissionShaded' in wrd.world_defs:
                 f.write(f'#define GBUF_IDX_EMISSION {idx_emission}\n')
                 idx_refraction += 1
+                idx_subsurface += 1
 
             if '_SSRefraction' in wrd.world_defs:
                 f.write(f'#define GBUF_IDX_REFRACTION {idx_refraction}\n')
+                idx_subsurface += 1
+
+            if '_SSS' in wrd.world_defs:
+                f.write(f'#define GBUF_IDX_SUBSURFACE_1 {idx_subsurface}\n')
+                f.write(f'#define GBUF_IDX_SUBSURFACE_2 {idx_subsurface + 1}\n')
 
         f.write("""#if defined(HLSL) || defined(METAL)
 #define _InvY


### PR DESCRIPTION
This pull request implements the sss.glsl transmittance function into light.glsl so that not only config with
_Sun
_Spot && _SinglePoint
get a call to SSSTransmitance() function.

It also allows the refractive materials to have a materialID used for testing which material is processed by the SSS shader itself.

So refractive and translucent objects can have subsurface materials.

All the options from the principled shader regarding the subsurface are used in the pass excepted the anisotropy.  

The updated SSSBlur() function is enhanced by deepseek coder. Of course it's reviewed and tested.
The sss.glsl shader gets a cubeSSSSTransmittance function from deepseek-coder too, and it seems to work as the subsurface effect is much more powerful when the light is behind the object from the camera pov. (The video shared bellow uses a point light).

The rock is blue but the subsurface color is green, the refraction is enabled and the opacity is < 1.0.
![Screenshot_20240704_074003](https://github.com/armory3d/armory/assets/29781855/1c775fdb-6a02-45c1-8728-b729e85b095d)