### PR TITLE
fix SubStringNode

### DIFF
--- a/armory/Sources/armory/logicnode/SubStringNode.hx
+++ b/armory/Sources/armory/logicnode/SubStringNode.hx
@@ -10,7 +10,7 @@ class SubStringNode extends LogicNode {
         var string: String = inputs[0].get();
 		var start: Int = inputs[1].get();
 		var end: Int = inputs[2].get();
-		if (start == null || end == null || string == null) return null;
+		if (string == null) return null;
 
         return string.substring(start, end);
 	}


### PR DESCRIPTION
This causes an error when compiling to windows c:

`armsdk\armory\Sources/armory/logicnode/SubStringNode.hx:13: characters 16-20 : On static platforms, null can’t be used as basic type Int`

Start and end can never be null since they are by default 0 in the node.

![image](https://github.com/user-attachments/assets/33616127-90b2-42ad-8a2e-6d4006e42d0d)


