### PR TITLE
fix error deferred_light.frag.glsl: variable LWVPSpot0

### DIFF
--- a/armory/Shaders/deferred_light/deferred_light.frag.glsl
+++ b/armory/Shaders/deferred_light/deferred_light.frag.glsl
@@ -443,7 +443,7 @@ void main() {
 
 	#ifdef _Spot
 	#ifdef _SSS
-	if (matid == 2) fragColor.rgb += fragColor.rgb * SSSSTransmittance(LWVPSpot0, p, n, normalize(pointPos - p), lightPlane.y, shadowMapSpot[0]);//TODO implement transparent shadowmaps into the SSSSTransmittance()
+	if (matid == 2) fragColor.rgb += fragColor.rgb * SSSSTransmittance(LWVPSpot[0], p, n, normalize(pointPos - p), lightPlane.y, shadowMapSpot[0]);//TODO implement transparent shadowmaps into the SSSSTransmittance()
 	#endif
 	#endif
 


### PR DESCRIPTION
Variable `LWVPSpot0` does not exist so it causes error. The correct sintaxis is `LWVPSpot[0]`