### PR TITLE
Fixes for Play Action From Node

### DIFF
--- a/Sources/armory/logicnode/PlayActionFromNode.hx
+++ b/Sources/armory/logicnode/PlayActionFromNode.hx
@@ -13,6 +13,7 @@ class PlayActionFromNode extends LogicNode {
 	var endFrame: Int = -1;
 	var loop: Bool;
 	var reverse: Bool;
+	var action: String;
 	var actionR: String;
 
 	public function new(tree: LogicTree) {
@@ -21,8 +22,8 @@ class PlayActionFromNode extends LogicNode {
 	}
 	
 	function update() {
-		if (animation != null) {
-			if (animation.currentFrame() == endFrame) {
+		if (animation != null && action == animation.action) {
+			if (animation.currentFrame() == endFrame-1) {
 				if (loop) animation.setFrame(startFrame);
 				else {
 					if (!animation.paused) {
@@ -36,7 +37,7 @@ class PlayActionFromNode extends LogicNode {
 
 	override function run(from: Int) {
 		var object: Object = inputs[1].get();
-		var action: String = inputs[2].get();
+		action = inputs[2].get();
 		startFrame = inputs[3].get();
 		endFrame = inputs[4].get();
 		var blendTime: Float = inputs[5].get();
@@ -58,32 +59,89 @@ class PlayActionFromNode extends LogicNode {
 
 				if (isnew){
 					for(a in animation.armature.actions)
-						if(a.name == action)
-							animation.armature.actions.push({
-								name: actionR,
-								bones: a.bones,
-								mats: null});
-
-					for(a in animation.armature.actions)
-						if(a.name == actionR){
+						if(a.name == action){
+							var bones = [];
+							var cn = [];
 							for(bone in a.bones){
-								var val: Array<Float> = [];
 								var v = bone.anim.tracks[0];
 								var len: Int = v.values.length;
+								var val = new Float32Array(len);
 								var l = Std.int(len/16);
 								for(i in 0...l)
-									for(j in 0...16)
-										val.push(v.values[(l-i)*16+j-16]);
-								for(i in 0...v.values.length)
-									v.values[i] = val[i];
+									for(j in 0...16){
+										val[i*16+j] = v.values[(l-i)*16+j-16];
+									}
+
+								if (bone.children != null){
+									var cdn = [];
+									for (child in bone.children)
+										cdn.push(child.name);
+									cn.push(cdn);
+								} else cn.push(null);
+
+								var a: iron.data.SceneFormat.TObj = {
+									type : bone.type,
+							        name : bone.name,
+							        transform : {
+							        		//target : null,
+							                values : bone.transform.values
+							        },
+							        anim : {
+							                tracks : [{
+						                                target : v.target,
+						                                frames : v.frames,
+						                                values : val,
+						                                ref_values : null
+							                        }]//,
+							                //begin : null,
+							                //end : null,
+							                //has_delta : null,
+							                //marker_frames : null,
+							                //marker_names : null
+							        },
+							        children : bone.children,
+							        data_ref : null
+							    	}
+
+								if (bone.parent != null){
+									a.parent = bone.parent;
+								}
+
+						    	bones.push(a);
 							}
 
-						var castBoneAnim = cast(animation, iron.object.BoneAnimation);
-						castBoneAnim.data.geom.actions.set(actionR, a.bones);
-						castBoneAnim.data.geom.mats.set(actionR, castBoneAnim.data.geom.mats.get(action));
+							for (i in 0...bones.length){
+								var cd = [];
+								if (cn[i] != null)
+									for (name in cn[i])
+										for (bone in bones)
+											if (bone.name == name)
+												cd.push(bone);
+								bones[i].children = cd;
+							}
+							
+							for (i in 0...bones.length){
+								if (bones[i].parent != null)
+									for (bone in bones)
+										if (bone.name == bones[i].parent.name)
+											bones[i].parent = bone;
 
-						for(o in iron.Scene.active.raw.objects)
-							if (o.name == object.name) o.bone_actions.push('action_'+o.bone_actions[0].split('_')[1]+'_'+actionR);
+							}
+
+							animation.armature.actions.push({
+								name: actionR,
+								bones: bones,
+								mats: null});
+
+							var mats: Array<iron.math.Mat4> = [];
+							for (bone in a.bones) mats.push(iron.math.Mat4.fromFloat32Array(bone.transform.values));
+
+							var castBoneAnim = cast(animation, iron.object.BoneAnimation);
+							castBoneAnim.data.geom.actions.set(actionR, bones);
+							castBoneAnim.data.geom.mats.set(actionR, mats);
+
+							for(o in iron.Scene.active.raw.objects)
+								if (o.name == object.name) o.bone_actions.push('action_'+o.bone_actions[0].split('_')[1]+'_'+actionR);
 						}
 				}
 			}
@@ -95,16 +153,15 @@ class PlayActionFromNode extends LogicNode {
 				var oactions = cast(animation, ObjectAnimation).oactions;
 
 				for (a in oactions)
-					if (a.objects[0].name == actionR) isnew = false;
+					if (a != null && a.objects[0].name == actionR) isnew = false;
 
 				if (isnew){
 					for (a in oactions){
-						if (a.objects[0].name == action){
+						if (a != null && a.objects[0].name == action){
 							oaction = a.objects[0];
 							for(b in a.objects[0].anim.tracks){
 								var val: Array<Float> = [];
-								for(c in b.values) val.push(c);
-								val.reverse();
+								for(c in b.values) val.unshift(c);
 								var vali = new Float32Array(val.length);
 								for(i in 0...val.length) vali[i] = val[i];
 								tracks.push({target: b.target, frames: b.frames, values: vali});

--- a/blender/arm/logicnode/animation/LN_play_action_from.py
+++ b/blender/arm/logicnode/animation/LN_play_action_from.py
@@ -3,12 +3,12 @@ from arm.logicnode.arm_nodes import *
 
 class PlayActionFromNode(ArmLogicTreeNode):
     """
-    Plays animation action, that starts from given frame, and ends at given frame.
+    Plays animation action, that starts from given frame (0 is the first), and ends at given frame (-1 for last frame).
 
     @input In: Activates the node logic.
     @input Object: States object/armature to run the animation action on.
     @input Action: States animation action to be played.
-    @input Start Frame: Sets frame the animation should start at.
+    @input Start Frame: Sets frame the animation should start at from 0.
     @input End Frame: Sets frame the animation should end at. HINT: Set to "-1" if you want the total frames length of the animation.
     @input Blend: Sets rate to blend multiple animations together.
     @input Speed: Sets rate the animation plays at.


### PR DESCRIPTION
This one was a long due. I finally managed to fix the problem with the Reverse option for the boneAnimation Actions. Previous logic only worked for bones without parents. Now all the armature is reverse as expected.

Besides that, I also fixed another problem regarding the start and end frames for an action, that according to discord, i wasn't working either for all the cases. 

Considering Actions and keyframes from blender, all animation track frames range from 0 to length-1. So when using the PlayActionFromNode, those are the ranges to use. Previous version of start-end frames was been executed because the condition from frame end was never met using the wrong end frame index. Besides, if the action was changed triggered by another PlayActionFromNode, the previous update function that considered start-end frames values got in the way, but that was solved using also the animation.action as reference for the condition.

This was very hard to solve but finally a better version is available for everyone until the new animation nodes arrive. 