### PR TITLE
Gi clipmaps optimizations and crash fix.

### DIFF
--- a/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/Shaders/deferred_light/deferred_light.frag.glsl
@@ -283,7 +283,7 @@ void main() {
 #endif
 
 #ifdef _VoxelAOvar
-	envl.rgb *= 1.0 - textureLod(voxels_ao, texCoord, 0.0).r;
+	envl.rgb *= textureLod(voxels_ao, texCoord, 0.0).r;
 #endif
 
 #ifndef _VoxelGI

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -75,7 +75,7 @@ uniform sampler2D sltcMag;
 	#endif
 	#ifdef _Clusters
 		uniform sampler2DShadow shadowMapSpot[maxLightsCluster];
-		uniform mat4 LWVPSpotArray[maxLightsCluster];
+		uniform mat4 LWVPSpot[maxLightsCluster];
 	#endif
 	#endif
 #endif

--- a/Shaders/voxel_light/voxel_light.comp.glsl
+++ b/Shaders/voxel_light/voxel_light.comp.glsl
@@ -83,9 +83,7 @@ float lpToDepth(vec3 lp, const vec2 lightProj) {
 
 void main() {
 	int res = voxelgiResolution.x;
-
 	ivec3 dst = ivec3(gl_GlobalInvocationID.xyz);
-
 	vec3 P = (gl_GlobalInvocationID.xyz + 0.5) / voxelgiResolution;
 	P = P * 2.0 - 1.0;
 	P *= clipmaps[int(clipmapLevel * 10)];
@@ -138,8 +136,8 @@ void main() {
 		}
 	}
 
-	light.rgb += visibility * lightColor;
-	light = clamp(light, vec4(0.0), vec4(1.0));
-
-	imageAtomicMax(voxelsLight, dst, convVec4ToRGBA8(light));
+	light.rgb = visibility * lightColor;
+	imageAtomicAdd(voxelsLight, dst, uint(light.r * 255));
+	imageAtomicAdd(voxelsLight, dst + ivec3(0, 0, voxelgiResolution.x), uint(light.g * 255));
+	imageAtomicAdd(voxelsLight, dst + ivec3(0, 0, voxelgiResolution.x * 2), uint(light.b * 255));
 }

--- a/Shaders/voxel_offsetprev/voxel_offsetprev.comp.glsl
+++ b/Shaders/voxel_offsetprev/voxel_offsetprev.comp.glsl
@@ -30,11 +30,11 @@ layout (local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 #include "std/voxels_constants.glsl"
 
 #ifdef _VoxelGI
-uniform layout(rgba8) image3D voxelsB;
-uniform layout(rgba8) image3D voxelsOut;
+uniform layout(rgba16) image3D voxelsB;
+uniform layout(rgba16) image3D voxelsOut;
 #else
-uniform layout(r8) image3D voxelsB;
-uniform layout(r8) image3D voxelsOut;
+uniform layout(r16) image3D voxelsB;
+uniform layout(r16) image3D voxelsOut;
 #endif
 
 uniform int clipmapLevel;

--- a/Shaders/voxel_resolve_ao/voxel_resolve_ao.comp.glsl
+++ b/Shaders/voxel_resolve_ao/voxel_resolve_ao.comp.glsl
@@ -67,7 +67,7 @@ void main() {
 	n.xy = n.z >= 0.0 ? g0.xy : octahedronWrap(g0.xy);
 	n = normalize(n);
 
-	float occ = traceAO(P, n, voxels, clipmaps);
+	float occ = 1.0 - traceAO(P, n, voxels, clipmaps);
 
 	imageStore(voxels_ao, ivec2(pixel), vec4(occ));
 }

--- a/Shaders/voxel_sdf_jumpflood/voxel_sdf_jumpflood.comp.glsl
+++ b/Shaders/voxel_sdf_jumpflood/voxel_sdf_jumpflood.comp.glsl
@@ -23,8 +23,8 @@ THE SOFTWARE.
 
 #include "compiled.inc"
 
-uniform layout(r8) image3D input_sdf;
-uniform layout(r8) image3D output_sdf;
+uniform layout(r16) image3D input_sdf;
+uniform layout(r16) image3D output_sdf;
 
 uniform float jump_size;
 uniform int clipmapLevel;

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -566,19 +566,12 @@ class Inc {
 		var res = iron.RenderPath.getVoxelRes();
 		var resZ =  iron.RenderPath.getVoxelResZ();
 
-		if (t.name == "voxels_diffuse" || t.name == "voxels_specular") {
+		if (t.name == "voxels_diffuse" || t.name == "voxels_specular" || t.name == "voxels_ao") {
 			t.width = 0;
 			t.height = 0;
 			t.displayp = getDisplayp();
 			t.scale = getSuperSampling();
-			t.format = getHdrFormat();
-		}
-		else if (t.name == "voxels_ao") {
-			t.width = 0;
-			t.height = 0;
-			t.displayp = getDisplayp();
-			t.scale = getSuperSampling();
-			t.format = "R8";
+			t.format = t.name == "voxels_ao" ? "R8" : "RGBA32";
 		}
 		else {
 			if (t.name == "voxelsSDF" || t.name == "voxelsSDFtmp") {
@@ -591,7 +584,7 @@ class Inc {
 				#if (rp_voxels == "Voxel AO")
 				{
 					if (t.name == "voxelsOut" || t.name == "voxelsOutB") {
-						t.format = "R8";
+						t.format = "R16";
 						t.width = res * (6 + 16);
 						t.height = res * Main.voxelgiClipmapCount;
 						t.depth = res;
@@ -606,29 +599,29 @@ class Inc {
 				#else
 				{
 					if (t.name == "voxelsOut" || t.name == "voxelsOutB") {
+						t.format = "RGBA64";
 						t.width = res * (6 + 16);
 						t.height = res * Main.voxelgiClipmapCount;
-						t.format = "RGBA32";
 						t.depth = res;
 					}
 					else if (t.name == "voxelsLight") {
+						t.format = "R32";
 						t.width = res;
 						t.height = res;
-						t.format = "R32";
-						t.depth = res;
+						t.depth = res * 3;
 					}
 					else {
+						t.format = "R32";
 						t.width = res * 6;
 						t.height = res;
-						t.format = "R32";
 						t.depth = res * 9;
 					}
 				}
 				#end
 			}
 		}
-		t.mipmaps = true;
 		t.is_image = true;
+		t.mipmaps = true;
 		path.createRenderTarget(t);
 	}
 	#end

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -585,6 +585,9 @@ class RenderPathDeferred {
 			}
 			else
 			{
+				#if (rp_voxels == "Voxel GI")
+				path.clearImage("voxelsLight", 0x00000000);
+				#end
 				path.clearImage("voxels", 0x00000000);
 				Inc.computeVoxelsOffsetPrev();
 			}

--- a/Sources/armory/renderpath/RenderPathForward.hx
+++ b/Sources/armory/renderpath/RenderPathForward.hx
@@ -387,6 +387,9 @@ class RenderPathForward {
 			}
 			else
 			{
+				#if (rp_voxels == "Voxel GI")
+				path.clearImage("voxelsLight", 0x00000000);
+				#end
 				path.clearImage("voxels", 0x00000000);
 				Inc.computeVoxelsOffsetPrev();
 			}

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -682,7 +682,7 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
         frag.add_uniform('float clipmaps[voxelgiClipmapCount * 10]', link='_clipmaps')
 
     if '_VoxelAOvar' in wrd.world_defs:
-        frag.write('indirect *= (1.0 - traceAO(wposition, n, voxels, clipmaps).r);')
+        frag.write('indirect *= 1.0 - traceAO(wposition, n, voxels, clipmaps);')
 
     if '_VoxelGI' in wrd.world_defs:
         frag.write('indirect += traceDiffuse(wposition, n, voxels, clipmaps).rgb * albedo * voxelgiDiff;')

--- a/blender/arm/material/make_voxel.py
+++ b/blender/arm/material/make_voxel.py
@@ -1,24 +1,3 @@
-"""
-Copyright (c) 2024 Turánszki János
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-"""
 import bpy
 
 import arm.utils

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -445,25 +445,6 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     rp_stereo: BoolProperty(name="VR", description="Stereo rendering", default=False, update=update_renderpath)
     rp_water: BoolProperty(name="Water", description="Enable water surface pass", default=False, update=update_renderpath)
     rp_pp: BoolProperty(name="Realtime postprocess", description="Realtime postprocess", default=False, update=update_renderpath)
-    rp_gi: EnumProperty( # TODO: remove in 0.8
-        items=[('Off', 'Off', 'Off'),
-               ('Voxel GI', 'Voxel GI', 'Voxel GI', 'ERROR', 1),
-               ('Voxel AO', 'Voxel AO', 'Voxel AO')
-               ],
-        name="Global Illumination", description="Dynamic global illumination", default='Off', update=update_renderpath)
-    rp_voxelao: BoolProperty(name="Voxel AO", description="Voxel-based ambient occlusion", default=False, update=update_renderpath)
-    rp_voxelgi_resolution: EnumProperty(
-        items=[('32', '32', '32'),
-               ('64', '64', '64'),
-               ('128', '128', '128'),
-               ('256', '256', '256'),
-               ('512', '512', '512')],
-        name="Resolution", description="3D texture resolution", default='128', update=update_renderpath)
-    rp_voxelgi_resolution_z: EnumProperty(
-        items=[('1.0', '1.0', '1.0'),
-              ('0.5', '0.5', '0.5'),
-               ('0.25', '0.25', '0.25')],
-        name="Resolution Z", description="3D texture z resolution multiplier", default='1.0', update=update_renderpath)
     arm_clouds: BoolProperty(name="Clouds", description="Enable clouds pass", default=False, update=assets.invalidate_shader_cache)
     arm_ssrs: BoolProperty(name="SSRS", description="Screen-space ray-traced shadows", default=False, update=assets.invalidate_shader_cache)
     arm_micro_shadowing: BoolProperty(name="Micro Shadowing", description="Use the shaders' occlusion parameter to compute micro shadowing for the scene's sun lamp. This option is not available for render paths using mobile or solid material models", default=False, update=assets.invalidate_shader_cache)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1710,12 +1710,13 @@ class ARM_PT_RenderPathVoxelsPanel(bpy.types.Panel):
         col2.enabled = rpdat.rp_voxels == 'Voxel GI'
         col3 = col.column()
         col3.enabled = rpdat.rp_voxels == 'Voxel AO'
-        col.prop(rpdat, 'arm_voxelgi_shadows', text='Shadows')
+        #col.prop(rpdat, 'arm_voxelgi_shadows', text='Shadows')
         #col2.prop(rpdat, 'arm_voxelgi_refraction', text='Refraction')
         #col2.prop(rpdat, 'arm_voxelgi_bounces')
         col.prop(rpdat, 'arm_voxelgi_clipmap_count')
         #col.prop(rpdat, 'arm_voxelgi_cones')
         col.prop(rpdat, 'rp_voxelgi_resolution')
+        col.prop(rpdat, 'arm_voxelgi_size')
         #col.prop(rpdat, 'rp_voxelgi_resolution_z')
         col2.enabled = rpdat.rp_voxels == 'Voxel GI'
         #col.prop(rpdat, 'arm_voxelgi_temporal')
@@ -1727,7 +1728,6 @@ class ARM_PT_RenderPathVoxelsPanel(bpy.types.Panel):
         #col2.prop(rpdat, 'arm_voxelgi_refr')
         col.prop(rpdat, 'arm_voxelgi_occ')
         col.label(text="Ray")
-        col.prop(rpdat, 'arm_voxelgi_size')
         col.prop(rpdat, 'arm_voxelgi_step')
         col.prop(rpdat, 'arm_voxelgi_range')
         #col.prop(rpdat, 'arm_voxelgi_offset')


### PR DESCRIPTION
- voxels resolve image are set to RGBA32.
- voxels light image uses offset coordinates to store rgb values in disctinct channels.
- imageAtomicAdd is used in place of imageAtomicMax for writing to voxelsLight.
- step size is used for diffuse conetracing to avoid missing voxels when resolution is high.
- moved the voxel size option to the voxels settings (not the ray panel).