### PR TITLE
OnTimerNode: add false to true case

### DIFF
--- a/armory/Sources/armory/logicnode/OnTimerNode.hx
+++ b/armory/Sources/armory/logicnode/OnTimerNode.hx
@@ -20,8 +20,6 @@ class OnTimerNode extends LogicNode {
 
 	function update() {
 
-		trace(duration, repeat);
-
 		if (duration <= 0.0) {
 			duration = inputs[0].get();
 			repeat = inputs[1].get();

--- a/armory/Sources/armory/logicnode/OnTimerNode.hx
+++ b/armory/Sources/armory/logicnode/OnTimerNode.hx
@@ -11,7 +11,16 @@ class OnTimerNode extends LogicNode {
 		tree.notifyOnUpdate(update);
 	}
 
+	function reactivate() {
+		if (inputs[1].get() == true){
+			tree.notifyOnUpdate(update);
+			tree.removeUpdate(reactivate);
+		}
+	}
+
 	function update() {
+
+		trace(duration, repeat);
 
 		if (duration <= 0.0) {
 			duration = inputs[0].get();
@@ -20,7 +29,7 @@ class OnTimerNode extends LogicNode {
 
 		duration -= iron.system.Time.delta;
 		if (duration <= 0.0) {
-			if (!repeat) tree.removeUpdate(update);
+			if (!repeat) { tree.removeUpdate(update); tree.notifyOnUpdate(reactivate); }
 			runOutput(0);
 		}
 	}


### PR DESCRIPTION
On Timer Node:
-- if repeat is set to false it just does one iteration
-- if repeat is set to true it repeats iterations
-- if repeat is changed from true to false during runtime it stops from doing new iterations
-- but if repeat is changed from false to true during runtime it does not continue to do new iterations
I modified the node with a reactivation function so in that case it can continue to do new iterations.

I think that way is more consistent.

![image](https://github.com/user-attachments/assets/b17c98b0-d78f-47d9-97b0-22c42d6655c3)
