### PR TITLE
Rotation matrix node

### DIFF
--- a/armory/Sources/armory/logicnode/RotationFromTransformNode.hx
+++ b/armory/Sources/armory/logicnode/RotationFromTransformNode.hx
@@ -1,0 +1,27 @@
+package armory.logicnode;
+
+import iron.math.Mat4;
+import iron.math.Vec4;
+
+class RotationFromTransformNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var m: Mat4 = inputs[0].get();
+
+		if (m == null) return null;
+
+		var mr: Mat4 = m.clone().toRotation();
+
+		return switch(from){
+			case 0: new Vec4(mr._00, mr._10, mr._20, mr._30);
+			case 1: new Vec4(mr._01, mr._11, mr._21, mr._31);
+			case 2: new Vec4(mr._02, mr._12, mr._22, mr._32);
+			default: null;
+		}
+
+	}
+}

--- a/armory/blender/arm/logicnode/transform/LN_transform_to_rotation.py
+++ b/armory/blender/arm/logicnode/transform/LN_transform_to_rotation.py
@@ -1,0 +1,14 @@
+from arm.logicnode.arm_nodes import *
+
+class RotationFromTransformNode(ArmLogicTreeNode):
+    """Returns rotation matrix from the given transform."""
+    bl_idname = 'LNRotationFromTransformNode'
+    bl_label = 'Transform to Rotation Matrix'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmDynamicSocket', 'Transform')
+
+        self.add_output('ArmVectorSocket', 'Vector x')
+        self.add_output('ArmVectorSocket', 'Vector y')
+        self.add_output('ArmVectorSocket', 'Vector z')


### PR DESCRIPTION
this node allows to get the rotation matrix of an object transform.

This is useful when retrieving the vertex positions of a geometry to get the actual rotation of the vertices.

![image](https://github.com/user-attachments/assets/042aec45-f85a-4d94-b9f5-3f1d0adc9c9e)
