### PR TITLE
fix voxel gi

### DIFF
--- a/Shaders/ssr_pass/ssr_pass.frag.glsl
+++ b/Shaders/ssr_pass/ssr_pass.frag.glsl
@@ -92,7 +92,7 @@ void main() {
 
 	vec3 viewNormal = V3 * n;
 	vec3 viewPos = getPosView(viewRay, d, cameraProj);
-	vec3 reflected = reflect(normalize(viewPos), viewNormal);
+	vec3 reflected = reflect(viewPos, viewNormal);
 	hitCoord = viewPos;
 
 	#ifdef _CPostprocess

--- a/Shaders/std/conetrace.glsl
+++ b/Shaders/std/conetrace.glsl
@@ -169,7 +169,7 @@ vec4 traceDiffuse(const vec3 origin, const vec3 normal, const sampler3D voxels, 
 }
 
 vec4 traceSpecular(const vec3 origin, const vec3 normal, const sampler3D voxels, const sampler3D voxelsSDF, const vec3 viewDir, const float roughness, const float clipmaps[voxelgiClipmapCount * 10], const vec2 pixel) {
-	vec3 specularDir = reflect(-viewDir, normal);
+	vec3 specularDir = normalize(reflect(-viewDir, normal));
 	vec3 P = origin + specularDir * (BayerMatrix8[int(pixel.x) % 8][int(pixel.y) % 8] - 0.5) * voxelgiStep;
 	vec4 amount = traceCone(voxels, voxelsSDF, P, normal, specularDir, 0, true, roughness, voxelgiStep, clipmaps);
 

--- a/Shaders/std/light.glsl
+++ b/Shaders/std/light.glsl
@@ -23,6 +23,21 @@
 #include "std/light_common.glsl"
 #endif
 
+#ifdef _VoxelGI
+//!uniform sampler2D voxels_diffuse;
+//!uniform sampler2D voxels_specular;
+#ifdef _VoxelRefract
+//!uniform sampler2D gbuffer_refraction;
+//!uniform sampler2D voxels_refraction;
+#endif
+#endif
+#ifdef _VoxelAOvar
+//!uniform sampler2D voxels_ao;
+#endif
+#ifdef _VoxelShadow
+//!uniform sampler2D voxels_shadows;
+#endif
+
 #ifdef _ShadowMap
 	#ifdef _SinglePoint
 		#ifdef _Spot
@@ -75,7 +90,7 @@ uniform sampler2D sltcMag;
 	#endif
 	#ifdef _Clusters
 		uniform sampler2DShadow shadowMapSpot[maxLightsCluster];
-		uniform mat4 LWVPSpotArray[maxLightsCluster];
+		uniform mat4 LWVPSpot[maxLightsCluster];
 	#endif
 	#endif
 #endif
@@ -90,9 +105,7 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 		, bool isSpot, float spotSize, float spotBlend, vec3 spotDir, vec2 scale, vec3 right
 	#endif
 	#ifdef _VoxelShadow
-		, sampler3D voxels
-		, sampler3D voxelsSDF
-		, float clipmaps[voxelgiClipmapCount * 10]
+		, vec2 texCoord
 	#endif
 	#ifdef _MicroShadowing
 		, float occ
@@ -138,7 +151,7 @@ vec3 sampleLight(const vec3 p, const vec3 n, const vec3 v, const float dotNV, co
 	#endif
 
 	#ifdef _VoxelShadow
-	direct *= 1.0 - traceShadow(p, n, voxels, voxelsSDF, l, clipmaps);
+	direct *= textureLod(voxels_shadows, texCoord, 0.0).r * voxelgiShad;
 	#endif
 
 	#ifdef _LTC

--- a/Shaders/voxel_offsetprev/voxel_offsetprev.comp.glsl
+++ b/Shaders/voxel_offsetprev/voxel_offsetprev.comp.glsl
@@ -33,8 +33,8 @@ layout (local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 uniform layout(rgba8) image3D voxelsB;
 uniform layout(rgba8) image3D voxelsOut;
 #else
-uniform layout(r8) image3D voxelsB;
-uniform layout(r8) image3D voxelsOut;
+uniform layout(r16) image3D voxelsB;
+uniform layout(r16) image3D voxelsOut;
 #endif
 
 uniform int clipmapLevel;

--- a/Shaders/voxel_resolve_shadows/voxel_resolve_shadows.comp.glsl
+++ b/Shaders/voxel_resolve_shadows/voxel_resolve_shadows.comp.glsl
@@ -31,9 +31,10 @@ layout (local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 #include "std/conetrace.glsl"
 
 uniform sampler3D voxels;
+uniform sampler3D voxelsSDF;
 uniform sampler2D gbufferD;
 uniform sampler2D gbuffer0;
-uniform layout(r8) image2D voxels_ao;
+uniform layout(r8) image2D voxels_shadows;
 
 uniform float clipmaps[voxelgiClipmapCount * 10];
 uniform mat4 InvVP;
@@ -41,6 +42,7 @@ uniform vec2 cameraProj;
 uniform vec3 eye;
 uniform vec3 eyeLook;
 uniform vec2 postprocess_resolution;
+uniform vec3 lPos;
 
 void main() {
 	const vec2 pixel = gl_GlobalInvocationID.xy;
@@ -67,7 +69,7 @@ void main() {
 	n.xy = n.z >= 0.0 ? g0.xy : octahedronWrap(g0.xy);
 	n = normalize(n);
 
-	float occ = 1.0 - traceAO(P, n, voxels, clipmaps);
+	float occ = 1.0 - traceShadow(P, n, voxels, voxelsSDF, normalize(lPos - P), clipmaps, pixel);
 
-	imageStore(voxels_ao, ivec2(pixel), vec4(occ));
+	imageStore(voxels_shadows, ivec2(pixel), vec4(occ));
 }

--- a/Shaders/voxel_sdf_jumpflood/voxel_sdf_jumpflood.comp.glsl
+++ b/Shaders/voxel_sdf_jumpflood/voxel_sdf_jumpflood.comp.glsl
@@ -23,8 +23,8 @@ THE SOFTWARE.
 
 #include "compiled.inc"
 
-uniform layout(r8) image3D input_sdf;
-uniform layout(r8) image3D output_sdf;
+uniform layout(r16) image3D input_sdf;
+uniform layout(r16) image3D output_sdf;
 
 uniform float jump_size;
 uniform int clipmapLevel;

--- a/Shaders/voxel_temporal/voxel_temporal.comp.glsl
+++ b/Shaders/voxel_temporal/voxel_temporal.comp.glsl
@@ -172,9 +172,9 @@ void main() {
 			vec4 trace = traceDiffuse(wposition, wnormal, voxelsSampler, clipmaps);
 			vec3 diffuse_indirect = trace.rgb + envl * (1.0 - trace.a);
 			#ifdef _ShadowMap
-			radiance.rgb *= light / PI + diffuse_indirect;
+			radiance.rgb *= light + diffuse_indirect;
 			#else
-			radiance.rgb *= 1.0 / PI + diffuse_indirect;
+			radiance.rgb *= diffuse_indirect;
 			#endif
 			radiance.rgb += emission.rgb;
 			#else

--- a/Shaders/voxel_temporal/voxel_temporal.comp.glsl
+++ b/Shaders/voxel_temporal/voxel_temporal.comp.glsl
@@ -42,9 +42,10 @@ uniform float shadowsBias;
 uniform mat4 LVP;
 #endif
 uniform sampler3D voxelsSampler;
+uniform sampler3D voxelsSDFSampler;
 uniform layout(r32ui) uimage3D voxels;
-uniform layout(rgba8) image3D voxelsB;
 uniform layout(r32ui) uimage3D voxelsLight;
+uniform layout(rgba8) image3D voxelsB;
 uniform layout(rgba8) image3D voxelsOut;
 #ifdef _ShadowMap
 uniform sampler2DShadow shadowMap;
@@ -66,24 +67,24 @@ uniform int envmapNumMipmaps;
 #ifdef _EnvCol
 uniform vec3 backgroundCol;
 #endif
-uniform sampler2D gbufferD;
-uniform sampler2D gbuffer0;
-uniform sampler2D gbuffer1;
 #ifdef _gbuffer2
 #ifdef _Deferred
 uniform sampler2D gbuffer2;
 #endif
 #endif
 uniform vec3 eye;
-uniform layout(r8) image3D SDF;
+uniform vec3 eyeLook;
+uniform vec3 viewRay;
+uniform vec2 cameraProj;
+uniform layout(r16) image3D SDF;
 #else
 #ifdef _VoxelAOvar
 #ifdef _VoxelShadow
-uniform layout(r8) image3D SDF;
+uniform layout(r16) image3D SDF;
 #endif
 uniform layout(r32ui) uimage3D voxels;
-uniform layout(r8) image3D voxelsB;
-uniform layout(r8) image3D voxelsOut;
+uniform layout(r16) image3D voxelsB;
+uniform layout(r16) image3D voxelsOut;
 #endif
 #endif
 
@@ -94,12 +95,6 @@ layout (local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 
 void main() {
 	int res = voxelgiResolution.x;
-	#ifdef _VoxelGI
-	vec4 aniso_colors[6];
-	#else
-	float opac;
-	float aniso_colors[6];
-	#endif
 
 	#ifdef _VoxelGI
 	float sdf = float(clipmaps[int(clipmapLevel * 10)]) * 2.0 * res;
@@ -110,17 +105,28 @@ void main() {
 	#endif
 
 	#ifdef _VoxelGI
-	vec4 light = convRGBA8ToVec4(imageLoad(voxelsLight, ivec3(gl_GlobalInvocationID.xyz)).r);
+	vec3 light = vec3(0.0);
+	light.r = float(imageLoad(voxelsLight, ivec3(gl_GlobalInvocationID.xyz))) / 255;
+	light.g = float(imageLoad(voxelsLight, ivec3(gl_GlobalInvocationID.xyz) + ivec3(0, 0, voxelgiResolution.x))) / 255;
+	light.b = float(imageLoad(voxelsLight, ivec3(gl_GlobalInvocationID.xyz) + ivec3(0, 0, voxelgiResolution.x * 2))) / 255;
+	light /= 3;
 	#endif
 
 	for (int i = 0; i < 6 + DIFFUSE_CONE_COUNT; i++)
 	{
+		#ifdef _VoxelGI
+		vec4 aniso_colors[6];
+		#else
+		float aniso_colors[6];
+		#endif
+
 		ivec3 src = ivec3(gl_GlobalInvocationID.xyz);
 		src.x += i * res;
 		ivec3 dst = src;
 		dst.y += clipmapLevel * res;
 		#ifdef _VoxelGI
 		vec4 radiance = vec4(0.0);
+		vec4 bounce = vec4(0.0);
 		#else
 		float opac = 0.0;
 		#endif
@@ -143,6 +149,17 @@ void main() {
 			N.g = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 8))) / 255;
 			N /= 2;
 			vec3 wnormal = decode_oct(N.rg * 2 - 1);
+			float roughness = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 9))) / 255;
+			float metallic = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 10))) / 255;
+			vec3 envl = vec3(0.0);
+			envl.r = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 11))) / 255;
+			envl.g = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 12))) / 255;
+			envl.b = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 13))) / 255;
+			envl /= 3;
+
+			#ifdef _HOSEK
+			envl *= 10;
+			#endif
 
 			//clipmap to world
 			vec3 wposition = (gl_GlobalInvocationID.xyz + 0.5) / voxelgiResolution.x;
@@ -151,96 +168,15 @@ void main() {
 			wposition *= voxelgiResolution.x;
 			wposition += vec3(clipmaps[clipmapLevel * 10 + 4], clipmaps[clipmapLevel * 10 + 5], clipmaps[clipmapLevel * 10 + 6]);
 
-			#ifdef _Deferred
-			const vec2 pixel = gl_GlobalInvocationID.xy;
-			const vec2 uv = (pixel + 0.5) / voxelgiResolution.xy;
-
-			vec4 g0 = textureLod(gbuffer0, uv, 0.0); // Normal.xy, roughness, metallic/matid
-			vec3 n;
-			n.z = 1.0 - abs(g0.x) - abs(g0.y);
-			n.xy = n.z >= 0.0 ? g0.xy : octahedronWrap(g0.xy);
-			n = normalize(n);
-
-			float roughness = g0.b;
-			float metallic;
-			uint matid;
-			unpackFloatInt16(g0.a, metallic, matid);
-
-			vec4 g1 = textureLod(gbuffer1, uv, 0.0); // Basecolor.rgb, spec/occ
-			vec2 occspec = unpackFloat2(g1.a);
-			vec3 albedo = surfaceAlbedo(g1.rgb, metallic); // g1.rgb - basecolor
-			vec3 f0 = surfaceF0(g1.rgb, metallic);
-
-			vec3 v = normalize(eye - wposition);
-			float dotNV = max(dot(wnormal, v), 0.0);
-
-			#ifdef _gbuffer2
-				vec4 g2 = textureLod(gbuffer2, uv, 0.0);
-			#endif
-
-			#ifdef _Brdf
-				vec2 envBRDF = texelFetch(senvmapBrdf, ivec2(vec2(dotNV, 1.0 - roughness) * 256.0), 0).xy;
-			#endif
-
-				// Envmap
-			#ifdef _Irr
-				vec3 envl = shIrradiance(wnormal, shirr);
-
-				#ifdef _gbuffer2
-					if (g2.b < 0.5) {
-						envl = envl;
-					} else {
-						envl = vec3(0.0);
-					}
-				#endif
-
-				#ifdef _EnvTex
-					envl /= PI;
-				#endif
-			#else
-				vec3 envl = vec3(0.0);
-			#endif
-
-			#ifdef _Rad
-				vec3 reflectionWorld = reflect(-v, wnormal);
-				float lod = getMipFromRoughness(roughness, envmapNumMipmaps);
-				vec3 prefilteredColor = textureLod(senvmapRadiance, envMapEquirect(reflectionWorld), lod).rgb;
-			#endif
-
-			#ifdef _EnvLDR
-				envl.rgb = pow(envl.rgb, vec3(2.2));
-				#ifdef _Rad
-					prefilteredColor = pow(prefilteredColor, vec3(2.2));
-				#endif
-			#endif
-
-				envl.rgb *= albedo;
-
-			#ifdef _Brdf
-				envl.rgb *= 1.0 - (f0 * envBRDF.x + envBRDF.y);
-			#endif
-
-			#ifdef _Rad // Indirect specular
-				envl.rgb += prefilteredColor * (f0 * envBRDF.x + envBRDF.y);
-			#else
-				#ifdef _EnvCol
-				envl.rgb += backgroundCol * (f0 * envBRDF.x + envBRDF.y);
-				#endif
-			#endif
-
-			envl.rgb *= envmapStrength * occspec.x;
-			#else
-			vec3 envl = vec3(0.0);
-			#endif
-
 			radiance = basecol;
-
 			vec4 trace = traceDiffuse(wposition, wnormal, voxelsSampler, clipmaps);
-			vec3 indirect = trace.rgb + envl.rgb * (1.0 - trace.a);
-			radiance.rgb *= light.rgb / PI + indirect.rgb;
+			vec3 diffuse_indirect = trace.rgb + envl * (1.0 - trace.a);
+			#ifdef _ShadowMap
+			radiance.rgb *= light / PI + diffuse_indirect;
+			#else
+			radiance.rgb *= 1.0 / PI + diffuse_indirect;
+			#endif
 			radiance.rgb += emission.rgb;
-			radiance = clamp(radiance, vec4(0.0), vec4(1.0));
-
 			#else
 			opac = float(imageLoad(voxels, src)) / 255;
 			#endif

--- a/Sources/armory/logicnode/StringCharAtNode.hx
+++ b/Sources/armory/logicnode/StringCharAtNode.hx
@@ -1,0 +1,21 @@
+package armory.logicnode;
+
+class StringCharAtNode extends LogicNode {
+	public var char: String;
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function run(from:Int) {
+	    var string: String = inputs[1].get();
+	    var index: Int = inputs[2].get();
+	    char = string.charAt(index);
+		  runOutput(0);
+	}
+
+	override function get(from: Int): String {
+		return char;
+	}
+
+}

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -68,7 +68,6 @@ class Inc {
 	static var voxel_cb2:kha.compute.ConstantLocation;
 	static var voxel_cc2:kha.compute.ConstantLocation;
 	#end
-	#if arm_deferred
 	static var voxel_sh3:kha.compute.Shader = null;
 	static var voxel_ta3:kha.compute.TextureUnit;
 	static var voxel_tb3:kha.compute.TextureUnit;
@@ -93,7 +92,36 @@ class Inc {
 	static var voxel_cd4:kha.compute.ConstantLocation;
 	static var voxel_ce4:kha.compute.ConstantLocation;
 	static var voxel_cf4:kha.compute.ConstantLocation;
+	#if arm_voxelgi_refract
+	static var voxel_sh6:kha.compute.Shader = null;
+	static var voxel_ta6:kha.compute.TextureUnit;
+	static var voxel_tb6:kha.compute.TextureUnit;
+	static var voxel_tc6:kha.compute.TextureUnit;
+	static var voxel_td6:kha.compute.TextureUnit;
+	static var voxel_te6:kha.compute.TextureUnit;
+	static var voxel_tf6:kha.compute.TextureUnit;
+	static var voxel_ca6:kha.compute.ConstantLocation;
+	static var voxel_cb6:kha.compute.ConstantLocation;
+	static var voxel_cc6:kha.compute.ConstantLocation;
+	static var voxel_cd6:kha.compute.ConstantLocation;
+	static var voxel_ce6:kha.compute.ConstantLocation;
+	static var voxel_cf6:kha.compute.ConstantLocation;
 	#end
+	#end
+	#if arm_voxelgi_shadows
+	static var voxel_sh7:kha.compute.Shader = null;
+	static var voxel_ta7:kha.compute.TextureUnit;
+	static var voxel_tb7:kha.compute.TextureUnit;
+	static var voxel_tc7:kha.compute.TextureUnit;
+	static var voxel_td7:kha.compute.TextureUnit;
+	static var voxel_te7:kha.compute.TextureUnit;
+	static var voxel_ca7:kha.compute.ConstantLocation;
+	static var voxel_cb7:kha.compute.ConstantLocation;
+	static var voxel_cc7:kha.compute.ConstantLocation;
+	static var voxel_cd7:kha.compute.ConstantLocation;
+	static var voxel_ce7:kha.compute.ConstantLocation;
+	static var voxel_cf7:kha.compute.ConstantLocation;
+	static var voxel_cg7:kha.compute.ConstantLocation;
 	#end
 	#if (rp_voxels == "Voxel GI")
 	static var voxel_sh5:kha.compute.Shader = null;
@@ -508,13 +536,21 @@ class Inc {
 			#end
 		}
 		#end
+
 		#if (rp_voxels != "Off")
-		path.bindTarget("voxelsOut", "voxels");
-		#if (rp_voxels == "Voxel GI")
-		path.bindTarget("voxelsSDF", "voxelsSDF");
+		#if (rp_voxels == "Voxel AO")
+		path.bindTarget("voxels_ao", "voxels_ao");
+		#else
+		path.bindTarget("voxels_diffuse", "voxels_diffuse");
+		path.bindTarget("voxels_specular", "voxels_specular");
 		#end
 		#end
+		#if arm_voxelgi_shadows
+		path.bindTarget("voxels_shadows", "voxels_shadows");
+		#end
+
 		path.drawMeshes("translucent");
+
 		#if rp_render_to_texture
 		{
 			path.setTarget(target);
@@ -566,23 +602,16 @@ class Inc {
 		var res = iron.RenderPath.getVoxelRes();
 		var resZ =  iron.RenderPath.getVoxelResZ();
 
-		if (t.name == "voxels_diffuse" || t.name == "voxels_specular") {
+		if (t.name == "voxels_diffuse" || t.name == "voxels_specular" || t.name == "voxels_refraction" || t.name == "voxels_shadows" || t.name == "voxels_ao") {
 			t.width = 0;
 			t.height = 0;
 			t.displayp = getDisplayp();
 			t.scale = getSuperSampling();
-			t.format = getHdrFormat();
-		}
-		else if (t.name == "voxels_ao") {
-			t.width = 0;
-			t.height = 0;
-			t.displayp = getDisplayp();
-			t.scale = getSuperSampling();
-			t.format = "R8";
+			t.format = (t.name == "voxels_ao" || t.name == "voxels_shadow") ? "R8" : "RGBA32";
 		}
 		else {
 			if (t.name == "voxelsSDF" || t.name == "voxelsSDFtmp") {
-				t.format = "R8";
+				t.format = "R16";
 				t.width = res;
 				t.height = res * Main.voxelgiClipmapCount;
 				t.depth = res;
@@ -591,7 +620,7 @@ class Inc {
 				#if (rp_voxels == "Voxel AO")
 				{
 					if (t.name == "voxelsOut" || t.name == "voxelsOutB") {
-						t.format = "R8";
+						t.format = "R16";
 						t.width = res * (6 + 16);
 						t.height = res * Main.voxelgiClipmapCount;
 						t.depth = res;
@@ -606,28 +635,27 @@ class Inc {
 				#else
 				{
 					if (t.name == "voxelsOut" || t.name == "voxelsOutB") {
+						t.format = "RGBA32";
 						t.width = res * (6 + 16);
 						t.height = res * Main.voxelgiClipmapCount;
-						t.format = "RGBA32";
 						t.depth = res;
 					}
 					else if (t.name == "voxelsLight") {
+						t.format = "R32";
 						t.width = res;
 						t.height = res;
-						t.format = "R32";
-						t.depth = res;
+						t.depth = res * 3;
 					}
 					else {
+						t.format = "R32";
 						t.width = res * 6;
 						t.height = res;
-						t.format = "R32";
-						t.depth = res * 9;
+						t.depth = res * 14;
 					}
 				}
 				#end
 			}
 		}
-		t.mipmaps = true;
 		t.is_image = true;
 		path.createRenderTarget(t);
 	}
@@ -773,7 +801,6 @@ class Inc {
 			voxel_cc2 = voxel_sh2.getConstantLocation("jump_size");
 		}
 		#end
-		#if arm_deferred
 		if (voxel_sh3 == null)
 		{
 			#if (rp_voxels == "Voxel AO")
@@ -805,18 +832,50 @@ class Inc {
 			voxel_tc4 = voxel_sh4.getTextureUnit("gbuffer0");
 			voxel_td4 = voxel_sh4.getTextureUnit("voxelsSDF");
 			voxel_te4 = voxel_sh4.getTextureUnit("voxels_specular");
-
 	 		voxel_ca4 = voxel_sh4.getConstantLocation("clipmaps");
 	 		voxel_cb4 = voxel_sh4.getConstantLocation("InvVP");
 	 		voxel_cc4 = voxel_sh4.getConstantLocation("cameraProj");
 	 		voxel_cd4 = voxel_sh4.getConstantLocation("eye");
 	 		voxel_ce4 = voxel_sh4.getConstantLocation("eyeLook");
 	 		voxel_cf4 = voxel_sh4.getConstantLocation("postprocess_resolution");
+	 		#if arm_voxelgi_refract
+			voxel_sh6 = path.getComputeShader("voxel_resolve_refraction");
+			voxel_ta6 = voxel_sh6.getTextureUnit("voxels");
+			voxel_tb6 = voxel_sh6.getTextureUnit("gbufferD");
+			voxel_tc6 = voxel_sh6.getTextureUnit("gbuffer0");
+			voxel_td6 = voxel_sh6.getTextureUnit("voxelsSDF");
+			voxel_te6 = voxel_sh6.getTextureUnit("voxels_refraction");
+			voxel_tf6 = voxel_sh6.getTextureUnit("gbuffer_refraction");
+	 		voxel_ca6 = voxel_sh6.getConstantLocation("clipmaps");
+	 		voxel_cb6 = voxel_sh6.getConstantLocation("InvVP");
+	 		voxel_cc6 = voxel_sh6.getConstantLocation("cameraProj");
+	 		voxel_cd6 = voxel_sh6.getConstantLocation("eye");
+	 		voxel_ce6 = voxel_sh6.getConstantLocation("eyeLook");
+	 		voxel_cf6 = voxel_sh6.getConstantLocation("postprocess_resolution");
+	 		#end
 		}
 		#end
-		#end // arm_deferred
+		#if arm_voxelgi_shadows
+		if (voxel_sh7 == null)
+		{
+			voxel_sh7 = path.getComputeShader("voxel_resolve_shadows");
+			voxel_ta7 = voxel_sh7.getTextureUnit("voxels");
+			voxel_tb7 = voxel_sh7.getTextureUnit("gbufferD");
+			voxel_tc7 = voxel_sh7.getTextureUnit("gbuffer0");
+			voxel_td7 = voxel_sh7.getTextureUnit("voxelsSDF");
+			voxel_te7 = voxel_sh7.getTextureUnit("voxels_shadows");
+			voxel_ca7 = voxel_sh7.getConstantLocation("clipmaps");
+			voxel_cb7 = voxel_sh7.getConstantLocation("InvVP");
+			voxel_cc7 = voxel_sh7.getConstantLocation("cameraProj");
+			voxel_cd7 = voxel_sh7.getConstantLocation("eye");
+			voxel_ce7 = voxel_sh7.getConstantLocation("eyeLook");
+			voxel_cf7 = voxel_sh7.getConstantLocation("postprocess_resolution");
+			voxel_cg7 = voxel_sh7.getConstantLocation("lPos");
+		}
+		#end
 		#if (rp_voxels == "Voxel GI")
-		if (voxel_sh5 == null) {
+		if (voxel_sh5 == null)
+		{
 			voxel_sh5 = path.getComputeShader("voxel_light");
 			voxel_ta5 = voxel_sh5.getTextureUnit("voxelsLight");
 
@@ -918,10 +977,15 @@ class Inc {
 
 		kha.compute.Compute.setInt(voxel_cb1, iron.RenderPath.clipmapLevel);
 
-		#if (rp_voxels == "Voxel GI" && arm_deferred)
+		#if (rp_voxels == "Voxel GI")
+		#if arm_deferred
 		kha.compute.Compute.setSampledTexture(voxel_tg1, rts.get("gbuffer0").image);
 		kha.compute.Compute.setSampledTexture(voxel_th1, rts.get("gbuffer1").image);
-		#if rp_gbuffer2
+		#else
+		kha.compute.Compute.setSampledTexture(voxel_tg1, rts.get("lbuffer1").image);
+		kha.compute.Compute.setSampledTexture(voxel_th1, rts.get("lbuffer0").image);
+		#end
+		#if (rp_gbuffer2 && arm_deferred)
 		kha.compute.Compute.setSampledTexture(voxel_ti1, rts.get("gbuffer2").image);
 		#end
 		#if arm_brdf
@@ -953,7 +1017,7 @@ class Inc {
 		kha.compute.Compute.compute(Std.int(res / 8), Std.int(res / 8), Std.int(res / 8));
 	}
 
-	#if (arm_voxelgi_shadows || rp_voxels == "Voxel GI")
+	#if (arm_voxelgi_shadows || (rp_voxels == "Voxel GI"))
 	public static function computeVoxelsSDF() {
 		var rts = path.renderTargets;
 	 	var res = iron.RenderPath.getVoxelRes();
@@ -1003,7 +1067,6 @@ class Inc {
 	}
 	#end
 
-	#if arm_deferred
 	#if (rp_voxels == "Voxel AO")
 	public static function resolveAO() {
 		var rts = path.renderTargets;
@@ -1016,7 +1079,11 @@ class Inc {
 
 		kha.compute.Compute.setSampledTexture(voxel_ta3, rts.get("voxelsOut").image);
 		kha.compute.Compute.setSampledTexture(voxel_tb3, rts.get("half").image);
+		#if arm_deferred
 		kha.compute.Compute.setSampledTexture(voxel_tc3, rts.get("gbuffer0").image);
+		#else
+		kha.compute.Compute.setSampledTexture(voxel_tc3, rts.get("lbuffer1").image);
+		#end
 		kha.compute.Compute.setTexture(voxel_td3, rts.get("voxels_ao").image, kha.compute.Access.Write);
 
 		var fa:Float32Array = new Float32Array(Main.voxelgiClipmapCount * 10);
@@ -1073,9 +1140,8 @@ class Inc {
 		}
 		kha.compute.Compute.setFloat2(voxel_cf3, width, height);
 
-		kha.compute.Compute.compute(Std.int(width / 8), Std.int(height / 8), 1);
+		kha.compute.Compute.compute(Std.int((width + 7) / 8), Std.int((height + 7) / 8), 1);
 	}
-
 	#else
 	public static function resolveDiffuse() {
 		var rts = path.renderTargets;
@@ -1088,7 +1154,11 @@ class Inc {
 
 		kha.compute.Compute.setSampledTexture(voxel_ta3, rts.get("voxelsOut").image);
 		kha.compute.Compute.setSampledTexture(voxel_tb3, rts.get("half").image);
+		#if arm_deferred
 		kha.compute.Compute.setSampledTexture(voxel_tc3, rts.get("gbuffer0").image);
+		#else
+		kha.compute.Compute.setSampledTexture(voxel_tc3, rts.get("lbuffer1").image);
+		#end
 		kha.compute.Compute.setTexture(voxel_td3, rts.get("voxels_diffuse").image, kha.compute.Access.Write);
 
 		var fa:Float32Array = new Float32Array(Main.voxelgiClipmapCount * 10);
@@ -1145,7 +1215,7 @@ class Inc {
 		}
 		kha.compute.Compute.setFloat2(voxel_cf3, width, height);
 
-		kha.compute.Compute.compute(Std.int(width / 8), Std.int(height / 8), 1);
+		kha.compute.Compute.compute(Std.int((width + 7) / 8), Std.int((height + 7) / 8), 1);
 	}
 
 	public static function resolveSpecular() {
@@ -1159,7 +1229,11 @@ class Inc {
 
 		kha.compute.Compute.setSampledTexture(voxel_ta4, rts.get("voxelsOut").image);
 		kha.compute.Compute.setSampledTexture(voxel_tb4, rts.get("half").image);
+		#if arm_deferred
 		kha.compute.Compute.setSampledTexture(voxel_tc4, rts.get("gbuffer0").image);
+		#else
+		kha.compute.Compute.setSampledTexture(voxel_tc4, rts.get("lbuffer1").image);
+		#end
 		kha.compute.Compute.setSampledTexture(voxel_td4, rts.get("voxelsSDF").image);
 		kha.compute.Compute.setTexture(voxel_te4, rts.get("voxels_specular").image, kha.compute.Access.Write);
 
@@ -1217,10 +1291,175 @@ class Inc {
 		}
 		kha.compute.Compute.setFloat2(voxel_cf4, width, height);
 
-		kha.compute.Compute.compute(Std.int(width / 8), Std.int(height / 8), 1);
+		kha.compute.Compute.compute(Std.int((width + 7) / 8), Std.int((height + 7) / 8), 1);
 	}
+
+	#if arm_voxelgi_refract
+	public static function resolveRefraction() {
+		var rts = path.renderTargets;
+	 	var res = iron.RenderPath.getVoxelRes();
+	 	var camera = iron.Scene.active.camera;
+	 	var clipmaps = iron.RenderPath.clipmaps;
+	 	var clipmap = clipmaps[iron.RenderPath.clipmapLevel];
+
+		kha.compute.Compute.setShader(voxel_sh6);
+
+		kha.compute.Compute.setSampledTexture(voxel_ta6, rts.get("voxelsOut").image);
+		kha.compute.Compute.setSampledTexture(voxel_tb6, rts.get("half").image);
+		#if arm_deferred
+		kha.compute.Compute.setSampledTexture(voxel_tc6, rts.get("gbuffer0").image);
+		#else
+		kha.compute.Compute.setSampledTexture(voxel_tc6, rts.get("lbuffer1").image);
+		#end
+		kha.compute.Compute.setSampledTexture(voxel_td6, rts.get("voxelsSDF").image);
+		kha.compute.Compute.setTexture(voxel_te6, rts.get("voxels_refraction").image, kha.compute.Access.Write);
+		kha.compute.Compute.setSampledTexture(voxel_tf6, rts.get("gbuffer_refraction").image);
+
+		var fa:Float32Array = new Float32Array(Main.voxelgiClipmapCount * 10);
+		for (i in 0...Main.voxelgiClipmapCount) {
+			fa[i * 10] = clipmaps[i].voxelSize;
+			fa[i * 10 + 1] = clipmaps[i].extents.x;
+			fa[i * 10 + 2] = clipmaps[i].extents.y;
+			fa[i * 10 + 3] = clipmaps[i].extents.z;
+			fa[i * 10 + 4] = clipmaps[i].center.x;
+			fa[i * 10 + 5] = clipmaps[i].center.y;
+			fa[i * 10 + 6] = clipmaps[i].center.z;
+			fa[i * 10 + 7] = clipmaps[i].offset_prev.x;
+			fa[i * 10 + 8] = clipmaps[i].offset_prev.y;
+			fa[i * 10 + 9] = clipmaps[i].offset_prev.z;
+		}
+
+		kha.compute.Compute.setFloats(voxel_ca6, fa);
+
+		#if arm_centerworld
+		m.setFrom(vmat(camera.V));
+		#else
+		m.setFrom(camera.V);
+		#end
+		m.multmat(camera.P);
+		m.getInverse(m);
+
+		kha.compute.Compute.setMatrix(voxel_cb6, m.self);
+
+		var near = camera.data.raw.near_plane;
+		var far = camera.data.raw.far_plane;
+		var v = new iron.math.Vec2();
+		v.x = far / (far - near);
+		v.y = (-far * near) / (far - near);
+
+		kha.compute.Compute.setFloat2(voxel_cc6, v.x, v.y);
+
+
+		kha.compute.Compute.setFloat3(voxel_cd6, camera.transform.worldx(), camera.transform.worldy(), camera.transform.worldz());
+		var eyeLook = camera.lookWorld().normalize();
+		kha.compute.Compute.setFloat3(voxel_ce6, eyeLook.x, eyeLook.y, eyeLook.z);
+
+		var width = iron.App.w();
+		var height = iron.App.h();
+		var dp = getDisplayp();
+		if (dp != null) { // 1080p/..
+			if (width > height) {
+				width = Std.int(width * (dp / height));
+				height = dp;
+			}
+			else {
+				height = Std.int(height * (dp / width));
+				width = dp;
+			}
+		}
+		kha.compute.Compute.setFloat2(voxel_cf6, width, height);
+
+		kha.compute.Compute.compute(Std.int((width + 7) / 8), Std.int((height + 7) / 8), 1);
+	}
+	#end
 	#end // voxel ao
-	#end // deferred
+	#if arm_voxelgi_shadows
+	public static function resolveShadows() {
+		var rts = path.renderTargets;
+	 	var res = iron.RenderPath.getVoxelRes();
+	 	var camera = iron.Scene.active.camera;
+	 	var clipmaps = iron.RenderPath.clipmaps;
+	 	var clipmap = clipmaps[iron.RenderPath.clipmapLevel];
+		var lights = iron.Scene.active.lights;
+
+	 	for (i in 0...lights.length) {
+	 		var l = lights[i];
+	 		if (!l.visible) continue;
+	 		path.light = l;
+
+			kha.compute.Compute.setShader(voxel_sh7);
+
+	 		kha.compute.Compute.setSampledTexture(voxel_ta7, rts.get("voxelsOut").image);
+			kha.compute.Compute.setSampledTexture(voxel_tb7, rts.get("half").image);
+			#if arm_deferred
+			kha.compute.Compute.setSampledTexture(voxel_tc7, rts.get("gbuffer0").image);
+			#else
+			kha.compute.Compute.setSampledTexture(voxel_tc7, rts.get("lbuffer1").image);
+			#end
+			kha.compute.Compute.setSampledTexture(voxel_td7, rts.get("voxelsSDF").image);
+			kha.compute.Compute.setTexture(voxel_te7, rts.get("voxels_shadows").image, kha.compute.Access.Write);
+
+			var fa:Float32Array = new Float32Array(Main.voxelgiClipmapCount * 10);
+			for (i in 0...Main.voxelgiClipmapCount) {
+				fa[i * 10] = clipmaps[i].voxelSize;
+				fa[i * 10 + 1] = clipmaps[i].extents.x;
+				fa[i * 10 + 2] = clipmaps[i].extents.y;
+				fa[i * 10 + 3] = clipmaps[i].extents.z;
+				fa[i * 10 + 4] = clipmaps[i].center.x;
+				fa[i * 10 + 5] = clipmaps[i].center.y;
+				fa[i * 10 + 6] = clipmaps[i].center.z;
+				fa[i * 10 + 7] = clipmaps[i].offset_prev.x;
+				fa[i * 10 + 8] = clipmaps[i].offset_prev.y;
+				fa[i * 10 + 9] = clipmaps[i].offset_prev.z;
+			}
+
+			kha.compute.Compute.setFloats(voxel_ca7, fa);
+
+			#if arm_centerworld
+			m.setFrom(vmat(camera.V));
+			#else
+			m.setFrom(camera.V);
+			#end
+			m.multmat(camera.P);
+			m.getInverse(m);
+
+			kha.compute.Compute.setMatrix(voxel_cb7, m.self);
+
+			var near = camera.data.raw.near_plane;
+			var far = camera.data.raw.far_plane;
+			var v = new iron.math.Vec2();
+			v.x = far / (far - near);
+			v.y = (-far * near) / (far - near);
+
+			kha.compute.Compute.setFloat2(voxel_cc7, v.x, v.y);
+
+
+			kha.compute.Compute.setFloat3(voxel_cd7, camera.transform.worldx(), camera.transform.worldy(), camera.transform.worldz());
+			var eyeLook = camera.lookWorld().normalize();
+			kha.compute.Compute.setFloat3(voxel_ce7, eyeLook.x, eyeLook.y, eyeLook.z);
+
+			var width = iron.App.w();
+			var height = iron.App.h();
+			var dp = getDisplayp();
+			if (dp != null) { // 1080p/..
+				if (width > height) {
+					width = Std.int(width * (dp / height));
+					height = dp;
+				}
+				else {
+					height = Std.int(height * (dp / width));
+					width = dp;
+				}
+			}
+			kha.compute.Compute.setFloat2(voxel_cf7, width, height);
+
+	 		// lightPos
+	 		kha.compute.Compute.setFloat3(voxel_cg7, l.transform.worldx(), l.transform.worldy(), l.transform.worldz());
+
+			kha.compute.Compute.compute(Std.int((width + 7) / 8), Std.int((height + 7) / 8), 1);
+		}
+	}
+	#end
 
 	#if (rp_voxels == "Voxel GI")
 	public static function computeVoxelsLight() {
@@ -1302,7 +1541,7 @@ class Inc {
 	 		// LVP
 	 		m.setFrom(l.VP);
 	 		m.multmat(iron.object.Uniforms.biasMat);
-	 		/*
+
 	 		#if arm_shadowmap_atlas
 			if (l.data.raw.type == "sun")
 			{
@@ -1323,7 +1562,6 @@ class Inc {
 				#end
 			}
 			#end
-			*/
 	 		kha.compute.Compute.setMatrix(voxel_cj5, m.self);
 	 		// shadowsBias
 	 		kha.compute.Compute.setFloat(voxel_ck5, l.data.raw.shadows_bias);

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -762,27 +762,6 @@ class Inc {
 			voxel_td1 = voxel_sh1.getTextureUnit("voxelsSampler");
 			voxel_te1 = voxel_sh1.getTextureUnit("voxelsLight");
 			voxel_tf1 = voxel_sh1.getTextureUnit("SDF");
-
-			voxel_tg1 = voxel_sh1.getTextureUnit("gbuffer0");
-			voxel_th1 = voxel_sh1.getTextureUnit("gbuffer1");
-			#if (rp_gbuffer2 && arm_deferred)
-			voxel_ti1 = voxel_sh1.getTextureUnit("gbuffer2");
-			#end
-			#if arm_brdf
-			voxel_tj1 = voxel_sh1.getTextureUnit("senvmapBrdf");
-			#end
-			#if arm_radiance
-			voxel_tk1 = voxel_sh1.getTextureUnit("senvmapRadiance");
-			voxel_ce1 = voxel_sh1.getConstantLocation("envmapNumMipmaps");
-			#end
-			#if arm_irradiance
-			voxel_cc1 = voxel_sh1.getConstantLocation("shirr");
-			#end
-			voxel_cd1 = voxel_sh1.getConstantLocation("envmapStrength");
-			#if arm_envldr
-			voxel_cf1 = voxel_sh1.getConstantLocation("backgroundCol");
-			#end
-			voxel_cg1 = voxel_sh1.getConstantLocation("eye");
 			#else
 			#if arm_voxelgi_shadows
 			voxel_tf1 = voxel_sh1.getTextureUnit("SDF");
@@ -976,43 +955,6 @@ class Inc {
 		kha.compute.Compute.setFloats(voxel_ca1, fa);
 
 		kha.compute.Compute.setInt(voxel_cb1, iron.RenderPath.clipmapLevel);
-
-		#if (rp_voxels == "Voxel GI")
-		#if arm_deferred
-		kha.compute.Compute.setSampledTexture(voxel_tg1, rts.get("gbuffer0").image);
-		kha.compute.Compute.setSampledTexture(voxel_th1, rts.get("gbuffer1").image);
-		#else
-		kha.compute.Compute.setSampledTexture(voxel_tg1, rts.get("lbuffer1").image);
-		kha.compute.Compute.setSampledTexture(voxel_th1, rts.get("lbuffer0").image);
-		#end
-		#if (rp_gbuffer2 && arm_deferred)
-		kha.compute.Compute.setSampledTexture(voxel_ti1, rts.get("gbuffer2").image);
-		#end
-		#if arm_brdf
-		kha.compute.Compute.setSampledTexture(voxel_tj1, iron.Scene.active.embedded.get("brdf.png"));
-		#end
-		#if arm_radiance
-		kha.compute.Compute.setSampledTexture(voxel_tk1, iron.Scene.active.world.probe.radiance);
-		var w = iron.Scene.active.world;
-		var i = w != null ? w.probe.raw.radiance_mipmaps + 1 - 2 : 1;
-		kha.compute.Compute.setFloat(voxel_ce1, i);
-		#end
-		#if arm_irradiance
-		fa = iron.Scene.active.world == null ? iron.data.WorldData.getEmptyIrradiance() : iron.Scene.active.world.probe.irradiance;
-		kha.compute.Compute.setFloats(voxel_cc1, fa);
-		#end
-		kha.compute.Compute.setFloat(voxel_cd1, iron.Scene.active.world == null ? 0.0 : iron.Scene.active.world.probe.raw.strength);
-
-		#if arm_envldr
-		var envCol:iron.math.Vec3;
-		if (camera.data.raw.clear_color != null)
-			envCol = new iron.math.Vec3(camera.data.raw.clear_color[0], camera.data.raw.clear_color[1], camera.data.raw.clear_color[2]);
-		else
-			envCol = new iron.math.Vec3(0.0);
-		kha.compute.Compute.setFloat3(voxel_cf1, envCol.x, envCol.y, envCol.z);
-		#end
-		kha.compute.Compute.setFloat3(voxel_cg1, camera.transform.worldx(), camera.transform.worldy(), camera.transform.worldz());
-		#end
 
 		kha.compute.Compute.compute(Std.int(res / 8), Std.int(res / 8), Std.int(res / 8));
 	}
@@ -1501,7 +1443,11 @@ class Inc {
 	 		#if rp_shadowmap
 	 		if (l.data.raw.type == "sun") {
 				#if arm_shadowmap_atlas
+				#if arm_shadowmap_atlas_single_map
+	 			kha.compute.Compute.setSampledTexture(voxel_tb5, rts.get("shadowMapAtlas").image);
+	 			#else
 	 			kha.compute.Compute.setSampledTexture(voxel_tb5, rts.get("shadowMapAtlasSun").image);
+	 			#end
 	 			#else
 	 			kha.compute.Compute.setSampledTexture(voxel_tb5, rts.get("shadowMap").image);
 	 			#end
@@ -1509,7 +1455,11 @@ class Inc {
 	 		}
 	 		else if (l.data.raw.type == "spot" || l.data.raw.type == "area") {
 				#if arm_shadowmap_atlas
+				#if arm_shadowmap_atlas_single_map
+	 			kha.compute.Compute.setSampledTexture(voxel_tc5, rts.get("shadowMapAtlas").image);
+	 			#else
 	 			kha.compute.Compute.setSampledTexture(voxel_tc5, rts.get("shadowMapAtlasSpot").image);
+	 			#end
 	 			#else
 	 			kha.compute.Compute.setSampledTexture(voxel_tc5, rts.get("shadowMapSpot[" + spotIndex + "]").image);
 	 			spotIndex++;
@@ -1518,7 +1468,11 @@ class Inc {
 	 		}
 	 		else {
 				#if arm_shadowmap_atlas
+				#if arm_shadowmap_atlas_single_map
+				kha.compute.Compute.setSampledTexture(voxel_td5, rts.get("shadowMapAtlas").image);
+				#else
 				kha.compute.Compute.setSampledTexture(voxel_td5, rts.get("shadowMapAtlasPoint").image);
+				#end
 				kha.compute.Compute.setInt(voxel_cl5, i);
 				kha.compute.Compute.setFloats(voxel_cm5, iron.object.LightObject.pointLightsData);
 				#else

--- a/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -354,7 +354,7 @@ class RenderPathDeferred {
 			t.width = 0;
 			t.height = 0;
 			t.displayp = Inc.getDisplayp();
-			t.depth_buffer = "main";
+			//t.depth_buffer = "main";
 			t.format = "RGBA64";
 			t.scale = Inc.getSuperSampling();
 			path.createRenderTarget(t);
@@ -472,11 +472,6 @@ class RenderPathDeferred {
 			path.setTarget("gbuffer2");
 			path.clearTarget(0xff000000);
 		}
-		#end
-
-		#if (arm_voxelgi_refract || rp_ssrefr)
-		path.setTarget("gbuffer_refraction");
-		path.clearTarget(0xff000000);
 		#end
 
 		RenderPathCreator.setTargetMeshes();
@@ -861,6 +856,7 @@ class RenderPathDeferred {
 				path.drawMeshes("refraction");
 
 				#if arm_voxelgi_refract
+				//we need the updated half depth to resolve the refraction objects writen by the 'refraction' pass
 				path.setTarget("half");
 				path.bindTarget("_main", "texdepth");
 				path.drawShader("shader_datas/downsample_depth/downsample_depth");

--- a/Sources/armory/renderpath/RenderPathForward.hx
+++ b/Sources/armory/renderpath/RenderPathForward.hx
@@ -24,7 +24,7 @@ class RenderPathForward {
 		{
 			path.setTarget("lbuffer0", [
 				#if (rp_ssr || rp_ssrefr) "lbuffer1",  #end
-				#if rp_ssrefr "gbuffer_refraction" #end]
+				#if (rp_ssrefr || arm_voxelgi_refract) "gbuffer_refraction" #end]
 			);
 		}
 		#else
@@ -105,7 +105,7 @@ class RenderPathForward {
 			t.depth_buffer = "main";
 			path.createRenderTarget(t);
 
-			#if (rp_ssr || rp_ssrefr)
+			#if rp_ssr
 			{
 				var t = new RenderTargetRaw();
 				t.name = "lbuffer1";
@@ -118,7 +118,7 @@ class RenderPathForward {
 			}
 			#end
 
-			#if rp_ssrefr
+			#if (rp_ssrefr || arm_voxelgi_refract)
 			{
 				//holds ior and opacity
 				var t = new RenderTargetRaw();
@@ -128,8 +128,13 @@ class RenderPathForward {
 				t.displayp = Inc.getDisplayp();
 				t.format = "RGBA64";
 				t.scale = Inc.getSuperSampling();
+				t.depth_buffer = "main";
 				path.createRenderTarget(t);
+			}
+			#end
 
+			#if rp_ssrefr
+			{
 				//holds colors before refractive meshes are drawn
 				var t = new RenderTargetRaw();
 				t.name = "refr";
@@ -138,7 +143,6 @@ class RenderPathForward {
 				t.displayp = Inc.getDisplayp();
 				t.format = "RGBA64";
 				t.scale = Inc.getSuperSampling();
-				t.depth_buffer = "main";
 				path.createRenderTarget(t);
 
 				//holds background depth
@@ -196,12 +200,22 @@ class RenderPathForward {
 			Inc.initGI("voxels");
 			Inc.initGI("voxelsOut");
 			Inc.initGI("voxelsOutB");
-			#if (arm_voxelgi_shadows || rp_voxels == "Voxel GI")
+			#if (arm_voxelgi_shadows || (rp_voxels == "Voxel GI"))
 			Inc.initGI("voxelsSDF");
 			Inc.initGI("voxelsSDFtmp");
 			#end
+			#if arm_voxelgi_shadows
+			Inc.initGI("voxels_shadows");
+			#end
 			#if (rp_voxels == "Voxel GI")
 			Inc.initGI("voxelsLight");
+			Inc.initGI("voxels_diffuse");
+			Inc.initGI("voxels_specular");
+			#if arm_voxelgi_refract
+			Inc.initGI("voxels_refraction");
+			#end
+			#else
+			Inc.initGI("voxels_ao");
 			#end
 			iron.RenderPath.clipmaps = new Array<Clipmap>();
 			for (i in 0...Main.voxelgiClipmapCount) {
@@ -352,7 +366,6 @@ class RenderPathForward {
 	}
 
 	public static function commands() {
-
 		#if rp_shadowmap
 		{
 			#if arm_shadowmap_atlas
@@ -379,7 +392,7 @@ class RenderPathForward {
 				path.clearImage("voxels", 0x00000000);
 				path.clearImage("voxelsOut", 0x00000000);
 				path.clearImage("voxelsOutB", 0x00000000);
-				#if (arm_voxelgi_shadows || rp_voxels == "Voxel GI")
+				#if (arm_voxelgi_shadows || (rp_voxels == "Voxel GI"))
 				path.clearImage("voxelsSDF", 0x00000000);
 				path.clearImage("voxelsSDFtmp", 0x00000000);
 				#end
@@ -387,6 +400,9 @@ class RenderPathForward {
 			}
 			else
 			{
+				#if (rp_voxels == "Voxel GI")
+				path.clearImage("voxelsLight", 0x00000000);
+				#end
 				path.clearImage("voxels", 0x00000000);
 				Inc.computeVoxelsOffsetPrev();
 			}
@@ -403,10 +419,26 @@ class RenderPathForward {
 			#end
 			Inc.computeVoxelsTemporal();
 
-			#if (arm_voxelgi_shadows || rp_voxels == "Voxel GI")
+			#if (arm_voxelgi_shadows || (rp_voxels == "Voxel GI"))
 			Inc.computeVoxelsSDF();
 			#end
 
+			if (iron.RenderPath.res_pre_clear == true)
+			{
+				iron.RenderPath.res_pre_clear = false;
+				#if (rp_voxels == "Voxel GI")
+				path.clearImage("voxels_diffuse", 0x00000000);
+				path.clearImage("voxels_specular", 0x00000000);
+				#if arm_voxelgi_refract
+				path.clearImage("voxels_refraction", 0x00000000);
+				#end
+				#else
+				path.clearImage("voxels_ao", 0x00000000);
+				#end
+				#if arm_voxelgi_shadows
+				path.clearImage("voxels_shadows", 0x00000000);
+				#end
+			}
 		}
 		#end
 
@@ -425,9 +457,10 @@ class RenderPathForward {
 		#if rp_depthprepass
 		{
 			path.drawMeshes("depth");
-			RenderPathCreator.setTargetMeshes();
 		}
 		#end
+
+		RenderPathCreator.setTargetMeshes();
 
 		#if rp_shadowmap
 		{
@@ -443,9 +476,18 @@ class RenderPathForward {
 		#if (rp_voxels != "Off")
 		if (armory.data.Config.raw.rp_gi != false)
 		{
-			path.bindTarget("voxelsOut", "voxels");
-			#if (arm_voxelgi_shadows || rp_voxels == "Voxel GI")
-			path.bindTarget("voxelsSDF", "voxelsSDF");
+			#if (rp_voxels == "Voxel AO")
+			Inc.resolveAO();
+			path.bindTarget("voxels_ao", "voxels_ao");
+			#else
+			Inc.resolveDiffuse();
+			Inc.resolveSpecular();
+			path.bindTarget("voxels_diffuse", "voxels_diffuse");
+			path.bindTarget("voxels_specular", "voxels_specular");
+			#end
+			#if arm_voxelgi_shadows
+			Inc.resolveShadows();
+			path.bindTarget("voxels_shadows", "voxels_shadows");
 			#end
 		}
 		#end
@@ -480,10 +522,33 @@ class RenderPathForward {
 					path.bindTarget("lbuffer0", "tex");
 					path.drawShader("shader_datas/copy_pass/copy_pass");
 
-					RenderPathCreator.setTargetMeshes();
+					path.setTarget("lbuffer0", ["lbuffer1", "gbuffer_refraction"]);
+
+					#if (rp_voxels != "Off")
+					#if (rp_voxels == "Voxel AO")
+					path.bindTarget("voxels_ao", "voxels_ao");
+					#else
+					path.bindTarget("voxels_diffuse", "voxels_diffuse");
+					path.bindTarget("voxels_specular", "voxels_specular");
+					#end
+					#end
+					#if arm_voxelgi_shadows
+					path.bindTarget("voxels_shadows", "voxels_shadows");
+					#end
+
 					path.drawMeshes("refraction");
 
+					#if arm_voxelgi_refract
+					path.setTarget("half");
+					path.bindTarget("_main", "texdepth");
+					path.drawShader("shader_datas/downsample_depth/downsample_depth");
+					Inc.resolveRefraction();
+					#end
+
 					path.setTarget("lbuffer0");
+					#if arm_voxelgi_refract
+					path.bindTarget("voxels_refraction", "voxels_refraction");
+					#end
 					path.bindTarget("refr", "tex1");
 					path.bindTarget("lbuffer0", "tex");
 					path.bindTarget("_main", "gbufferD");

--- a/blender/arm/logicnode/string/LN_string_charat.py
+++ b/blender/arm/logicnode/string/LN_string_charat.py
@@ -1,0 +1,18 @@
+from arm.logicnode.arm_nodes import *
+
+
+class StringCharAtNode(ArmLogicTreeNode):
+    """String CharAt"""
+    bl_idname = 'LNStringCharAtNode'
+    bl_label = 'String CharAt'
+    bl_description = 'Returns the character at position index of the String. If the index is negative or exceeds the string.length, an empty String "" is returned.'
+    arm_category = 'String'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmStringSocket', 'String')
+        self.add_input('ArmIntSocket', 'Index')
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('ArmStringSocket', 'Char')

--- a/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -310,7 +310,6 @@ def parse_tex_sky(node: bpy.types.ShaderNodeTexSky, out_socket: bpy.types.NodeSo
     if node.sky_type == 'PREETHAM' or node.sky_type == 'HOSEK_WILKIE':
         if node.sky_type == 'PREETHAM':
             log.info('Info: Preetham sky model is not supported, using Hosek Wilkie sky model instead')
-
         return parse_sky_hosekwilkie(node, state)
 
     elif node.sky_type == 'NISHITA':
@@ -352,6 +351,8 @@ def parse_sky_hosekwilkie(node: bpy.types.ShaderNodeTexSky, state: ParserState) 
     wrd = bpy.data.worlds['Arm']
     rpdat = arm.utils.get_rp()
     mobile_mat = rpdat.arm_material_model == 'Mobile' or rpdat.arm_material_model == 'Solid'
+
+    wrd.world_defs += '_HOSEK'
 
     if not state.radiance_written:
         # Irradiance json file name

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -85,7 +85,7 @@ def write(vert: shader.Shader, frag: shader.Shader):
         frag.write('\t, lightsArraySpot[li * 2 + 1].xyz') # right
     if '_VoxelShadow' in wrd.world_defs:
         frag.add_uniform("sampler2D voxels_shadows", top=True)
-        frag.write(', gl_FragCoord.xy')
+        frag.write(', texCoord')
     if '_MicroShadowing' in wrd.world_defs and not is_mobile:
         frag.write('\t, occlusion')
     frag.write(');')

--- a/blender/arm/material/make_cluster.py
+++ b/blender/arm/material/make_cluster.py
@@ -84,10 +84,8 @@ def write(vert: shader.Shader, frag: shader.Shader):
         frag.write('\t, vec2(lightsArray[li * 3].w, lightsArray[li * 3 + 1].w)') # scale
         frag.write('\t, lightsArraySpot[li * 2 + 1].xyz') # right
     if '_VoxelShadow' in wrd.world_defs:
-            frag.write(', voxels')
-            frag.write(', voxelsSDF')
-            frag.write(', clipmaps')
-        
+        frag.add_uniform("sampler2D voxels_shadows", top=True)
+        frag.write(', gl_FragCoord.xy')
     if '_MicroShadowing' in wrd.world_defs and not is_mobile:
         frag.write('\t, occlusion')
     frag.write(');')

--- a/blender/arm/material/make_depth.py
+++ b/blender/arm/material/make_depth.py
@@ -45,6 +45,7 @@ def make(context_id, rpasses, shadowmap=False):
 
     vert.write_attrib('vec4 spos = vec4(pos.xyz, 1.0);')
     vert.add_include('compiled.inc')
+    frag.add_include('compiled.inc')
 
     parse_opacity = 'translucent' in rpasses or mat_state.material.arm_discard or 'refraction' in rpasses
 

--- a/blender/arm/material/make_finalize.py
+++ b/blender/arm/material/make_finalize.py
@@ -75,7 +75,7 @@ def make(con_mesh: ShaderContext):
     if export_wpos:
         vert.add_uniform('mat4 W', '_worldMatrix')
         vert.add_out('vec3 wposition')
-        vert.write_attrib('wposition = vec4(W * spos).xyz;')
+        vert.write('wposition = vec4(W * spos).xyz;')
     elif write_wpos:
         vert.add_uniform('mat4 W', '_worldMatrix')
         vert.write_attrib('vec3 wposition = vec4(W * spos).xyz;')

--- a/blender/arm/material/make_mesh.py
+++ b/blender/arm/material/make_mesh.py
@@ -667,23 +667,25 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
     else:
         frag.write('vec3 indirect = envl;')
 
+    # Computing texCoord in vertex shader from pos.xy doesn't work
+    if '_VoxelAOvar' in wrd.world_defs or '_VoxelGI' in wrd.world_defs:
+        rpdat = arm.utils.get_rp()
+        resx, resy = arm.utils.get_render_resolution(arm.utils.get_active_scene())
+        if rpdat.arm_rp_resolution == 'Custom':
+            if resx > resy:
+                resx = int(resx * (rpdat.arm_rp_resolution_size / resy));
+                resy = rpdat.arm_rp_resolution_size;
+            else:
+                resy = int(resy * (rpdat.arm_rp_resolution_size / resx));
+                resx = rpdat.arm_rp_resolution_size;
+        frag.write(f'vec2 texCoord = gl_FragCoord.xy / vec2({resx}, {resy});')
+
     if '_VoxelAOvar' in wrd.world_defs:
         frag.add_uniform("sampler2D voxels_ao");
-        vert.add_out('vec2 texCoord')
-        vert.write('const vec2 madd = vec2(0.5, 0.5);')
-        vert.write('texCoord = pos.xy * madd + madd;')
-        if '_InvY' in wrd.world_defs:
-            frag.write('texCoord.y = 1.0 - texCoord.y;')
-        frag.write('indirect *= textureLod(voxels_ao, texCoord.xy, 0.0).r;')
 
     if '_VoxelGI' in wrd.world_defs:
         frag.add_uniform("sampler2D voxels_diffuse")
         frag.add_uniform("sampler2D voxels_specular")
-        vert.add_out('vec2 texCoord')
-        vert.write('const vec2 madd = vec2(0.5, 0.5);')
-        vert.write('texCoord = pos.xy * madd + madd;')
-        if '_InvY' in wrd.world_defs:
-            vert.write('texCoord.y = 1.0 - texCoord.y;')
         frag.write("indirect = textureLod(voxels_diffuse, texCoord, 0.0).rgb * albedo * voxelgiDiff;")
         frag.write("if (roughness < 1.0 && specular > 0.0)")
         frag.write("    indirect += textureLod(voxels_specular, texCoord, 0.0).rgb * specular * voxelgiRefl;")
@@ -728,7 +730,7 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
             frag.write('}') # receiveShadow
         if '_VoxelShadow' in wrd.world_defs:
             frag.add_uniform('sampler2D voxels_shadows', top=True)
-            frag.write('svisibility *= textureLod(voxels_shadows, gl_FragCoord.xy, 0.0).r * voxelgiShad;')
+            frag.write('svisibility *= textureLod(voxels_shadows, texCoord, 0.0).r * voxelgiShad;')
         frag.write('direct += (lambertDiffuseBRDF(albedo, sdotNL) + specularBRDF(f0, roughness, sdotNL, sdotNH, dotNV, sdotVH) * specular) * sunCol * svisibility;')
         # sun
 
@@ -757,7 +759,7 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
             frag.write(', true, spotData.x, spotData.y, spotDir, spotData.zw, spotRight')
         if '_VoxelShadow' in wrd.world_defs:
             frag.add_uniform("sampler2D voxels_shadows", top=True)
-            frag.write(', gl_FragCoord.xy')
+            frag.write(', texCoord')
         if '_MicroShadowing' in wrd.world_defs:
             frag.write(', occlusion')
         frag.write(');')

--- a/blender/arm/material/make_refract.py
+++ b/blender/arm/material/make_refract.py
@@ -19,6 +19,7 @@ else:
 
 def make(context_id):
     con_refract = mat_state.data.add_context({ 'name': context_id, 'depth_write': True, 'compare_mode': 'less', 'cull_mode': 'clockwise' })
+    con_refract.data["vertex_elements"].append({'name' : 'pos', 'data' : 'short4norm'})
 
     make_mesh.make_forward_base(con_refract, parse_opacity=True, transluc_pass=True)
 

--- a/blender/arm/material/make_refraction_buffer.py
+++ b/blender/arm/material/make_refraction_buffer.py
@@ -1,0 +1,54 @@
+import bpy
+
+import arm
+import arm.material.cycles as cycles
+import arm.material.mat_state as mat_state
+import arm.material.mat_utils as mat_utils
+import arm.material.make_mesh as make_mesh
+import arm.material.make_finalize as make_finalize
+import arm.assets as assets
+
+if arm.is_reload(__name__):
+	cycles = arm.reload_module(cycles)
+	mat_state = arm.reload_module(mat_state)
+	make_mesh = arm.reload_module(make_mesh)
+	make_finalize = arm.reload_module(make_finalize)
+	assets = arm.reload_module(assets)
+else:
+	arm.enable_reload(__name__)
+
+
+def make(context_id):
+    con_refraction_buffer = mat_state.data.add_context({ 'name': context_id, 'depth_write': True, 'compare_mode': 'less', 'cull_mode': 'clockwise' })
+
+    arm_discard = mat_state.material.arm_discard
+    blend = mat_state.material.arm_blending
+    is_transluc = mat_utils.is_transluc(mat_state.material)
+    parse_opacity = (blend and is_transluc) or arm_discard
+
+    make_mesh.make_base(con_refraction_buffer, parse_opacity)
+
+    vert = con_refraction_buffer.vert
+    frag = con_refraction_buffer.frag
+    tese = con_refraction_buffer.tese
+
+    frag.add_include('std/gbuffer.glsl')
+    frag.add_out('vec4 fragColor')
+
+    # Remove fragColor = ...;
+    frag.main = frag.main[:frag.main.rfind('fragColor')]
+    frag.write('\n')
+
+    wrd = bpy.data.worlds['Arm']
+
+    if parse_opacity:
+        frag.write('fragColor = vec4(ior, opacity, 0.0, 0.0);')
+    else:
+        frag.write('fragColor = vec4(1.0, 1.0, 0.0, 0.0);')
+
+    make_finalize.make(con_refraction_buffer)
+
+    # assets.vs_equal(con_refract, assets.shader_cons['transluc_vert']) # shader_cons has no transluc yet
+    # assets.fs_equal(con_refract, assets.shader_cons['transluc_frag'])
+
+    return con_refraction_buffer

--- a/blender/arm/material/make_transluc.py
+++ b/blender/arm/material/make_transluc.py
@@ -18,34 +18,34 @@ else:
 
 
 def make(context_id):
-	con_transluc = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'less', 'cull_mode': 'clockwise', \
+    con_transluc = mat_state.data.add_context({ 'name': context_id, 'depth_write': False, 'compare_mode': 'less', 'cull_mode': 'clockwise', \
 		'blend_source': 'blend_one', 'blend_destination': 'blend_one', 'blend_operation': 'add', \
 		'alpha_blend_source': 'blend_zero', 'alpha_blend_destination': 'inverse_source_alpha', 'alpha_blend_operation': 'add' })
 
-	make_mesh.make_forward_base(con_transluc, parse_opacity=True, transluc_pass=True)
+    make_mesh.make_forward_base(con_transluc, parse_opacity=True, transluc_pass=True)
 
-	vert = con_transluc.vert
-	frag = con_transluc.frag
-	tese = con_transluc.tese
+    vert = con_transluc.vert
+    frag = con_transluc.frag
+    tese = con_transluc.tese
 
-	frag.add_out('vec4 fragColor[2]')
+    frag.add_out('vec4 fragColor[2]')
 
-	# Remove fragColor = ...;
-	frag.main = frag.main[:frag.main.rfind('fragColor')]
-	frag.write('\n')
+    # Remove fragColor = ...;
+    frag.main = frag.main[:frag.main.rfind('fragColor')]
+    frag.write('\n')
 
-	wrd = bpy.data.worlds['Arm']
-	if '_VoxelAOvar' in wrd.world_defs:
-		frag.write('indirect *= 0.25;')
-	frag.write('vec4 premultipliedReflect = vec4(vec3(direct + indirect * 0.5) * opacity, opacity);')
+    wrd = bpy.data.worlds['Arm']
+    if '_VoxelAOvar' in wrd.world_defs:
+        frag.write('indirect *= 0.25;')
+    frag.write('vec4 premultipliedReflect = vec4(vec3(direct + indirect * 0.5) * opacity, opacity);')
 
-	frag.write('float w = clamp(pow(min(1.0, premultipliedReflect.a * 10.0) + 0.01, 3.0) * 1e8 * pow(1.0 - (gl_FragCoord.z) * 0.9, 3.0), 1e-2, 3e3);')
-	frag.write('fragColor[0] = vec4(premultipliedReflect.rgb * w, premultipliedReflect.a);')
-	frag.write('fragColor[1] = vec4(premultipliedReflect.a * w, 0.0, 0.0, 1.0);')
+    frag.write('float w = clamp(pow(min(1.0, premultipliedReflect.a * 10.0) + 0.01, 3.0) * 1e8 * pow(1.0 - (gl_FragCoord.z) * 0.9, 3.0), 1e-2, 3e3);')
+    frag.write('fragColor[0] = vec4(premultipliedReflect.rgb * w, premultipliedReflect.a);')
+    frag.write('fragColor[1] = vec4(premultipliedReflect.a * w, 0.0, 0.0, 1.0);')
 
-	make_finalize.make(con_transluc)
+    make_finalize.make(con_transluc)
 
-	# assets.vs_equal(con_transluc, assets.shader_cons['transluc_vert']) # shader_cons has no transluc yet
+    # assets.vs_equal(con_transluc, assets.shader_cons['transluc_vert']) # shader_cons has no transluc yet
     # assets.fs_equal(con_transluc, assets.shader_cons['transluc_frag'])
 
-	return con_transluc
+    return con_transluc

--- a/blender/arm/material/make_voxel.py
+++ b/blender/arm/material/make_voxel.py
@@ -29,10 +29,6 @@ import arm.material.mat_utils as mat_utils
 import arm.material.make_particle as make_particle
 import arm.make_state as state
 
-import arm.utils
-import arm.assets as assets
-import arm.material.mat_state as mat_state
-
 if arm.is_reload(__name__):
     arm.utils = arm.reload_module(arm.utils)
     assets = arm.reload_module(assets)
@@ -76,6 +72,7 @@ def make_gi(context_id):
     rpdat = arm.utils.get_rp()
     frag.add_uniform('layout(r32ui) uimage3D voxels')
 
+    frag.write('vec3 n;')
     frag.write('vec3 wposition;')
     frag.write('vec3 basecol;')
     frag.write('float roughness;') #
@@ -83,7 +80,8 @@ def make_gi(context_id):
     frag.write('float occlusion;') #
     frag.write('float specular;') #
     frag.write('vec3 emissionCol = vec3(0.0);')
-    parse_opacity = rpdat.arm_voxelgi_refraction
+    blend = mat_state.material.arm_blending
+    parse_opacity = blend or mat_utils.is_transluc(mat_state.material)
     if parse_opacity:
         frag.write('float opacity;')
         frag.write('float ior;')
@@ -91,7 +89,7 @@ def make_gi(context_id):
         frag.write('float opacity = 1.0;')
 
     frag.write('float dotNV = 0.0;')
-    cycles.parse(mat_state.nodes, con_voxel, vert, frag, geom, tesc, tese, parse_opacity=False, parse_displacement=False, basecol_only=True)
+    cycles.parse(mat_state.nodes, con_voxel, vert, frag, geom, tesc, tese, parse_opacity=parse_opacity, parse_displacement=False, basecol_only=True)
 
     # Voxelized particles
     particle = mat_state.material.arm_particle_flag
@@ -199,19 +197,66 @@ def make_gi(context_id):
     frag.write('uvw = (uvw * 0.5 + 0.5);')
     frag.write('if(any(notEqual(uvw, clamp(uvw, 0.0, 1.0)))) return;')
     frag.write('vec3 writecoords = floor(uvw * voxelgiResolution);')
-    frag.write_attrib('vec3 n = normalize(voxnormal);')
-    frag.write('vec3 aniso_direction = n;')
+    frag.write_attrib('vec3 N = normalize(voxnormal);')
+    frag.write('vec3 aniso_direction = N;')
     frag.write('uvec3 face_offsets = uvec3(')
     frag.write('    aniso_direction.x > 0 ? 0 : 1,')
     frag.write('    aniso_direction.y > 0 ? 2 : 3,')
     frag.write('    aniso_direction.z > 0 ? 4 : 5')
     frag.write('    ) * voxelgiResolution;')
-    frag.write('vec3 direction_weights = abs(n);')
+    frag.write('vec3 direction_weights = abs(N);')
+
+    frag.write('vec3 albedo = surfaceAlbedo(basecol, metallic);')
+    frag.write('vec3 f0 = surfaceF0(basecol, metallic);')
+
+    frag.add_uniform('vec3 eye', '_cameraPosition')
+    frag.write('vec3 eyeDir = eye - wposition;')
+
+    if '_Brdf' in wrd.world_defs:
+        frag.add_uniform('sampler2D senvmapBrdf', link='$brdf.png')
+        frag.write('vec2 envBRDF = texelFetch(senvmapBrdf, ivec2(vec2(dotNV, 1.0 - roughness) * 256.0), 0).xy;')
+
+    if '_Irr' in wrd.world_defs:
+        frag.add_include('std/shirr.glsl')
+        frag.add_uniform('vec4 shirr[7]', link='_envmapIrradiance')
+        frag.write('vec3 envl = shIrradiance(n, shirr);')
+        if '_EnvTex' in wrd.world_defs:
+            frag.write('envl /= PI;')
+    else:
+        frag.write('vec3 envl = vec3(0.0);')
+
+    if '_Rad' in wrd.world_defs:
+        frag.add_uniform('sampler2D senvmapRadiance', link='_envmapRadiance')
+        frag.add_uniform('int envmapNumMipmaps', link='_envmapNumMipmaps')
+        frag.write('vec3 reflectionWorld = reflect(-eyeDir, n);')
+        frag.write('float lod = getMipFromRoughness(roughness, envmapNumMipmaps);')
+        frag.write('vec3 prefilteredColor = textureLod(senvmapRadiance, envMapEquirect(reflectionWorld), lod).rgb;')
+
+    if '_EnvLDR' in wrd.world_defs:
+        frag.write('envl = pow(envl, vec3(2.2));')
+        if '_Rad' in wrd.world_defs:
+            frag.write('prefilteredColor = pow(prefilteredColor, vec3(2.2));')
+
+    frag.write('envl *= albedo;')
+
+    if '_Brdf' in wrd.world_defs:
+        frag.write('envl.rgb *= 1.0 - (f0 * envBRDF.x + envBRDF.y);')
+    if '_Rad' in wrd.world_defs:
+        frag.write('envl += prefilteredColor * (f0 * envBRDF.x + envBRDF.y);')
+    elif '_EnvCol' in wrd.world_defs:
+        frag.add_uniform('vec3 backgroundCol', link='_backgroundCol')
+        frag.write('envl += backgroundCol * (f0 * envBRDF.x + envBRDF.y);')
+
+    frag.add_uniform('float envmapStrength', link='_envmapStrength')
+    frag.write('envl *= envmapStrength * occlusion;')
 
     frag.write('if (direction_weights.x > 0) {')
     frag.write('    vec4 basecol_direction = vec4(min(basecol * direction_weights.x, vec3(1.0)), opacity);')
-    frag.write('    vec3 emission_direction = min(emissionCol * direction_weights.x, vec3(1.0));')
-    frag.write('    vec2 normal_direction = encode_oct(n * direction_weights.x) * 0.5 + 0.5;')
+    frag.write('    vec3 emission_direction = emissionCol * direction_weights.x;')
+    frag.write('    vec2 normal_direction = encode_oct(N * direction_weights.x) * 0.5 + 0.5;')
+    frag.write('    float roughness_direction = roughness * direction_weights.x;')
+    frag.write('    float metallic_direction = metallic * direction_weights.x;')
+    frag.write('    vec3 envl_direction = envl * direction_weights.x;')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, 0)), uint(basecol_direction.r * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x)), uint(basecol_direction.g * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x * 2)), uint(basecol_direction.b * 255));')
@@ -221,13 +266,20 @@ def make_gi(context_id):
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x * 6)), uint(emission_direction.b * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x * 7)), uint(normal_direction.r * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x * 8)), uint(normal_direction.g * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x * 9)), uint(roughness_direction * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x * 10)), uint(metallic_direction * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x * 11)), uint(envl_direction.r * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x * 12)), uint(envl_direction.g * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, voxelgiResolution.x * 13)), uint(envl_direction.b * 255));')
     frag.write('}')
-
 
     frag.write('if (direction_weights.y > 0) {')
     frag.write('    vec4 basecol_direction = vec4(min(basecol * direction_weights.y, vec3(1.0)), opacity);')
-    frag.write('    vec3 emission_direction = min(emissionCol * direction_weights.y, vec3(1.0));')
-    frag.write('    vec2 normal_direction = encode_oct(n * direction_weights.y) * 0.5 + 0.5;')
+    frag.write('    vec3 emission_direction = emissionCol * direction_weights.y;')
+    frag.write('    vec2 normal_direction = encode_oct(N * direction_weights.y) * 0.5 + 0.5;')
+    frag.write('    float roughness_direction = roughness * direction_weights.y;')
+    frag.write('    float metallic_direction = metallic * direction_weights.y;')
+    frag.write('    vec3 envl_direction = envl * direction_weights.y;')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, 0)), uint(basecol_direction.r * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x)), uint(basecol_direction.g * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x * 2)), uint(basecol_direction.b * 255));')
@@ -237,13 +289,20 @@ def make_gi(context_id):
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x * 6)), uint(emission_direction.b * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x * 7)), uint(normal_direction.r * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x * 8)), uint(normal_direction.g * 255));')
-
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x * 9)), uint(roughness_direction * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x * 10)), uint(metallic_direction * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x * 11)), uint(envl_direction.r * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x * 12)), uint(envl_direction.g * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, voxelgiResolution.x * 13)), uint(envl_direction.b * 255));')
     frag.write('}')
 
     frag.write('if (direction_weights.z > 0) {')
     frag.write('    vec4 basecol_direction = vec4(min(basecol * direction_weights.z, vec3(1.0)), opacity);')
-    frag.write('    vec3 emission_direction = min(emissionCol * direction_weights.z, vec3(1.0));')
+    frag.write('    vec3 emission_direction = emissionCol * direction_weights.z;')
     frag.write('    vec2 normal_direction = encode_oct(n * direction_weights.z) * 0.5 + 0.5;')
+    frag.write('    float roughness_direction = roughness * direction_weights.z;')
+    frag.write('    float metallic_direction = metallic * direction_weights.z;')
+    frag.write('    vec3 envl_direction = envl * direction_weights.z;')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, 0)), uint(basecol_direction.r * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x)), uint(basecol_direction.g * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x * 2)), uint(basecol_direction.b * 255));')
@@ -253,6 +312,11 @@ def make_gi(context_id):
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x * 6)), uint(emission_direction.b * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x * 7)), uint(normal_direction.r * 255));')
     frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x * 8)), uint(normal_direction.g * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x * 9)), uint(roughness_direction * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x * 10)), uint(metallic_direction * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x * 11)), uint(envl_direction.r * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x * 12)), uint(envl_direction.g * 255));')
+    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, voxelgiResolution.x * 13)), uint(envl_direction.b * 255));')
     frag.write('}')
 
     return con_voxel
@@ -436,15 +500,15 @@ def make_ao(context_id):
     frag.write('vec3 direction_weights = abs(N);')
 
     frag.write('if (direction_weights.x > 0) {')
-    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, 0)), uint(direction_weights.x * 255));')
+    frag.write('    imageAtomicAdd(voxels, ivec3(writecoords + ivec3(face_offsets.x, 0, 0)), uint(direction_weights.x * 255));')
     frag.write('}')
 
     frag.write('if (direction_weights.y > 0) {')
-    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, 0)), uint(direction_weights.y * 255));')
+    frag.write('    imageAtomicAdd(voxels, ivec3(writecoords + ivec3(face_offsets.y, 0, 0)), uint(direction_weights.y * 255));')
     frag.write('}')
 
     frag.write('if (direction_weights.z > 0) {')
-    frag.write('    imageAtomicMax(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, 0)), uint(direction_weights.z * 255));')
+    frag.write('    imageAtomicAdd(voxels, ivec3(writecoords + ivec3(face_offsets.z, 0, 0)), uint(direction_weights.z * 255));')
     frag.write('}')
 
     return con_voxel

--- a/blender/arm/props.py
+++ b/blender/arm/props.py
@@ -23,7 +23,7 @@ else:
     arm.enable_reload(__name__)
 
 # Armory version
-arm_version = '2024.2'
+arm_version = '2024.7'
 arm_commit = '$Id$'
 
 def get_project_html5_copy(self):

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -488,7 +488,8 @@ class ArmRPListItem(bpy.types.PropertyGroup):
                ],
         name="Voxels", description="Dynamic global illumination", default='Off', update=update_renderpath)
     rp_voxelgi_resolution: EnumProperty(
-        items=[('32', '32', '32'),
+        items=[('16', '16', '16'),
+               ('32', '32', '32'),
                ('64', '64', '64'),
                ('128', '128', '128'),
                ('256', '256', '256'),

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -445,25 +445,6 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     rp_stereo: BoolProperty(name="VR", description="Stereo rendering", default=False, update=update_renderpath)
     rp_water: BoolProperty(name="Water", description="Enable water surface pass", default=False, update=update_renderpath)
     rp_pp: BoolProperty(name="Realtime postprocess", description="Realtime postprocess", default=False, update=update_renderpath)
-    rp_gi: EnumProperty( # TODO: remove in 0.8
-        items=[('Off', 'Off', 'Off'),
-               ('Voxel GI', 'Voxel GI', 'Voxel GI', 'ERROR', 1),
-               ('Voxel AO', 'Voxel AO', 'Voxel AO')
-               ],
-        name="Global Illumination", description="Dynamic global illumination", default='Off', update=update_renderpath)
-    rp_voxelao: BoolProperty(name="Voxel AO", description="Voxel-based ambient occlusion", default=False, update=update_renderpath)
-    rp_voxelgi_resolution: EnumProperty(
-        items=[('32', '32', '32'),
-               ('64', '64', '64'),
-               ('128', '128', '128'),
-               ('256', '256', '256'),
-               ('512', '512', '512')],
-        name="Resolution", description="3D texture resolution", default='128', update=update_renderpath)
-    rp_voxelgi_resolution_z: EnumProperty(
-        items=[('1.0', '1.0', '1.0'),
-              ('0.5', '0.5', '0.5'),
-               ('0.25', '0.25', '0.25')],
-        name="Resolution Z", description="3D texture z resolution multiplier", default='1.0', update=update_renderpath)
     arm_clouds: BoolProperty(name="Clouds", description="Enable clouds pass", default=False, update=assets.invalidate_shader_cache)
     arm_ssrs: BoolProperty(name="SSRS", description="Screen-space ray-traced shadows", default=False, update=assets.invalidate_shader_cache)
     arm_micro_shadowing: BoolProperty(name="Micro Shadowing", description="Use the shaders' occlusion parameter to compute micro shadowing for the scene's sun lamp. This option is not available for render paths using mobile or solid material models", default=False, update=assets.invalidate_shader_cache)
@@ -518,7 +499,7 @@ class ArmRPListItem(bpy.types.PropertyGroup):
                ('0.5', '0.5', '0.5'),
                ('0.25', '0.25', '0.25')],
         name="Resolution Z", description="3D texture z resolution multiplier", default='1.0', update=update_renderpath)
-    arm_voxelgi_refraction: BoolProperty(name="Trace Refraction", description="Use voxels to render refraction", default=False, update=update_renderpath)
+    arm_voxelgi_refract: BoolProperty(name="Trace Refraction", description="Use voxels to render refraction", default=False, update=update_renderpath)
     arm_voxelgi_bounces: EnumProperty(
         items=[
         	   ('1', '1', '1'),
@@ -545,12 +526,13 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_voxelgi_diff: FloatProperty(name="Diffuse", description="", default=1.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_spec: FloatProperty(name="Reflection", description="", default=1.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_refr: FloatProperty(name="Refraction", description="", default=1.0, update=assets.invalidate_shader_cache)
-    arm_voxelgi_occ: FloatProperty(name="Intensity", description="", default=1.0, update=assets.invalidate_shader_cache)
+    arm_voxelgi_shad: FloatProperty(name="Shadows", description="", default=1.0, update=assets.invalidate_shader_cache)
+    arm_voxelgi_occ: FloatProperty(name="Occlusion", description="", default=1.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_size: FloatProperty(name="Size", description="Voxel size", default=0.25, update=assets.invalidate_shader_cache)
     arm_voxelgi_step: FloatProperty(name="Step", description="Step size", default=1.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_range: FloatProperty(name="Range", description="Maximum range", default=1.0, update=assets.invalidate_shader_cache)
-    arm_voxelgi_offset: FloatProperty(name="Offset", description="Offset for dealing with self occlusion", default=1.0, update=assets.invalidate_shader_cache)
-    arm_voxelgi_aperture: FloatProperty(name="Aperture", description="Cone aperture for shadow trace", default=0.5, update=assets.invalidate_shader_cache)
+    arm_voxelgi_offset: FloatProperty(name="Offset", description="Multiplicative Offset for dealing with self occlusion", default=1.0, update=assets.invalidate_shader_cache)
+    arm_voxelgi_aperture: FloatProperty(name="Aperture", description="Cone aperture for shadow trace", default=0.0, update=assets.invalidate_shader_cache)
     arm_sss_width: FloatProperty(name="Width", description="SSS blur strength", default=1.0, update=assets.invalidate_shader_cache)
     arm_water_color: FloatVectorProperty(name="Color", size=3, default=[1, 1, 1], subtype='COLOR', min=0, max=1, update=assets.invalidate_shader_cache)
     arm_water_level: FloatProperty(name="Level", default=0.0, update=assets.invalidate_shader_cache)

--- a/blender/arm/props_ui.py
+++ b/blender/arm/props_ui.py
@@ -1711,11 +1711,11 @@ class ARM_PT_RenderPathVoxelsPanel(bpy.types.Panel):
         col3 = col.column()
         col3.enabled = rpdat.rp_voxels == 'Voxel AO'
         col.prop(rpdat, 'arm_voxelgi_shadows', text='Shadows')
-        #col2.prop(rpdat, 'arm_voxelgi_refraction', text='Refraction')
-        #col2.prop(rpdat, 'arm_voxelgi_bounces')
+        col2.prop(rpdat, 'arm_voxelgi_refract', text='Refraction')
         col.prop(rpdat, 'arm_voxelgi_clipmap_count')
         #col.prop(rpdat, 'arm_voxelgi_cones')
         col.prop(rpdat, 'rp_voxelgi_resolution')
+        col.prop(rpdat, 'arm_voxelgi_size')
         #col.prop(rpdat, 'rp_voxelgi_resolution_z')
         col2.enabled = rpdat.rp_voxels == 'Voxel GI'
         #col.prop(rpdat, 'arm_voxelgi_temporal')
@@ -1724,13 +1724,13 @@ class ARM_PT_RenderPathVoxelsPanel(bpy.types.Panel):
         col2.enabled = rpdat.rp_voxels == 'Voxel GI'
         col2.prop(rpdat, 'arm_voxelgi_diff')
         col2.prop(rpdat, 'arm_voxelgi_spec')
-        #col2.prop(rpdat, 'arm_voxelgi_refr')
+        col2.prop(rpdat, 'arm_voxelgi_refr')
+        col.prop(rpdat, 'arm_voxelgi_shad')
         col.prop(rpdat, 'arm_voxelgi_occ')
         col.label(text="Ray")
-        col.prop(rpdat, 'arm_voxelgi_size')
+        col.prop(rpdat, 'arm_voxelgi_offset')
         col.prop(rpdat, 'arm_voxelgi_step')
         col.prop(rpdat, 'arm_voxelgi_range')
-        #col.prop(rpdat, 'arm_voxelgi_offset')
         #col.prop(rpdat, 'arm_voxelgi_aperture')
 
 class ARM_PT_RenderPathWorldPanel(bpy.types.Panel):

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -601,7 +601,7 @@ def write_compiledglsl(defs, make_variants):
                 f.write(f'#define GBUF_IDX_EMISSION {idx_emission}\n')
                 idx_refraction += 1
 
-            if '_SSRefraction' in wrd.world_defs:
+            if '_SSRefraction' in wrd.world_defs or '_VoxelRefract' in wrd.world_defs:
                 f.write(f'#define GBUF_IDX_REFRACTION {idx_refraction}\n')
 
         f.write("""#if defined(HLSL) || defined(METAL)
@@ -773,11 +773,12 @@ const float compoDOFLength = 160.0;
             f.write("""const ivec3 voxelgiResolution = ivec3(""" + str(rpdat.rp_voxelgi_resolution) + """, """ + str(rpdat.rp_voxelgi_resolution) + """, """ + str(rpdat.rp_voxelgi_resolution) + """);
 const int voxelgiClipmapCount = """ + str(rpdat.arm_voxelgi_clipmap_count) + """;
 const float voxelgiOcc = """ + str(round(rpdat.arm_voxelgi_occ * 100) / 100) + """;
-const float voxelgiVoxelSize = """ + str(round(rpdat.arm_voxelgi_size * 100) / 100) + """;
-const float voxelgiStep = """ + str(round(rpdat.arm_voxelgi_step * 100) / 100) + """;
+const float voxelgiVoxelSize = """ + str(round(rpdat.arm_voxelgi_size * 1000) / 1000) + """;
+const float voxelgiStep = """ + str(round(rpdat.arm_voxelgi_step * 1000) / 1000) + """;
 const float voxelgiRange = """ + str(round(rpdat.arm_voxelgi_range * 100) / 100) + """;
-const float voxelgiOffset = """ + str(round(rpdat.arm_voxelgi_offset * 100) / 100) + """;
+const float voxelgiOffset = """ + str(round(rpdat.arm_voxelgi_offset * 1000) / 1000) + """;
 const float voxelgiAperture = """ + str(round(rpdat.arm_voxelgi_aperture * 100) / 100) + """;
+const float voxelgiShad = """ + str(round(rpdat.arm_voxelgi_shad * 100) / 100) + """;
 """)
         if rpdat.rp_voxels == 'Voxel GI':
             f.write("""

--- a/blender/arm/write_data.py
+++ b/blender/arm/write_data.py
@@ -232,7 +232,7 @@ project.addSources('Sources');
             khafile.write('project.addShaders("' + shaders_path + '", { noprocessing: true, noembed: ' + str(noembed).lower() + ' });\n')
 
         # Move assets for published game to /data folder
-        use_data_dir = is_publish and (state.target == 'krom-windows' or state.target == 'krom-linux' or state.target == 'windows-hl' or state.target == 'linux-hl')
+        use_data_dir = is_publish and (state.target == 'krom-windows' or state.target == 'krom-linux' or state.target == 'windows-hl' or state.target == 'linux-hl' or state.target == 'html5')
         if use_data_dir:
             assets.add_khafile_def('arm_data_dir')
 
@@ -346,6 +346,9 @@ project.addSources('Sources');
 
         if wrd.arm_winresize or state.target == 'html5':
             assets.add_khafile_def('arm_resizable')
+
+        if get_winmode(wrd.arm_winmode) == 1 and state.target.startswith('html5'):
+            assets.add_khafile_def('kha_html5_disable_automatic_size_adjust')
 
         # if bpy.data.scenes[0].unit_settings.system_rotation == 'DEGREES':
             # assets.add_khafile_def('arm_degrees')
@@ -467,12 +470,20 @@ def write_mainhx(scene_name, resx, resy, is_play, is_publish):
     with open('Sources/Main.hx', 'w', encoding="utf-8") as f:
         f.write(
 """// Auto-generated
-package ;
+package;\n""")
+        
+        if winmode == 1 and state.target.startswith('html5'):
+            f.write("""
+import js.Browser.document;
+import js.Browser.window;
+import js.html.CanvasElement;
+import kha.Macros;\n""")
+        
+        f.write("""
 class Main {
     public static inline var projectName = '""" + arm.utils.safestr(wrd.arm_project_name) + """';
     public static inline var projectVersion = '""" + arm.utils.safestr(wrd.arm_project_version) + """';
     public static inline var projectPackage = '""" + arm.utils.safestr(wrd.arm_project_package) + """';""")
-
 
         if rpdat.rp_voxels == 'Voxel GI' or rpdat.rp_voxels == 'Voxel AO':
             f.write("""
@@ -486,11 +497,16 @@ class Main {
             f.write("""
     public static inline var resolutionSize = """ + str(rpdat.arm_rp_resolution_size) + """;""")
 
-        f.write("""
+        f.write("""\n
     public static function main() {""")
+        if winmode == 1 and state.target.startswith('html5'): 
+            f.write("""
+        setFullWindowCanvas();""")
+
         if rpdat.arm_skin != 'Off':
             f.write("""
         iron.object.BoneAnimation.skinMaxBones = """ + str(rpdat.arm_skin_max_bones) + """;""")
+        
         if rpdat.rp_shadows:
             if rpdat.rp_shadowmap_cascades != '1':
                 f.write("""
@@ -499,6 +515,7 @@ class Main {
             if rpdat.arm_shadowmap_bounds != 1.0:
                 f.write("""
             iron.object.LightObject.cascadeBounds = """ + str(rpdat.arm_shadowmap_bounds) + """;""")
+        
         if is_publish and wrd.arm_loadscreen:
             asset_references = list(set(assets.assets))
             loadscreen_class = 'armory.trait.internal.LoadingScreen'
@@ -507,11 +524,15 @@ class Main {
             f.write("""
         armory.system.Starter.numAssets = """ + str(len(asset_references)) + """;
         armory.system.Starter.drawLoading = """ + loadscreen_class + """.render;""")
+        
         if wrd.arm_ui == 'Enabled':
             if wrd.arm_canvas_img_scaling_quality == 'low':
-                f.write(f"armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.Low;")
+                f.write("""
+        armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.Low;""")
             elif wrd.arm_canvas_img_scaling_quality == 'high':
-                f.write(f"armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.High;")
+                f.write("""
+        armory.ui.Canvas.imageScaleQuality = kha.graphics2.ImageScaleQuality.High;""")
+        
         f.write("""
         armory.system.Starter.main(
             '""" + arm.utils.safestr(scene_name) + scene_ext + """',
@@ -525,9 +546,37 @@ class Main {
             """ + ('true' if wrd.arm_vsync else 'false') + """,
             """ + pathpack + """.renderpath.RenderPathCreator.get
         );
-    }
-}
-""")
+    }""")
+        
+        if winmode == 1 and state.target.startswith('html5'):
+            f.write("""\n
+    static function setFullWindowCanvas(): Void {
+		document.documentElement.style.padding = "0";
+		document.documentElement.style.margin = "0";
+		document.body.style.padding = "0";
+		document.body.style.margin = "0";
+		final canvas: CanvasElement = cast document.getElementById(Macros.canvasId());
+		canvas.style.display = "block";
+		final resize = function() {
+			var w = document.documentElement.clientWidth;
+			var h = document.documentElement.clientHeight;
+			if (w == 0 || h == 0) {
+				w = window.innerWidth;
+				h = window.innerHeight;
+			}
+			canvas.width = Std.int(w * window.devicePixelRatio);
+			canvas.height = Std.int(h * window.devicePixelRatio);
+			if (canvas.style.width == "") {
+				canvas.style.width = "100%";
+				canvas.style.height = "100%";
+			}
+		}
+		window.onresize = resize;
+		resize();
+	}""")
+            
+        f.write("""
+}\n""")
 
 def write_indexhtml(w, h, is_publish):
     wrd = bpy.data.worlds['Arm']


### PR DESCRIPTION
This is a patch for the voxels module:
- Fix occlusion being multiplied by voxels specular instead of material's specular.
- Implements voxels shadows and also voxels refraction. Deals with material only illumination.
- Fix screen space refraction depth test that made background only appear through transparent objects.
- Removed the normalization of viewPos in the use of reflect / refract.
- Compute the environment light in the voxelizer and pass it in the "voxels" image for accuracy.

TODO:
- Voxels refraction only work with screen space refraction on, yet no hint is given in the UI.

Bugs:
- Forward renderer has wrong coordinates for sampling the voxels resolving images, so it results in strange projections.
The materials created with make_forward_base.py are working fine in deferred.