### PR TITLE
Update Texture nodes: Musgrave, Noise and Bricks

### DIFF
--- a/armory/blender/arm/material/cycles_functions.py
+++ b/armory/blender/arm/material/cycles_functions.py
@@ -296,6 +296,130 @@ float tex_brick_f(vec3 p) {
 }
 """
 
+#https://github.com/blender/blender/blob/main/source/blender/gpu/shaders/material/gpu_shader_material_tex_brick.glsl
+str_tex_brick_blender = """
+float integer_noise(int n)
+{
+  /* Integer bit-shifts for these calculations can cause precision problems on macOS.
+   * Using uint resolves these issues. */
+  uint nn;
+  nn = (uint(n) + 1013u) & 0x7fffffffu;
+  nn = (nn >> 13u) ^ nn;
+  nn = (uint(nn * (nn * nn * 60493u + 19990303u)) + 1376312589u) & 0x7fffffffu;
+  return 0.5f * (float(nn) / 1073741824.0f);
+}
+
+vec2 calc_brick_texture(vec3 p,
+                          float mortar_size,
+                          float mortar_smooth,
+                          float bias,
+                          float brick_width,
+                          float row_height,
+                          float offset_amount,
+                          int offset_frequency,
+                          float squash_amount,
+                          int squash_frequency)
+{
+  int bricknum, rownum;
+  float offset = 0.0f;
+  float x, y;
+
+  rownum = int(floor(p.y / row_height));
+
+  if (offset_frequency != 0 && squash_frequency != 0) {
+    brick_width *= (rownum % squash_frequency != 0) ? 1.0f : squash_amount;           /* squash */
+    offset = (rownum % offset_frequency != 0) ? 0.0f : (brick_width * offset_amount); /* offset */
+  }
+
+  bricknum = int(floor((p.x + offset) / brick_width));
+
+  x = (p.x + offset) - brick_width * bricknum;
+  y = p.y - row_height * rownum;
+
+  float tint = clamp((integer_noise((rownum << 16) + (bricknum & 0xFFFF)) + bias), 0.0f, 1.0f);
+
+  float min_dist = min(min(x, y), min(brick_width - x, row_height - y));
+  if (min_dist >= mortar_size) {
+    return vec2(tint, 0.0f);
+  }
+  else if (mortar_smooth == 0.0f) {
+    return vec2(tint, 1.0f);
+  }
+  else {
+    min_dist = 1.0f - min_dist / mortar_size;
+    return vec2(tint, smoothstep(0.0f, mortar_smooth, min_dist));
+  }
+}
+
+vec3 tex_brick_blender(vec3 co,
+                    vec3 color1,
+                    vec3 color2,
+                    vec3 mortar,
+                    float scale,
+                    float mortar_size,
+                    float mortar_smooth,
+                    float bias,
+                    float brick_width,
+                    float row_height,
+                    float offset_amount,
+                    float offset_frequency,
+                    float squash_amount,
+                    float squash_frequency)
+{
+  vec2 f2 = calc_brick_texture(co * scale,
+                                 mortar_size,
+                                 mortar_smooth,
+                                 bias,
+                                 brick_width,
+                                 row_height,
+                                 offset_amount,
+                                 int(offset_frequency),
+                                 squash_amount,
+                                 int(squash_frequency));
+  float tint = f2.x;
+  float f = f2.y;
+  if (f != 1.0f) {
+    float facm = 1.0f - tint;
+    color1 = facm * color1 + tint * color2;
+  }
+    return mix(color1, mortar, f);
+}
+
+float tex_brick_blender_f(vec3 co,
+                    vec3 color1,
+                    vec3 color2,
+                    vec3 mortar,
+                    float scale,
+                    float mortar_size,
+                    float mortar_smooth,
+                    float bias,
+                    float brick_width,
+                    float row_height,
+                    float offset_amount,
+                    float offset_frequency,
+                    float squash_amount,
+                    float squash_frequency)
+{
+  vec2 f2 = calc_brick_texture(co * scale,
+                                 mortar_size,
+                                 mortar_smooth,
+                                 bias,
+                                 brick_width,
+                                 row_height,
+                                 offset_amount,
+                                 int(offset_frequency),
+                                 squash_amount,
+                                 int(squash_frequency));
+  float tint = f2.x;
+  float f = f2.y;
+  if (f != 1.0f) {
+    float facm = 1.0f - tint;
+    color1 = facm * color1 + tint * color2;
+  }
+    return f;
+}
+"""
+
 str_tex_wave = """
 float tex_wave_f(const vec3 p, const int type, const int profile, const float dist, const float detail, const float detail_scale) {
     float n;

--- a/armory/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/armory/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -278,8 +278,8 @@ def parse_tex_noise(node: bpy.types.ShaderNodeTexNoise, out_socket: bpy.types.No
     distortion = c.parse_value_input(node.inputs[5])
     if bpy.app.version >= (4, 1, 0):
         if node.noise_type == "FBM":
+            state.curshader.add_function(c_functions.str_tex_musgrave)
             if out_socket == node.outputs[1]:
-                state.curshader.add_function(c_functions.str_tex_musgrave)
                 res = 'vec3(tex_musgrave_f({0} * {1}), tex_musgrave_f({0} * {1} + 120.0), tex_musgrave_f({0} * {1} + 168.0))'.format(co, scale, detail, distortion)
             else:
                 res = f'tex_musgrave_f({co} * {scale} * 1.0)'

--- a/armory/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/armory/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -254,10 +254,10 @@ if bpy.app.version < (4, 1, 0):
             co = 'bposition'
     
         scale = c.parse_value_input(node.inputs['Scale'])
-        # detail = c.parse_value_input(node.inputs[2])
-        # distortion = c.parse_value_input(node.inputs[3])
-    
-        res = f'tex_musgrave_f({co} * {scale} * 0.5)'
+        detail = c.parse_value_input(node.inputs[3])
+        distortion = c.parse_value_input(node.inputs[4])
+
+        res = f'tex_musgrave_f({co} * {scale} * 0.5, {detail}, {distortion})'
     
         return res
 
@@ -280,9 +280,9 @@ def parse_tex_noise(node: bpy.types.ShaderNodeTexNoise, out_socket: bpy.types.No
         if node.noise_type == "FBM":
             state.curshader.add_function(c_functions.str_tex_musgrave)
             if out_socket == node.outputs[1]:
-                res = 'vec3(tex_musgrave_f({0} * {1}), tex_musgrave_f({0} * {1} + 120.0), tex_musgrave_f({0} * {1} + 168.0))'.format(co, scale, detail, distortion)
+                res = 'vec3(tex_musgrave_f({0} * {1}, {2}, {3}), tex_musgrave_f({0} * {1} + 120.0, {2}, {3}), tex_musgrave_f({0} * {1} + 168.0, {2}, {3}))'.format(co, scale, detail, distortion)
             else:
-                res = f'tex_musgrave_f({co} * {scale} * 1.0)'
+                res = f'tex_musgrave_f({co} * {scale} * 1.0, {detail}, {distortion})'
         else:
             if out_socket == node.outputs[1]:
                 res = 'vec3(tex_noise({0} * {1},{2},{3}), tex_noise({0} * {1} + 120.0,{2},{3}), tex_noise({0} * {1} + 168.0,{2},{3}))'.format(co, scale, detail, distortion)

--- a/armory/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/armory/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -29,24 +29,35 @@ else:
 
 
 def parse_tex_brick(node: bpy.types.ShaderNodeTexBrick, out_socket: bpy.types.NodeSocket, state: ParserState) -> Union[floatstr, vec3str]:
-    state.curshader.add_function(c_functions.str_tex_brick)
+    state.curshader.add_function(c_functions.str_tex_brick_blender)
 
     if node.inputs[0].is_linked:
         co = c.parse_vector_input(node.inputs[0])
     else:
         co = 'bposition'
 
+    offset_amount = node.offset
+    offset_frequency = node.offset_frequency
+    squash_amount = node.squash
+    squash_frequency = node.squash_frequency        
+
+    col1 = c.parse_vector_input(node.inputs[1])
+    col2 = c.parse_vector_input(node.inputs[2])
+    col3 = c.parse_vector_input(node.inputs[3])
+    scale = c.parse_value_input(node.inputs[4])
+    mortar_size = c.parse_value_input(node.inputs[5])
+    mortar_smooth = c.parse_value_input(node.inputs[6])
+    bias = c.parse_value_input(node.inputs[7])
+    brick_width = c.parse_value_input(node.inputs[8])
+    row_height = c.parse_value_input(node.inputs[9])
+    #res = f'tex_brick({co} * {scale}, {col1}, {col2}, {col3})'
+
     # Color
     if out_socket == node.outputs[0]:
-        col1 = c.parse_vector_input(node.inputs[1])
-        col2 = c.parse_vector_input(node.inputs[2])
-        col3 = c.parse_vector_input(node.inputs[3])
-        scale = c.parse_value_input(node.inputs[4])
-        res = f'tex_brick({co} * {scale}, {col1}, {col2}, {col3})'
+        res = f'tex_brick_blender({co}, {col1}, {col2}, {col3}, {scale}, {mortar_size}, {mortar_smooth}, {bias}, {brick_width}, {row_height}, {offset_amount}, {offset_frequency}, {squash_amount}, {squash_frequency})'
     # Fac
     else:
-        scale = c.parse_value_input(node.inputs[4])
-        res = 'tex_brick_f({0} * {1})'.format(co, scale)
+        res = f'tex_brick_blender_f({co}, {col1}, {col2}, {col3}, {scale}, {mortar_size}, {mortar_smooth}, {bias}, {brick_width}, {row_height}, {offset_amount}, {offset_frequency}, {squash_amount}, {squash_frequency})'
 
     return res
 


### PR DESCRIPTION
`Fac Output` failed for `FBM` because `tex_musgrave` function was missing for 4.

I added commented params of detail and distortion to the musgrave function so now the node looks like in blender:

![image](https://github.com/user-attachments/assets/3b010a11-cd27-4280-a84f-8526645c7dc0)

Now Brick texture looks exactly like in blender:

![image](https://github.com/user-attachments/assets/2e5d9845-15da-4c34-b37e-b3b75fdfedc2)

