### PR TITLE
fix text area element from canvas

### DIFF
--- a/armory/Sources/armory/ui/Canvas.hx
+++ b/armory/Sources/armory/ui/Canvas.hx
@@ -251,9 +251,11 @@ class Canvas {
 				ui.t.LABEL_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
 				ui.t.ACCENT_COL = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
 				ui.t.ACCENT_HOVER_COL = getColor(element.color_hover, getTheme(canvas.theme).BUTTON_HOVER_COL);
+				if (element.editable == null) element.editable = true;
 
-				h.nest(element.id).text = getText(canvas, element);
-				zui.Ext.textArea(ui,h.nest(element.id), element.alignment,element.editable);
+				zui.Ext.textArea(ui, h.nest(element.id), element.alignment, element.editable, getText(canvas, element), true);
+				
+				//handle does not change
 				if (h.nest(element.id).changed) {
 					var e = element.event;
 					if (e != null && e != "") events.push(e);


### PR DESCRIPTION
This fixes historial error of canvas text area element.

Now it can be used.

I added a note because handle is not implemented in the text area function.