### PR TITLE
Enable debug draw with Oimo Physics

### DIFF
--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -3007,14 +3007,14 @@ Make sure the mesh only has tris/quads.""")
             if rbw is not None and rbw.enabled:
                 out_trait['parameters'] = [str(rbw.time_scale), str(rbw.substeps_per_frame), str(rbw.solver_iterations)]
 
-                if phys_pkg == 'bullet':
-                    debug_draw_mode = 1 if wrd.arm_bullet_dbg_draw_wireframe else 0
-                    debug_draw_mode |= 2 if wrd.arm_bullet_dbg_draw_aabb else 0
-                    debug_draw_mode |= 8 if wrd.arm_bullet_dbg_draw_contact_points else 0
-                    debug_draw_mode |= 2048 if wrd.arm_bullet_dbg_draw_constraints else 0
-                    debug_draw_mode |= 4096 if wrd.arm_bullet_dbg_draw_constraint_limits else 0
-                    debug_draw_mode |= 16384 if wrd.arm_bullet_dbg_draw_normals else 0
-                    debug_draw_mode |= 32768 if wrd.arm_bullet_dbg_draw_axis_gizmo else 0
+                if phys_pkg == 'bullet' or phys_pkg == 'oimo':
+                    debug_draw_mode = 1 if wrd.arm_physics_dbg_draw_wireframe else 0
+                    debug_draw_mode |= 2 if wrd.arm_physics_dbg_draw_aabb else 0
+                    debug_draw_mode |= 8 if wrd.arm_physics_dbg_draw_contact_points else 0
+                    debug_draw_mode |= 2048 if wrd.arm_physics_dbg_draw_constraints else 0
+                    debug_draw_mode |= 4096 if wrd.arm_physics_dbg_draw_constraint_limits else 0
+                    debug_draw_mode |= 16384 if wrd.arm_physics_dbg_draw_normals else 0
+                    debug_draw_mode |= 32768 if wrd.arm_physics_dbg_draw_axis_gizmo else 0
                     out_trait['parameters'].append(str(debug_draw_mode))
 
             self.output['traits'].append(out_trait)

--- a/armory/blender/arm/props.py
+++ b/armory/blender/arm/props.py
@@ -197,34 +197,34 @@ def init_properties():
         items=[('Bullet', 'Bullet', 'Bullet'),
                ('Oimo', 'Oimo', 'Oimo')],
         name="Physics Engine", default='Bullet', update=assets.invalidate_compiler_cache)
-    bpy.types.World.arm_bullet_dbg_draw_wireframe = BoolProperty(
+    bpy.types.World.arm_physics_dbg_draw_wireframe = BoolProperty(
         name="Collider Wireframes", default=False,
         description="Draw wireframes of the physics collider meshes and suspensions of raycast vehicle simulations"
     )
-    bpy.types.World.arm_bullet_dbg_draw_aabb = BoolProperty(
+    bpy.types.World.arm_physics_dbg_draw_aabb = BoolProperty(
         name="Axis-aligned Minimum Bounding Boxes", default=False,
         description="Draw axis-aligned minimum bounding boxes (AABBs) of the physics collider meshes"
     )
-    bpy.types.World.arm_bullet_dbg_draw_contact_points = BoolProperty(
+    bpy.types.World.arm_physics_dbg_draw_contact_points = BoolProperty(
         name="Contact Points", default=False,
         description="Visualize contact points of multiple colliders"
     )
-    bpy.types.World.arm_bullet_dbg_draw_constraints = BoolProperty(
+    bpy.types.World.arm_physics_dbg_draw_constraints = BoolProperty(
         name="Constraints", default=False,
         description="Draw axis gizmos for important constraint points"
     )
-    bpy.types.World.arm_bullet_dbg_draw_constraint_limits = BoolProperty(
+    bpy.types.World.arm_physics_dbg_draw_constraint_limits = BoolProperty(
         name="Constraint Limits", default=False,
         description="Draw additional constraint information such as distance or angle limits"
     )
-    bpy.types.World.arm_bullet_dbg_draw_normals = BoolProperty(
+    bpy.types.World.arm_physics_dbg_draw_normals = BoolProperty(
         name="Face Normals", default=False,
         description=(
             "Draw the normal vectors of the triangles of the physics collider meshes."
             " This only works for mesh collision shapes"
         )
     )
-    bpy.types.World.arm_bullet_dbg_draw_axis_gizmo = BoolProperty(
+    bpy.types.World.arm_physics_dbg_draw_axis_gizmo = BoolProperty(
         name="Axis Gizmos", default=False,
         description=(
             "Draw a small axis gizmo at the origin of the collision shape."

--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -1866,7 +1866,7 @@ class ARM_PT_RenderPathPostProcessPanel(bpy.types.Panel):
         col.prop(rpdat, "rp_bloom")
         _col = col.column()
         _col.enabled = rpdat.rp_bloom
-        if bpy.app.version <= (4, 2, 4):
+        if bpy.app.version < (4, 3, 0):
             _col.prop(rpdat, 'arm_bloom_follow_blender')
             if not rpdat.arm_bloom_follow_blender:
                 _col.prop(rpdat, 'arm_bloom_threshold')
@@ -2703,19 +2703,19 @@ class ARM_PT_BulletDebugDrawingPanel(bpy.types.Panel):
         layout.use_property_decorate = False
         wrd = bpy.data.worlds['Arm']
 
-        if wrd.arm_physics_engine != 'Bullet':
+        if wrd.arm_physics_engine != 'Bullet' and wrd.arm_physics_engine != 'Oimo':
             row = layout.row()
             row.alert = True
-            row.label(text="Physics debug drawing is only supported for the Bullet physics engine")
+            row.label(text="Physics debug drawing is only supported for the Bullet and Oimo physics engines")
 
         col = layout.column(align=False)
-        col.prop(wrd, "arm_bullet_dbg_draw_wireframe")
-        col.prop(wrd, "arm_bullet_dbg_draw_aabb")
-        col.prop(wrd, "arm_bullet_dbg_draw_contact_points")
-        col.prop(wrd, "arm_bullet_dbg_draw_constraints")
-        col.prop(wrd, "arm_bullet_dbg_draw_constraint_limits")
-        col.prop(wrd, "arm_bullet_dbg_draw_normals")
-        col.prop(wrd, "arm_bullet_dbg_draw_axis_gizmo")
+        col.prop(wrd, "arm_physics_dbg_draw_wireframe")
+        col.prop(wrd, "arm_physics_dbg_draw_aabb")
+        col.prop(wrd, "arm_physics_dbg_draw_contact_points")
+        col.prop(wrd, "arm_physics_dbg_draw_constraints")
+        col.prop(wrd, "arm_physics_dbg_draw_constraint_limits")
+        col.prop(wrd, "arm_physics_dbg_draw_normals")
+        col.prop(wrd, "arm_physics_dbg_draw_axis_gizmo")
 
 def draw_custom_node_menu(self, context):
     """Extension of the node context menu.


### PR DESCRIPTION
This enables debug draw with the Oimo Physics module.

@luboslenco I [forked](https://github.com/moisesjpelaez/oimo_module) the [Oimo module](https://github.com/armory3d/oimo_module) a couple of months ago and have been maintaining it, is it possible to reopen the public archive? or are there other plans for Oimo?