### PR TITLE
fix open node links

### DIFF
--- a/armory/blender/arm/nodes_logic.py
+++ b/armory/blender/arm/nodes_logic.py
@@ -264,7 +264,7 @@ class ArmOpenNodeHaxeSource(bpy.types.Operator):
                     version = arm.utils.get_last_commit()
                     if version == '':
                         version = 'main'
-                    webbrowser.open(f'https://github.com/armory3d/armory/tree/{version}/Sources/armory/logicnode/{name}.hx')
+                    webbrowser.open(f'https://github.com/armory3d/armory/blob/{version}/armory/Sources/armory/logicnode/{name}.hx')
         return{'FINISHED'}
 
 
@@ -282,7 +282,7 @@ class ArmOpenNodePythonSource(bpy.types.Operator):
                     if version == '':
                         version = 'main'
                     rel_path = node.__module__.replace('.', '/')
-                    webbrowser.open(f'https://github.com/armory3d/armory/tree/{version}/blender/{rel_path}.py')
+                    webbrowser.open(f'https://github.com/armory3d/armory/blob/{version}/armory/blender/{rel_path}.py')
         return{'FINISHED'}
 
 


### PR DESCRIPTION
This links don't work since the update in the repository:

![image](https://github.com/user-attachments/assets/bd4eecd6-a5e3-4fc7-b25d-59a32b38765d)
