### PR TITLE
Add Signals

### DIFF
--- a/Sources/armory/system/Signal.hx
+++ b/Sources/armory/system/Signal.hx
@@ -25,10 +25,6 @@ class Signal {
         return callbacks;
     }
 
-    public function getObject():Int {
-        return object;
-    }
-
     public function isConnected(callBack:Function):Bool {
         return callbacks.contains(callBack);
     }

--- a/Sources/armory/system/Signal.hx
+++ b/Sources/armory/system/Signal.hx
@@ -1,0 +1,39 @@
+package armory.system;
+
+import haxe.Constraints.Function;
+
+class Signal {
+    var callbacks:Array<Function> = [];
+
+    public function new() {
+        
+    }
+    
+    public function connect(callback:Function) {
+        if (!callbacks.contains(callback)) callbacks.push(callback);
+    }
+    
+    public function disconnect(callback:Function) {
+        if (callbacks.contains(callback)) callbacks.remove(callback);
+    }
+
+    public function emit(...args:Any) {
+        for (callback in callbacks) Reflect.callMethod(this, callback, args);
+    }
+
+    public function getConnections():Array<Function> {
+        return callbacks;
+    }
+
+    public function getObject():Int {
+        return object;
+    }
+
+    public function isConnected(callBack:Function):Bool {
+        return callbacks.contains(callBack);
+    }
+
+    public function isNull():Bool {
+        return callbacks.length == 0;
+    }
+}


### PR DESCRIPTION
This adds a `Signal` class that works similarly to Godot's signals. This can be an alternative to the `Event` class for handling events that need arguments. Also helpful to maintain the code modular.

This is a first iteration but I plan to add new features if they are needed, for now I think it can be merged if you all think this is a good idea.

@luboslenco @QuantumCoderQC @MoritzBrueckner @Onek8 