### PR TITLE
patched up.

### DIFF
--- a/Shaders/ssr_pass/ssr_pass.frag.glsl
+++ b/Shaders/ssr_pass/ssr_pass.frag.glsl
@@ -92,7 +92,7 @@ void main() {
 
 	vec3 viewNormal = V3 * n;
 	vec3 viewPos = getPosView(viewRay, d, cameraProj);
-	vec3 reflected = reflect(normalize(viewPos), viewNormal);
+	vec3 reflected = reflect(viewPos, viewNormal);
 	hitCoord = viewPos;
 
 	#ifdef _CPostprocess

--- a/Shaders/std/conetrace.glsl
+++ b/Shaders/std/conetrace.glsl
@@ -168,7 +168,7 @@ vec4 traceDiffuse(const vec3 origin, const vec3 normal, const sampler3D voxels, 
 
 vec4 traceSpecular(const vec3 origin, const vec3 normal, const sampler3D voxels, const sampler3D voxelsSDF, const vec3 viewDir, const float roughness, const float clipmaps[voxelgiClipmapCount * 10], const vec2 pixel) {
 	vec3 specularDir = reflect(-viewDir, normal);
-	vec3 P = origin;// + specularDir * (BayerMatrix8[int(pixel.x) % 8][int(pixel.y) % 8] - 0.5) * voxelgiStep;
+	vec3 P = origin + specularDir * (BayerMatrix8[int(pixel.x) % 8][int(pixel.y) % 8] - 0.5) * voxelgiStep;
 	vec4 amount = traceCone(voxels, voxelsSDF, P, normal, specularDir, 0, true, roughness, voxelgiStep, clipmaps);
 
 	amount.rgb = max(vec3(0.0), amount.rgb);

--- a/Shaders/voxel_light/voxel_light.comp.glsl
+++ b/Shaders/voxel_light/voxel_light.comp.glsl
@@ -6,6 +6,9 @@ layout (local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 #include "std/math.glsl"
 #include "std/gbuffer.glsl"
 #include "std/imageatomic.glsl"
+#ifdef _VoxelShadow
+#include "std/conetrace.glsl"
+#endif
 
 uniform vec3 lightPos;
 uniform vec3 lightColor;
@@ -27,6 +30,9 @@ uniform float clipmaps[voxelgiClipmapCount * 10];
 uniform int clipmapLevel;
 
 uniform layout(r32ui) uimage3D voxelsLight;
+uniform layout(r32ui) uimage3D voxels;
+uniform sampler3D voxelsSampler;
+uniform sampler3D voxelsSDFSampler;
 
 #ifdef _ShadowMap
 uniform sampler2DShadow shadowMap;
@@ -83,63 +89,109 @@ float lpToDepth(vec3 lp, const vec2 lightProj) {
 
 void main() {
 	int res = voxelgiResolution.x;
+	vec3 aniso_light[6];
 
-	ivec3 dst = ivec3(gl_GlobalInvocationID.xyz);
+	for (int i = 0; i < 6; i++) {
+		ivec3 src = ivec3(gl_GlobalInvocationID.xyz);
+		src.x += i * res;
+		ivec3 dst = src;
+		dst.y += clipmapLevel * res;
 
-	vec3 P = (gl_GlobalInvocationID.xyz + 0.5) / voxelgiResolution;
-	P = P * 2.0 - 1.0;
-	P *= clipmaps[int(clipmapLevel * 10)];
-	P *= voxelgiResolution;
-	P += vec3(clipmaps[int(clipmapLevel * 10 + 4)], clipmaps[int(clipmapLevel * 10 + 5)], clipmaps[int(clipmapLevel * 10 + 6)]);
+		vec3 P = (gl_GlobalInvocationID.xyz + 0.5) / voxelgiResolution;
+		P = P * 2.0 - 1.0;
+		P *= clipmaps[int(clipmapLevel * 10)];
+		P *= voxelgiResolution;
+		P += vec3(clipmaps[int(clipmapLevel * 10 + 4)], clipmaps[int(clipmapLevel * 10 + 5)], clipmaps[int(clipmapLevel * 10 + 6)]);
 
-	vec4 light = vec4(0.0);
+		vec3 visibility;
+		vec3 lp = lightPos - P;
+		vec3 l;
+		if (lightType == 0) { l = lightDir; visibility = vec3(1.0); }
+		else { l = normalize(lp); visibility = vec3(attenuate(distance(P, lightPos))); }
 
-	float visibility;
-	vec3 lp = lightPos - P;
-	vec3 l;
-	if (lightType == 0) { l = lightDir; visibility = 1.0; }
-	else { l = normalize(lp); visibility = attenuate(distance(P, lightPos)); }
+		vec3 wnormal = decNor(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 2)).r);
 
-	// float dotNL = max(dot(wnormal, l), 0.0);
-	// if (dotNL == 0.0) return;
+		// float dotNL = max(dot(wnormal, l), 0.0);
+		// if (dotNL == 0.0) return;
 
 #ifdef _ShadowMap
-	if (lightShadow == 1) {
-		vec4 lightPosition = LVP * vec4(P, 1.0);
-		vec3 lPos = lightPosition.xyz / lightPosition.w;
-		visibility = texture(shadowMap, vec3(lPos.xy, lPos.z - shadowsBias)).r;
-	}
-	else if (lightShadow == 2) {
-		vec4 lightPosition = LVP * vec4(P, 1.0);
-		vec3 lPos = lightPosition.xyz / lightPosition.w;
-		visibility *= texture(shadowMapSpot, vec3(lPos.xy, lPos.z - shadowsBias)).r;
-	}
-	else if (lightShadow == 3) {
-		#ifdef _ShadowMapAtlas
-		int faceIndex = 0;
-		const int lightIndex = index * 6;
-		const vec2 uv = sampleCube(-l, faceIndex);
-		vec4 pointLightTile = pointLightDataArray[lightIndex + faceIndex]; // x: tile X offset, y: tile Y offset, z: tile size relative to atlas
-		vec2 uvtiled = pointLightTile.z * uv + pointLightTile.xy;
-		#ifdef _FlipY
-		uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
-		#endif
-		visibility *= texture(shadowMapPoint, vec3(uvtiled, lpToDepth(lp, lightProj) - shadowsBias)).r;
-		#else
-		visibility *= texture(shadowMapPoint, vec4(-l, lpToDepth(lp, lightProj) - shadowsBias)).r;
-		#endif
-	}
+		if (lightShadow == 1) {
+			vec4 lightPosition = LVP * vec4(P, 1.0);
+			vec3 lPos = lightPosition.xyz / lightPosition.w;
+			visibility = texture(shadowMap, vec3(lPos.xy, lPos.z - shadowsBias)).rrr;
+		}
+		else if (lightShadow == 2) {
+			vec4 lightPosition = LVP * vec4(P, 1.0);
+			vec3 lPos = lightPosition.xyz / lightPosition.w;
+			visibility *= texture(shadowMapSpot, vec3(lPos.xy, lPos.z - shadowsBias)).r;
+		}
+		else if (lightShadow == 3) {
+			#ifdef _ShadowMapAtlas
+			int faceIndex = 0;
+			const int lightIndex = index * 6;
+			const vec2 uv = sampleCube(-l, faceIndex);
+			vec4 pointLightTile = pointLightDataArray[lightIndex + faceIndex]; // x: tile X offset, y: tile Y offset, z: tile size relative to atlas
+			vec2 uvtiled = pointLightTile.z * uv + pointLightTile.xy;
+			#ifdef _FlipY
+			uvtiled.y = 1.0 - uvtiled.y; // invert Y coordinates for direct3d coordinate system
+			#endif
+			visibility *= texture(shadowMapPoint, vec3(uvtiled, lpToDepth(lp, lightProj) - shadowsBias)).r;
+			#else
+			visibility *= texture(shadowMapPoint, vec4(-l, lpToDepth(lp, lightProj) - shadowsBias)).r;
+			#endif
+		}
 #endif
 
-	if (lightType == 2) {
-		float spotEffect = dot(lightDir, l);
-		if (spotEffect < spotData.x) {
-			visibility *= smoothstep(spotData.y, spotData.x, spotEffect);
+		if (lightType == 2) {
+			float spotEffect = dot(lightDir, l);
+			if (spotEffect < spotData.x) {
+				visibility *= smoothstep(spotData.y, spotData.x, spotEffect);
+			}
+		}
+
+		const vec2 pixel = gl_GlobalInvocationID.xy;
+		#ifdef _VoxelShadow
+		visibility *= traceShadow(P, wnormal, voxelsSampler, voxelsSDFSampler, lp, clipmaps, pixel);
+		#endif
+		vec3 light = visibility * lightColor;
+		aniso_light[i] = light;
+
+		if (i == 5) {
+			vec3 aniso_direction = wnormal;
+			uvec3 face_offsets = uvec3(
+				aniso_direction.x > 0 ? 0 : 1,
+				aniso_direction.y > 0 ? 2 : 3,
+				aniso_direction.z > 0 ? 4 : 5
+			) * voxelgiResolution;
+			vec3 direction_weights = abs(wnormal);
+			vec3 sam =
+				aniso_light[face_offsets.x] * direction_weights.x +
+				aniso_light[face_offsets.y] * direction_weights.y +
+				aniso_light[face_offsets.z] * direction_weights.z
+				;
+			light = sam;
+
+			if (direction_weights.x > 0) {
+				vec4 light_direction = vec4(min(light * direction_weights.x, vec3(1.0)), 1.0);
+				imageAtomicAdd(voxelsLight, src + ivec3(face_offsets.x, 0, 0), uint(light_direction.r));
+				imageAtomicAdd(voxelsLight, src + ivec3(face_offsets.x, 0, voxelgiResolution.x), uint(light_direction.g));
+				imageAtomicAdd(voxelsLight, src + ivec3(face_offsets.x, 0, voxelgiResolution.x * 2), uint(light_direction.b));
+			}
+
+			if (direction_weights.y > 0) {
+				vec4 light_direction = vec4(min(light * direction_weights.y, vec3(1.0)), 1.0);
+				imageAtomicAdd(voxelsLight, src + ivec3(face_offsets.y, 0, 0), uint(light_direction.r));
+				imageAtomicAdd(voxelsLight, src + ivec3(face_offsets.y, 0, voxelgiResolution.x), uint(light_direction.g));
+				imageAtomicAdd(voxelsLight, src + ivec3(face_offsets.y, 0, voxelgiResolution.x * 2), uint(light_direction.b));
+			}
+
+			if (direction_weights.z > 0) {
+				vec4 light_direction = vec4(min(light * direction_weights.z, vec3(1.0)), 1.0);
+				imageAtomicAdd(voxelsLight, src + ivec3(face_offsets.z, 0, 0), uint(light_direction.r));
+				imageAtomicAdd(voxelsLight, src + ivec3(face_offsets.z, 0, voxelgiResolution.x), uint(light_direction.g));
+				imageAtomicAdd(voxelsLight, src + ivec3(face_offsets.z, 0, voxelgiResolution.x * 2), uint(light_direction.b));
+			}
+
 		}
 	}
-
-	light.rgb += visibility * lightColor;
-	light = clamp(light, vec4(0.0), vec4(1.0));
-
-	imageAtomicMax(voxelsLight, dst, convVec4ToRGBA8(light));
 }

--- a/Shaders/voxel_sdf_jumpflood/voxel_sdf_jumpflood.comp.glsl
+++ b/Shaders/voxel_sdf_jumpflood/voxel_sdf_jumpflood.comp.glsl
@@ -23,8 +23,8 @@ THE SOFTWARE.
 
 #include "compiled.inc"
 
-uniform layout(r8) image3D input_sdf;
-uniform layout(r8) image3D output_sdf;
+uniform layout(r16) image3D input_sdf;
+uniform layout(r16) image3D output_sdf;
 
 uniform float jump_size;
 uniform int clipmapLevel;

--- a/Shaders/voxel_temporal/voxel_temporal.comp.glsl
+++ b/Shaders/voxel_temporal/voxel_temporal.comp.glsl
@@ -43,47 +43,18 @@ uniform mat4 LVP;
 #endif
 uniform sampler3D voxelsSampler;
 uniform layout(r32ui) uimage3D voxels;
-uniform layout(rgba8) image3D voxelsB;
 uniform layout(r32ui) uimage3D voxelsLight;
+uniform layout(rgba8) image3D voxelsB;
 uniform layout(rgba8) image3D voxelsOut;
-#ifdef _ShadowMap
-uniform sampler2DShadow shadowMap;
-uniform sampler2DShadow shadowMapSpot;
-uniform samplerCubeShadow shadowMapPoint;
-#endif
-#include "std/shirr.glsl"
-uniform float envmapStrength;
-#ifdef _Irr
-uniform vec4 shirr[7];
-#endif
-#ifdef _Brdf
-uniform sampler2D senvmapBrdf;
-#endif
-#ifdef _Rad
-uniform sampler2D senvmapRadiance;
-uniform int envmapNumMipmaps;
-#endif
-#ifdef _EnvCol
-uniform vec3 backgroundCol;
-#endif
-uniform sampler2D gbufferD;
-uniform sampler2D gbuffer0;
-uniform sampler2D gbuffer1;
-#ifdef _gbuffer2
-#ifdef _Deferred
-uniform sampler2D gbuffer2;
-#endif
-#endif
-uniform vec3 eye;
-uniform layout(r8) image3D SDF;
+uniform layout(r16) image3D SDF;
 #else
 #ifdef _VoxelAOvar
 #ifdef _VoxelShadow
-uniform layout(r8) image3D SDF;
+uniform layout(r16) image3D SDF;
 #endif
 uniform layout(r32ui) uimage3D voxels;
-uniform layout(r8) image3D voxelsB;
-uniform layout(r8) image3D voxelsOut;
+uniform layout(r16) image3D voxelsB;
+uniform layout(r16) image3D voxelsOut;
 #endif
 #endif
 
@@ -94,12 +65,6 @@ layout (local_size_x = 8, local_size_y = 8, local_size_z = 8) in;
 
 void main() {
 	int res = voxelgiResolution.x;
-	#ifdef _VoxelGI
-	vec4 aniso_colors[6];
-	#else
-	float opac;
-	float aniso_colors[6];
-	#endif
 
 	#ifdef _VoxelGI
 	float sdf = float(clipmaps[int(clipmapLevel * 10)]) * 2.0 * res;
@@ -109,24 +74,32 @@ void main() {
 	#endif
 	#endif
 
-	#ifdef _VoxelGI
-	vec4 light = convRGBA8ToVec4(imageLoad(voxelsLight, ivec3(gl_GlobalInvocationID.xyz)).r);
-	#endif
-
 	for (int i = 0; i < 6 + DIFFUSE_CONE_COUNT; i++)
 	{
+		#ifdef _VoxelGI
+		vec4 aniso_colors[6];
+		#else
+		float aniso_colors[6];
+		#endif
+
 		ivec3 src = ivec3(gl_GlobalInvocationID.xyz);
 		src.x += i * res;
 		ivec3 dst = src;
 		dst.y += clipmapLevel * res;
 		#ifdef _VoxelGI
 		vec4 radiance = vec4(0.0);
+		vec4 bounce = vec4(0.0);
 		#else
 		float opac = 0.0;
 		#endif
 
 		if (i < 6) {
 			#ifdef _VoxelGI
+			vec3 light = vec3(0.0);
+			light.r = float(imageLoad(voxelsLight, src)) / 255;
+			light.g = float(imageLoad(voxelsLight, src + ivec3(0, 0, voxelgiResolution.x))) / 255;
+			light.b = float(imageLoad(voxelsLight, src + ivec3(0, 0, voxelgiResolution.x * 2))) / 255;
+			light /= 3;
 			vec4 basecol = vec4(0.0);
 			basecol.r = float(imageLoad(voxels, src)) / 255;
 			basecol.g = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x))) / 255;
@@ -143,6 +116,12 @@ void main() {
 			N.g = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 8))) / 255;
 			N /= 2;
 			vec3 wnormal = decode_oct(N.rg * 2 - 1);
+			vec3 envl = vec3(0.0);
+			envl.r = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 9))) / 255;
+			envl.g = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 10))) / 255;
+			envl.b = float(imageLoad(voxels, src + ivec3(0, 0, voxelgiResolution.x * 11))) / 255;
+			envl /= 3;
+			envl *= 100;
 
 			//clipmap to world
 			vec3 wposition = (gl_GlobalInvocationID.xyz + 0.5) / voxelgiResolution.x;
@@ -151,95 +130,11 @@ void main() {
 			wposition *= voxelgiResolution.x;
 			wposition += vec3(clipmaps[clipmapLevel * 10 + 4], clipmaps[clipmapLevel * 10 + 5], clipmaps[clipmapLevel * 10 + 6]);
 
-			#ifdef _Deferred
-			const vec2 pixel = gl_GlobalInvocationID.xy;
-			const vec2 uv = (pixel + 0.5) / voxelgiResolution.xy;
-
-			vec4 g0 = textureLod(gbuffer0, uv, 0.0); // Normal.xy, roughness, metallic/matid
-			vec3 n;
-			n.z = 1.0 - abs(g0.x) - abs(g0.y);
-			n.xy = n.z >= 0.0 ? g0.xy : octahedronWrap(g0.xy);
-			n = normalize(n);
-
-			float roughness = g0.b;
-			float metallic;
-			uint matid;
-			unpackFloatInt16(g0.a, metallic, matid);
-
-			vec4 g1 = textureLod(gbuffer1, uv, 0.0); // Basecolor.rgb, spec/occ
-			vec2 occspec = unpackFloat2(g1.a);
-			vec3 albedo = surfaceAlbedo(g1.rgb, metallic); // g1.rgb - basecolor
-			vec3 f0 = surfaceF0(g1.rgb, metallic);
-
-			vec3 v = normalize(eye - wposition);
-			float dotNV = max(dot(wnormal, v), 0.0);
-
-			#ifdef _gbuffer2
-				vec4 g2 = textureLod(gbuffer2, uv, 0.0);
-			#endif
-
-			#ifdef _Brdf
-				vec2 envBRDF = texelFetch(senvmapBrdf, ivec2(vec2(dotNV, 1.0 - roughness) * 256.0), 0).xy;
-			#endif
-
-				// Envmap
-			#ifdef _Irr
-				vec3 envl = shIrradiance(wnormal, shirr);
-
-				#ifdef _gbuffer2
-					if (g2.b < 0.5) {
-						envl = envl;
-					} else {
-						envl = vec3(0.0);
-					}
-				#endif
-
-				#ifdef _EnvTex
-					envl /= PI;
-				#endif
-			#else
-				vec3 envl = vec3(0.0);
-			#endif
-
-			#ifdef _Rad
-				vec3 reflectionWorld = reflect(-v, wnormal);
-				float lod = getMipFromRoughness(roughness, envmapNumMipmaps);
-				vec3 prefilteredColor = textureLod(senvmapRadiance, envMapEquirect(reflectionWorld), lod).rgb;
-			#endif
-
-			#ifdef _EnvLDR
-				envl.rgb = pow(envl.rgb, vec3(2.2));
-				#ifdef _Rad
-					prefilteredColor = pow(prefilteredColor, vec3(2.2));
-				#endif
-			#endif
-
-				envl.rgb *= albedo;
-
-			#ifdef _Brdf
-				envl.rgb *= 1.0 - (f0 * envBRDF.x + envBRDF.y);
-			#endif
-
-			#ifdef _Rad // Indirect specular
-				envl.rgb += prefilteredColor * (f0 * envBRDF.x + envBRDF.y);
-			#else
-				#ifdef _EnvCol
-				envl.rgb += backgroundCol * (f0 * envBRDF.x + envBRDF.y);
-				#endif
-			#endif
-
-			envl.rgb *= envmapStrength * occspec.x;
-			#else
-			vec3 envl = vec3(0.0);
-			#endif
-
 			radiance = basecol;
-
 			vec4 trace = traceDiffuse(wposition, wnormal, voxelsSampler, clipmaps);
 			vec3 indirect = trace.rgb + envl.rgb * (1.0 - trace.a);
-			radiance.rgb *= light.rgb / PI + indirect.rgb;
+			radiance.rgb *= light.rgb + indirect.rgb;
 			radiance.rgb += emission.rgb;
-			radiance = clamp(radiance, vec4(0.0), vec4(1.0));
 
 			#else
 			opac = float(imageLoad(voxels, src)) / 255;

--- a/Shaders/water_pass/water_pass.frag.glsl
+++ b/Shaders/water_pass/water_pass.frag.glsl
@@ -149,7 +149,7 @@ void main() {
 
 	vec3 viewNormal = n2;
 	vec3 viewPos = getPosView(viewRay, gdepth, cameraProj);
-	vec3 reflected = reflect(normalize(viewPos), viewNormal);
+	vec3 reflected = reflect(viewPos, viewNormal);
 	hitCoord = viewPos;
 
 	#ifdef _CPostprocess

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -570,14 +570,12 @@ class Inc {
 			t.width = 0;
 			t.height = 0;
 			t.displayp = getDisplayp();
-			t.scale = getSuperSampling();
 			t.format = getHdrFormat();
 		}
 		else if (t.name == "voxels_ao") {
 			t.width = 0;
 			t.height = 0;
 			t.displayp = getDisplayp();
-			t.scale = getSuperSampling();
 			t.format = "R8";
 		}
 		else {
@@ -621,7 +619,7 @@ class Inc {
 						t.width = res * 6;
 						t.height = res;
 						t.format = "R32";
-						t.depth = res * 9;
+						t.depth = res * 12;
 					}
 				}
 				#end

--- a/Sources/armory/renderpath/Inc.hx
+++ b/Sources/armory/renderpath/Inc.hx
@@ -580,7 +580,7 @@ class Inc {
 		}
 		else {
 			if (t.name == "voxelsSDF" || t.name == "voxelsSDFtmp") {
-				t.format = "R8";
+				t.format = "R16";
 				t.width = res;
 				t.height = res * Main.voxelgiClipmapCount;
 				t.depth = res;

--- a/blender/arm/props_renderpath.py
+++ b/blender/arm/props_renderpath.py
@@ -548,7 +548,7 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_voxelgi_occ: FloatProperty(name="Intensity", description="", default=1.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_size: FloatProperty(name="Size", description="Voxel size", default=0.25, update=assets.invalidate_shader_cache)
     arm_voxelgi_step: FloatProperty(name="Step", description="Step size", default=1.0, update=assets.invalidate_shader_cache)
-    arm_voxelgi_range: FloatProperty(name="Range", description="Maximum range", default=1.0, update=assets.invalidate_shader_cache)
+    arm_voxelgi_range: FloatProperty(name="Range", description="Maximum range", default=100.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_offset: FloatProperty(name="Offset", description="Offset for dealing with self occlusion", default=1.0, update=assets.invalidate_shader_cache)
     arm_voxelgi_aperture: FloatProperty(name="Aperture", description="Cone aperture for shadow trace", default=0.5, update=assets.invalidate_shader_cache)
     arm_sss_width: FloatProperty(name="Width", description="SSS blur strength", default=1.0, update=assets.invalidate_shader_cache)


### PR DESCRIPTION
Hello @luboslenco,
At the beginning of the year, I made voxels clipmaps, working with GI.
There was a lot of possibilities with voxels like shadows or refraction, and I went on since to do it. But in the middle of these changes, and bug fixes I lost tracks. So this is a big rollback, everything is working fine, but no voxels refraction nor shadows.
I hope you merge this soon because it fixes screen space refraction's last bugs and also the transparent materials for voxels which are broken since the last commits.