### PR TITLE
Draw Polygon From Array Node

### DIFF
--- a/Sources/armory/logicnode/DrawPolygonFromArrayNode.hx
+++ b/Sources/armory/logicnode/DrawPolygonFromArrayNode.hx
@@ -1,0 +1,57 @@
+package armory.logicnode;
+
+import kha.Color;
+import kha.math.Vector2;
+import armory.renderpath.RenderToTexture;
+
+#if arm_ui
+using zui.GraphicsExtension;
+#end
+
+class DrawPolygonFromArrayNode extends LogicNode {
+
+	var vertices: Array<Vector2>;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		#if arm_ui
+		RenderToTexture.ensure2DContext("DrawPolygonNode");
+
+		var vertArr: Dynamic = inputs[6].get();
+
+		if (vertices == null) {
+			// Preallocate
+			vertices = [];
+			vertices.resize(vertArr.length);
+			for (i in 0...vertices.length) {
+				vertices[i] = new Vector2();
+			}
+		}
+
+		for (i in 0...vertArr.length) {
+			if (Std.isOfType(vertArr[i], iron.math.Vec4) || Std.isOfType(vertArr[i], iron.math.Vec3)){
+				vertices[i].x = vertArr[i].x;
+				vertices[i].y = vertArr[i].y;
+			} else {
+				assert(Error, vertArr[i].length >= 2, "Array positions must be an array of two dimensions (X, Y)");
+				vertices[i].x = vertArr[i][0];
+				vertices[i].y = vertArr[i][1];
+			}
+		}
+
+		final colorVec = inputs[1].get();
+		RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
+
+		if (inputs[2].get()) {
+			RenderToTexture.g.fillPolygon(inputs[4].get(), inputs[5].get(), vertices);
+		} else {
+			RenderToTexture.g.drawPolygon(inputs[4].get(), inputs[5].get(), vertices, inputs[3].get());
+		}
+		#end
+
+		runOutput(0);
+	}
+}

--- a/blender/arm/logicnode/draw/LN_draw_polygon_from_array.py
+++ b/blender/arm/logicnode/draw/LN_draw_polygon_from_array.py
@@ -1,0 +1,35 @@
+from arm.logicnode.arm_nodes import *
+
+class DrawPolygonFromArrayNode(ArmLogicTreeNode):
+    """Draws a polygon.
+
+    @input Draw: Activate to draw the polygon on this frame. The input must
+        be (indirectly) called from an `On Render2D` node.
+    @input Color: The color of the polygon.
+    @input Filled: Whether the polygon is filled or only the outline is drawn.
+    @input Strength: The line strength if the polygon is not filled.
+    @input Origin X/Origin Y: The origin position of the polygon, in pixels
+        from the top left corner. This position is added to all other
+        points, so they are defined relative to this position.
+    @input Xn/Yn: The position of polygon's points, in pixels from `Origin X`/`Origin Y`.
+
+    @output Out: Activated after the polygon has been drawn.
+
+    @see [`kha.graphics2.GraphicsExtension.drawPolygon()`](http://kha.tech/api/kha/graphics2/GraphicsExtension.html#drawPolygon).
+    @see [`kha.graphics2.GraphicsExtension.fillPolygon()`](http://kha.tech/api/kha/graphics2/GraphicsExtension.html#fillPolygon).
+    """
+    bl_idname = 'LNDrawPolygonFromArrayNode'
+    bl_label = 'Draw Polygon From Array'
+    arm_section = 'draw'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'Draw')
+        self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
+        self.add_input('ArmBoolSocket', 'Filled', default_value=False)
+        self.add_input('ArmFloatSocket', 'Strength', default_value=1.0)
+        self.add_input('ArmFloatSocket', 'Origin X')
+        self.add_input('ArmFloatSocket', 'Origin Y')
+        self.add_input('ArmNodeSocketArray', 'Array (X, Y)')        
+
+        self.add_output('ArmNodeSocketAction', 'Out')


### PR DESCRIPTION
This draw node draws a polygon from an array containing all vertices positions. The array input allows to dynamically change the vertices counts which was not possible with the existing version (Draw Polygon Node).

![image](https://github.com/user-attachments/assets/9feb03d2-8ebe-4287-bb5d-60b61e1fb8d5)
