### PR TITLE
Html5 Alert, Prompt and Confirm nodes

### DIFF
--- a/armory/Sources/armory/logicnode/AlertNode.hx
+++ b/armory/Sources/armory/logicnode/AlertNode.hx
@@ -1,0 +1,17 @@
+package armory.logicnode;
+
+class AlertNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+
+		#if kha_html5
+		js.Browser.window.alert(inputs[1].get());
+		#end
+
+		runOutput(0);
+	}
+}

--- a/armory/Sources/armory/logicnode/ConfirmNode.hx
+++ b/armory/Sources/armory/logicnode/ConfirmNode.hx
@@ -1,0 +1,20 @@
+package armory.logicnode;
+
+class ConfirmNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		
+		#if kha_html5
+		var answer: Bool = js.Browser.window.confirm(inputs[1].get());
+		if(answer)
+			return runOutput(0);
+		else
+			return runOutput(1);
+		#end
+
+	}
+}

--- a/armory/Sources/armory/logicnode/PromptNode.hx
+++ b/armory/Sources/armory/logicnode/PromptNode.hx
@@ -1,0 +1,23 @@
+package armory.logicnode;
+
+class PromptNode extends LogicNode {
+
+	var input: String = null;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		#if kha_html5
+		input = js.Browser.window.prompt(inputs[1].get(), inputs[2].get());
+		
+		runOutput(0);
+		#end
+
+	}
+
+	override function get(from: Int): Dynamic {
+		return input;
+	}
+}

--- a/armory/blender/arm/logicnode/native/LN_alert.py
+++ b/armory/blender/arm/logicnode/native/LN_alert.py
@@ -1,7 +1,10 @@
 from arm.logicnode.arm_nodes import *
 
 class PrintNode(ArmLogicTreeNode):
-    """Open a window alert with the give string value (works only for web browsers)."""
+    """Open a window alert with the give string value (works only for web browsers).
+
+    @input String: message to display.
+    """
     bl_idname = 'LNAlertNode'
     bl_label = 'Alert'
     arm_version = 1

--- a/armory/blender/arm/logicnode/native/LN_alert.py
+++ b/armory/blender/arm/logicnode/native/LN_alert.py
@@ -1,0 +1,13 @@
+from arm.logicnode.arm_nodes import *
+
+class PrintNode(ArmLogicTreeNode):
+    """Open a window alert with the give string value (works only for web browsers)."""
+    bl_idname = 'LNAlertNode'
+    bl_label = 'Alert'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmStringSocket', 'String')
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/logicnode/native/LN_confirm.py
+++ b/armory/blender/arm/logicnode/native/LN_confirm.py
@@ -2,7 +2,13 @@ from arm.logicnode.arm_nodes import *
 
 class ConfirmNode(ArmLogicTreeNode):
     """Open a window alert with the give string value and returns true or false 
-    according to the user answer (works only for web browsers)."""
+    according to the user answer (works only for web browsers).
+
+    @input String: message to display.
+
+    @output True: return in case user select yes/ok.
+    @output False: return in case user select no/cancel.
+    """
     bl_idname = 'LNConfirmNode'
     bl_label = 'Confirm'
     arm_version = 1

--- a/armory/blender/arm/logicnode/native/LN_confirm.py
+++ b/armory/blender/arm/logicnode/native/LN_confirm.py
@@ -1,0 +1,15 @@
+from arm.logicnode.arm_nodes import *
+
+class ConfirmNode(ArmLogicTreeNode):
+    """Open a window alert with the give string value and returns true or false 
+    according to the user answer (works only for web browsers)."""
+    bl_idname = 'LNConfirmNode'
+    bl_label = 'Confirm'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmStringSocket', 'String')
+
+        self.add_output('ArmNodeSocketAction', 'True')
+        self.add_output('ArmNodeSocketAction', 'False')

--- a/armory/blender/arm/logicnode/native/LN_prompt.py
+++ b/armory/blender/arm/logicnode/native/LN_prompt.py
@@ -1,0 +1,18 @@
+from arm.logicnode.arm_nodes import *
+
+class PromptNode(ArmLogicTreeNode):
+    """Open a prompt with the give string value an returns either the user value
+    or the default string if specified.
+
+     (works only for web browsers)."""
+    bl_idname = 'LNPromptNode'
+    bl_label = 'Prompt'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmStringSocket', 'String')
+        self.add_input('ArmStringSocket', 'Default')
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+        self.add_output('ArmStringSocket', 'String')

--- a/armory/blender/arm/logicnode/native/LN_prompt.py
+++ b/armory/blender/arm/logicnode/native/LN_prompt.py
@@ -2,9 +2,13 @@ from arm.logicnode.arm_nodes import *
 
 class PromptNode(ArmLogicTreeNode):
     """Open a prompt with the give string value an returns either the user value
-    or the default string if specified.
+    or the default string if specified (works only for web browsers).
 
-     (works only for web browsers)."""
+    @input String: message to display.
+    @input Default: default string value in case there is no user input.
+
+    @output String: user input value or default value in case is specified.
+    """
     bl_idname = 'LNPromptNode'
     bl_label = 'Prompt'
     arm_version = 1


### PR DESCRIPTION
Basic nodes for html5 messages and interaction:

![image](https://github.com/user-attachments/assets/459295cd-a7f0-4088-b527-ddac4824be8c)

I thought these 3 elements could help in a basic way for based game behavior or debugging because: 

- `Alert` shows a message as an ui does (for people who don't know how to get to the console).
- `Prompt` helps to retrieve an user input by keyboard (which is useful in devices that don't have any).
- `Confirm` has a yes or no decision worflow  (interaction with user).
