### PR TITLE
Fix Tween Nodes: add OnRemove Stop

### DIFF
--- a/Sources/armory/logicnode/TweenFloatNode.hx
+++ b/Sources/armory/logicnode/TweenFloatNode.hx
@@ -13,6 +13,7 @@ class TweenFloatNode extends LogicNode {
 
 	public function new(tree:LogicTree) {
 		super(tree);
+		tree.notifyOnRemove(onRemove);
 	}
 
 	override function run(from:Int) {
@@ -111,4 +112,10 @@ class TweenFloatNode extends LogicNode {
 	function done() {
 		runOutput(2);		
 	}	
+
+	function onRemove() {
+		if(anim != null){
+			Tween.stop(anim);
+		}
+	}
 }

--- a/Sources/armory/logicnode/TweenRotationNode.hx
+++ b/Sources/armory/logicnode/TweenRotationNode.hx
@@ -14,6 +14,7 @@ class TweenRotationNode extends LogicNode {
 
 	public function new(tree:LogicTree) {
 		super(tree);
+		tree.notifyOnRemove(onRemove);
 	}
 
 	override function run(from:Int) {
@@ -112,5 +113,11 @@ class TweenRotationNode extends LogicNode {
 
 	function done() {
 		runOutput(2);		
-	}	
+	}
+
+	function onRemove() {
+		if(anim != null){
+			Tween.stop(anim);
+		}
+	}
 }

--- a/Sources/armory/logicnode/TweenTransformNode.hx
+++ b/Sources/armory/logicnode/TweenTransformNode.hx
@@ -22,6 +22,7 @@ class TweenTransformNode extends LogicNode {
 
 	public function new(tree:LogicTree) {
 		super(tree);
+		tree.notifyOnRemove(onRemove);
 	}
 
 	override function run(from:Int) {
@@ -125,5 +126,12 @@ class TweenTransformNode extends LogicNode {
 
 	function done() {
 		runOutput(2);		
-	}	
+	}
+
+	function onRemove() {
+		if(anim != null){
+			Tween.stop(anim);
+		}
+	}
+
 }

--- a/Sources/armory/logicnode/TweenVectorNode.hx
+++ b/Sources/armory/logicnode/TweenVectorNode.hx
@@ -14,6 +14,7 @@ class TweenVectorNode extends LogicNode {
 
 	public function new(tree:LogicTree) {
 		super(tree);
+		tree.notifyOnRemove(onRemove);
 	}
 
 	override function run(from:Int) {
@@ -112,5 +113,11 @@ class TweenVectorNode extends LogicNode {
 
 	function done() {
 		runOutput(2);		
-	}	
+	}
+
+	function onRemove() {
+		if(anim != null){
+			Tween.stop(anim);
+		}
+	}
 }


### PR DESCRIPTION
Hi,

It seems when using Tween nodes on traits they don't stop and continue executing even though the Set Scene Active Node is used to restore the Scene to an initial state or even if the object is just removed. I have to manually stop them with an On Remove Event in order to keep consistency. I think the Tween nodes should trigger the stop function to stop the anim by default in the case the trait where is contained is removed.

This PR does that.