### PR TITLE
Screen Space Node: add result vector position At

### DIFF
--- a/Sources/armory/logicnode/ScreenToWorldSpaceNode.hx
+++ b/Sources/armory/logicnode/ScreenToWorldSpaceNode.hx
@@ -22,50 +22,58 @@ class ScreenToWorldSpaceNode extends LogicNode {
 		// Separator Out
 		if (property0) {
 			switch (from) {
-				// World
+				// At
 				case 0: {
+					return RayCaster.getRay(vInput.x, vInput.y, cam).at(inputs[2].get());
+				}
+				// Origin
+				case 1: {
 					return RayCaster.getRay(vInput.x, vInput.y, cam).origin;
 				}
-				// World X
-				case 1: {
+				// Origin X
+				case 2: {
 					return RayCaster.getRay(vInput.x, vInput.y, cam).origin.x;
 				}
-				// World Y
-				case 2: {
+				// Origin Y
+				case 3: {
 					return RayCaster.getRay(vInput.x, vInput.y, cam).origin.y;
 				}
-				// World Z
-				case 3: {
+				// Origin Z
+				case 4: {
 					return RayCaster.getRay(vInput.x, vInput.y, cam).origin.z;
 				}
 				// Direction
-				case 4: {
-					return RayCaster.getRay(vInput.x, vInput.y, cam).direction.normalize();
+				case 5: {
+					return RayCaster.getRay(vInput.x, vInput.y, cam).direction;
 				}
 				// Direction X
-				case 5: {
-					return RayCaster.getRay(vInput.x, vInput.y, cam).direction.normalize().x;
+				case 6: {
+					return RayCaster.getRay(vInput.x, vInput.y, cam).direction.x;
 				}
 				// Direction Y
-				case 6: {
-					return RayCaster.getRay(vInput.x, vInput.y, cam).direction.normalize().y;
+				case 7: {
+					return RayCaster.getRay(vInput.x, vInput.y, cam).direction.y;
 				}
 				// Direction Z
-				case 7: {
-					return RayCaster.getRay(vInput.x, vInput.y, cam).direction.normalize().z;
+				case 8: {
+					return RayCaster.getRay(vInput.x, vInput.y, cam).direction.z;
 				}
 			}
 		}
 		else
 		{
 			switch (from) {
-				// World
+				// At
 				case 0: {
+					return RayCaster.getRay(vInput.x, vInput.y, cam).at(inputs[2].get());
+				}
+				// Origin
+				case 1: {
 					return RayCaster.getRay(vInput.x, vInput.y, cam).origin;
 				}
 				// Direction
-				case 1: {
-					return RayCaster.getRay(vInput.x, vInput.y, cam).direction.normalize();
+				case 2: {
+					return RayCaster.getRay(vInput.x, vInput.y, cam).direction;
 				}
 			}	
 		}

--- a/blender/arm/logicnode/math/LN_screen_to_world_space.py
+++ b/blender/arm/logicnode/math/LN_screen_to_world_space.py
@@ -2,20 +2,33 @@ from arm.logicnode.arm_nodes import *
 
 
 class ScreenToWorldSpaceNode(ArmLogicTreeNode):
-    """Transforms the given screen coordinates into world coordinates."""
+    """Transforms the given screen coordinates into World coordinates.
+    
+    @input Screen X: screen x position.
+    @input Screen Y: screen y position.
+    @input Distance at: distance from camera to the result vector position.
+    Try between 0 and 1.
+
+    @output Screen At: result vector position.
+    @output Screen Word: origin position of the ray emitted from camera.
+    @output Screen Direction: ray direction.
+    """
+
     bl_idname = 'LNScreenToWorldSpaceNode'
     bl_label = 'Screen to World Space'
     arm_section = 'matrix'
-    arm_version = 1
-    max_outputs = 8
+    arm_version = 2
+    max_outputs = 9
 
     property0: HaxeBoolProperty('property0', name='Separator Out', default=False)
 
     def arm_init(self, context):
         self.add_input('ArmIntSocket', 'Screen X')
         self.add_input('ArmIntSocket', 'Screen Y')
+        self.add_input('ArmFloatSocket', 'Distance at', default_value = 0.1)
 
-        self.add_output('ArmVectorSocket', 'World')
+        self.add_output('ArmVectorSocket', 'At')
+        self.add_output('ArmVectorSocket', 'Origin')
         self.add_output('ArmVectorSocket', 'Direction')
 
     def draw_buttons(self, context, layout):
@@ -23,9 +36,9 @@ class ScreenToWorldSpaceNode(ArmLogicTreeNode):
         if self.property0:
             if len(self.outputs) < self.max_outputs:
                 self.outputs.remove(self.outputs.values()[-1])  # Direction vector
-                self.add_output('ArmFloatSocket', 'X')  # World X
-                self.add_output('ArmFloatSocket', 'Y')  # World Y
-                self.add_output('ArmFloatSocket', 'Z')  # World Z
+                self.add_output('ArmFloatSocket', 'X')  # Origin X
+                self.add_output('ArmFloatSocket', 'Y')  # Origin Y
+                self.add_output('ArmFloatSocket', 'Z')  # Origin Z
                 self.add_output('ArmVectorSocket', 'Direction')  # Vector
                 self.add_output('ArmFloatSocket', 'X')  # Direction X
                 self.add_output('ArmFloatSocket', 'Y')  # Direction Y
@@ -40,3 +53,9 @@ class ScreenToWorldSpaceNode(ArmLogicTreeNode):
                 self.outputs.remove(self.outputs.values()[-1])  # Y
                 self.outputs.remove(self.outputs.values()[-1])  # X
                 self.add_output('ArmVectorSocket', 'Direction')
+
+    def get_replacement_node(self, node_tree: bpy.types.NodeTree):
+        if self.arm_version not in (0, 1):
+            raise LookupError()
+
+        return NodeReplacement.Identity(self)


### PR DESCRIPTION
Previous version of the node retrieved origin (label as world) and direction and they needed to be combined in order to get the desired coordinated. Which until now I didn't know how to use it to get the right world position. Since ray class has a function name "At" that does that, i think is better to output this result for a simple way of using this node.

I also added basic description which explains vector "At" considers the "Origin" point where the ray is emitted from the camera and uses "Distance at" to multiply its "Direction". 

![image](https://github.com/user-attachments/assets/4141ef36-6f3b-4c33-878f-9ad5bf8e8759)

Here is a sample of the same cube spawn at different screen positions with different distance at values using the node:

![image](https://github.com/user-attachments/assets/6ba10bbf-8a73-461b-909e-d3767fa14db2)
 
