### PR TITLE
Fix GetBoneTransformNode: incorrect transform returned

### DIFF
--- a/armory/Sources/armory/logicnode/GetBoneTransformNode.hx
+++ b/armory/Sources/armory/logicnode/GetBoneTransformNode.hx
@@ -23,8 +23,9 @@ class GetBoneTransformNode extends LogicNode {
 		// Get bone in armature
 		var bone = anim.getBone(boneName);
 
-		return anim.getAbsWorldMat(bone);
-
+		//return anim.getAbsWorldMat(bone);
+		return anim.getAbsMat(bone).clone().multmat(object.transform.world);
+		
         #else
         return null;
 


### PR DESCRIPTION
Get Bone Transform works well if only 1 instance of an armature is spawned in the scene. But with 2 or more instances of the armature the Transform returned is not consistent with the action played by that instance at that point.

This PR fixes that so the correct Transform is returned for every instance of an armature.

I finally could solve this problem I got long time ago with this node.
  