### PR TITLE
Fixes add node group error

### DIFF
--- a/blender/arm/nodes_logic.py
+++ b/blender/arm/nodes_logic.py
@@ -105,7 +105,8 @@ class ARM_OT_AddNodeOverride(bpy.types.Operator):
         for setting in self.settings.values():
             setting_dicts.append({
                 "name": setting.name,
-                "value": setting.value
+                "value": setting.value,
+                "array_index": setting.array_index
             })
 
         bpy.ops.node.add_node('INVOKE_DEFAULT', type=self.type, use_transform=self.use_transform, settings=setting_dicts)


### PR DESCRIPTION
When adding a node group an error pops up and the node group is not added even though it exists because an array index setting is missing.

![image](https://github.com/user-attachments/assets/4487c80a-7ae3-4b02-a95b-97f8d6ae9ae0)


Error: Python: Traceback (most recent call last):
  File "D:\Armory3D\armsdk/armory\blender\arm\nodes_logic.py", line 112, in invoke
    bpy.ops.node.add_node('INVOKE_DEFAULT', type=self.type, use_transform=self.use_transform, settings=setting_dicts)
  File "C:\Program Files\Blender Foundation\Blender 3.6\3.6\scripts\modules\bpy\ops.py", line 111, in __call__
    ret = _op_call(self.idname_py(), C_dict, kw, C_exec, C_undo)
TypeError: Converting py args to operator properties:  NODE_OT_add_node.settings error converting a member of a collection from a dicts into an RNA collection, failed with: TypeError: Converting a Python list to an RNA collection: keyword "array_index" missing