### PR TITLE
Fix camera spawn position in Blender 4.2.x

### DIFF
--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -317,6 +317,7 @@ class ArmoryExporter:
     def export_object_transform(self, bobject: bpy.types.Object, o):
         wrd = bpy.data.worlds['Arm']
 
+        # HACK: In Blender 4.2.x, each camera must be selected to ensure its matrix is correctly assigned
         if bpy.app.version >= (4, 2, 0) and bobject.type == 'CAMERA' and bobject.users_scene:
             current_scene = bpy.context.window.scene
             

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -317,6 +317,20 @@ class ArmoryExporter:
     def export_object_transform(self, bobject: bpy.types.Object, o):
         wrd = bpy.data.worlds['Arm']
 
+        if bpy.app.version >= (4, 2, 0):
+            current_scene = bpy.context.window.scene
+            if bobject.users_scene:
+                bpy.context.window.scene = bobject.users_scene[0]
+                bpy.context.view_layer.update()
+
+            if bobject.type == 'CAMERA':
+                bobject.select_set(True)
+                bpy.context.view_layer.update()
+                bobject.select_set(False)
+
+            bpy.context.window.scene = current_scene
+            bpy.context.view_layer.update()
+
         # Static transform
         o['transform'] = {'values': ArmoryExporter.write_matrix(bobject.matrix_local)}
 

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -317,16 +317,15 @@ class ArmoryExporter:
     def export_object_transform(self, bobject: bpy.types.Object, o):
         wrd = bpy.data.worlds['Arm']
 
-        if bpy.app.version >= (4, 2, 0):
+        if bpy.app.version >= (4, 2, 0) and bobject.type == 'CAMERA' and bobject.users_scene:
             current_scene = bpy.context.window.scene
-            if bobject.users_scene:
-                bpy.context.window.scene = bobject.users_scene[0]
-                bpy.context.view_layer.update()
+            
+            bpy.context.window.scene = bobject.users_scene[0]
+            bpy.context.view_layer.update()
 
-            if bobject.type == 'CAMERA':
-                bobject.select_set(True)
-                bpy.context.view_layer.update()
-                bobject.select_set(False)
+            bobject.select_set(True)
+            bpy.context.view_layer.update()
+            bobject.select_set(False)
 
             bpy.context.window.scene = current_scene
             bpy.context.view_layer.update()


### PR DESCRIPTION
This approach selects all the cameras when the project is exported, so the proper matrix is built for each one. Closes #3131.