### PR TITLE
DecalMaterials: fix ior declaration missing

### DIFF
--- a/blender/arm/material/make_decal.py
+++ b/blender/arm/material/make_decal.py
@@ -71,6 +71,7 @@ def make(context_id):
     frag.write('float specular;')
     frag.write('float opacity;')
     frag.write('vec3 emissionCol;')  # Declared to prevent compiler errors, but decals currently don't output any emission
+    frag.write('float ior;')
     cycles.parse(mat_state.nodes, con_decal, vert, frag, geom, tesc, tese)
 
     frag.write('n /= (abs(n.x) + abs(n.y) + abs(n.z));')


### PR DESCRIPTION
Decal material example does not work anymore or any decal material because this declaration is missing

![image](https://github.com/user-attachments/assets/169aa6fa-878a-4b0a-a1b6-46bf3643dda2)
