### PR TITLE
New Image nodes: Draw Sub Image and Write Image

### DIFF
--- a/armory/Sources/armory/logicnode/DrawSubImageNode.hx
+++ b/armory/Sources/armory/logicnode/DrawSubImageNode.hx
@@ -1,0 +1,59 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+import kha.Image;
+import kha.Color;
+import armory.renderpath.RenderToTexture;
+
+class DrawSubImageNode extends LogicNode {
+	var img: Image;
+	var lastImgName = "";
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		RenderToTexture.ensure2DContext("DrawImageNode");
+
+		final imgName: String = inputs[1].get();
+		final colorVec: Vec4 = inputs[2].get();
+		final anchorH: Int = inputs[3].get();
+		final anchorV: Int = inputs[4].get();
+		final x: Float = inputs[5].get();
+		final y: Float = inputs[6].get();
+		final width: Float = inputs[7].get();
+		final height: Float = inputs[8].get();
+		final sx: Float = inputs[9].get();
+		final sy: Float = inputs[10].get();
+		final swidth: Float = inputs[11].get();
+		final sheight: Float = inputs[12].get();
+		final angle: Float = inputs[13].get();
+
+		final drawx = x - 0.5 * width * anchorH;
+		final drawy = y - 0.5 * height * anchorV;
+		final sdrawx = sx - 0.5 * swidth * anchorH;
+		final sdrawy = sy - 0.5 * sheight * anchorV;
+
+		RenderToTexture.g.rotate(angle, x, y);
+
+		if (imgName != lastImgName) {
+			// Load new image
+			lastImgName = imgName;
+			iron.data.Data.getImage(imgName, (image: Image) -> {
+				img = image;
+			});
+		}
+
+		if (img == null) {
+			runOutput(0);
+			return;
+		}
+
+		RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
+		RenderToTexture.g.drawScaledSubImage(img, sdrawx, sdrawy, swidth, sheight, drawx, drawy, width, height);
+		RenderToTexture.g.rotate(-angle, x, y);
+
+		runOutput(0);
+	}
+}

--- a/armory/Sources/armory/logicnode/WriteImageNode.hx
+++ b/armory/Sources/armory/logicnode/WriteImageNode.hx
@@ -78,8 +78,8 @@ class WriteImageNode extends LogicNode {
 				}
 			}
 
-			var pngwriter = new iron.format.bmp.Writer(bo);
-			pngwriter.write(iron.format.bmp.Tools.buildFromARGB(tw, th, rgb));
+			var imgwriter = new iron.format.bmp.Writer(bo);
+			imgwriter.write(iron.format.bmp.Tools.buildFromARGB(tw, th, rgb));
 
 			#if kha_krom
 			Krom.fileSaveBytes(Krom.getFilesLocation() +  "/" + file, bo.getBytes().getData());

--- a/armory/Sources/armory/logicnode/WriteImageNode.hx
+++ b/armory/Sources/armory/logicnode/WriteImageNode.hx
@@ -1,0 +1,105 @@
+package armory.logicnode;
+
+import iron.object.CameraObject;
+
+class WriteImageNode extends LogicNode {
+
+	var file: String;
+	var camera: CameraObject;
+	var renderTarget: kha.Image;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		// Relative or absolute path to file
+		file = inputs[1].get();
+
+		assert(Error, iron.App.w() % inputs[3].get() == 0 && iron.App.h() % inputs[4].get() == 0, "Aspect ratio must match display resolution ratio");
+
+		camera = inputs[2].get();
+		renderTarget = kha.Image.createRenderTarget(inputs[3].get(), inputs[4].get(),
+			kha.graphics4.TextureFormat.RGBA32,
+			kha.graphics4.DepthStencilFormat.NoDepthAndStencil);
+
+		tree.notifyOnRender(render);
+		
+	}
+
+	function render(g: kha.graphics4.Graphics) {
+
+		var ready = false;
+		final sceneCam = iron.Scene.active.camera;
+		final oldRT = camera.renderTarget;
+
+		iron.Scene.active.camera = camera;
+		camera.renderTarget = renderTarget;
+
+		camera.renderFrame(g);
+
+		var tex = camera.renderTarget;
+
+		camera.renderTarget = oldRT;
+		iron.Scene.active.camera = sceneCam;
+
+		var pixels = tex.getPixels();
+
+		for (i in 0...pixels.length){
+			if (pixels.get(i) != 0){ ready = true; break; }
+		}
+
+		//wait for getPixels ready
+		if (ready) { 
+
+			var tx = inputs[5].get();
+			var ty = inputs[6].get();
+			var tw = inputs[7].get();
+			var th = inputs[8].get();
+
+			var bo = new haxe.io.BytesOutput();
+			var rgb = haxe.io.Bytes.alloc(tw * th * 4);
+			for (j in ty...ty + th) {
+				for (i in tx...tx + tw) {
+					var k = j * tex.width + i;
+					var m =  (j - ty) * tw + i - tx;
+					
+					#if kha_krom
+					var l = k;
+					#elseif kha_html5
+					var l = (tex.height - j) * tex.width + i;
+					#end
+
+					//ARGB 0xff
+					rgb.set(m * 4 + 0, pixels.get(l * 4 + 3));
+					rgb.set(m * 4 + 1, pixels.get(l * 4 + 0)); 
+					rgb.set(m * 4 + 2, pixels.get(l * 4 + 1));
+					rgb.set(m * 4 + 3, pixels.get(l * 4 + 2));
+				}
+			}
+
+			var pngwriter = new iron.format.bmp.Writer(bo);
+			pngwriter.write(iron.format.bmp.Tools.buildFromARGB(tw, th, rgb));
+
+			#if kha_krom
+			Krom.fileSaveBytes(Krom.getFilesLocation() +  "/" + file, bo.getBytes().getData());
+	
+			#elseif kha_html5
+			var blob = new js.html.Blob([bo.getBytes().getData()], {type: "application"});
+	        var url = js.html.URL.createObjectURL(blob);
+	        var a = cast(js.Browser.document.createElement("a"), js.html.AnchorElement);
+	        a.href = url;
+	        a.download = file;
+	        a.click();
+	        js.html.URL.revokeObjectURL(url);
+			#end
+
+			runOutput(0);
+
+			tree.removeRender(render);
+
+		}
+
+	}
+
+}

--- a/armory/Sources/iron/format/bmp/Data.hx
+++ b/armory/Sources/iron/format/bmp/Data.hx
@@ -1,0 +1,50 @@
+/*
+ * format - Haxe File Formats
+ *
+ *  BMP File Format
+ *  Copyright (C) 2007-2009 Trevor McCauley, Baluta Cristian (hx port) & Robert Sköld (format conversion)
+ *
+ * Copyright (c) 2009, The Haxe Project Contributors
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE HAXE PROJECT CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE HAXE PROJECT CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+package iron.format.bmp;
+
+typedef Data = {
+	var header : iron.format.bmp.Header;
+	var pixels : haxe.io.Bytes;
+#if (haxe_ver < 4)
+	var colorTable : Null<haxe.io.Bytes>;
+#else
+	var ?colorTable : haxe.io.Bytes;
+#end
+}
+
+typedef Header = {
+	var width : Int;          // real width (in pixels)
+	var height : Int;         // real height (in pixels)
+	var paddedStride : Int;   // number of bytes in a stride (including padding)
+	var topToBottom : Bool;   // whether the bitmap is stored top to bottom
+	var bpp : Int;            // bits per pixel
+	var dataLength : Int;     // equal to `paddedStride` * `height`
+	var compression : Int;    // which compression is being used, 0 for no compression
+}

--- a/armory/Sources/iron/format/bmp/Reader.hx
+++ b/armory/Sources/iron/format/bmp/Reader.hx
@@ -1,0 +1,122 @@
+/*
+ * format - Haxe File Formats
+ *
+ *  BMP File Format
+ *  Copyright (C) 2007-2009 Robert Sköld
+ *
+ * Copyright (c) 2009, The Haxe Project Contributors
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE HAXE PROJECT CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE HAXE PROJECT CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+package iron.format.bmp;
+
+import iron.format.bmp.Data;
+
+
+class Reader {
+
+	var input : haxe.io.Input;
+
+	public function new( i ) {
+		input = i;
+	}
+
+	/** 
+	 * Only supports uncompressed 24bpp bitmaps (the most common format).
+	 * 
+	 * The returned bytes in `Data.pixels` will be in BGR order, and with padding (if present).
+	 * 
+	 * @see https://msdn.microsoft.com/en-us/library/windows/desktop/dd318229(v=vs.85).aspx
+	 * @see https://en.wikipedia.org/wiki/BMP_file_format#Bitmap_file_header
+	 */
+	public function read() : format.bmp.Data {
+		// Read Header
+		for (b in ["B".code, "M".code]) {
+			if (input.readByte() != b) throw "Invalid header";
+		}
+	
+		var fileSize = input.readInt32();
+		input.readInt32();							// Reserved
+		var offset = input.readInt32();
+
+		// Read InfoHeader
+		var infoHeaderSize = input.readInt32();		// InfoHeader size
+		if (infoHeaderSize != 40) {
+			throw 'Info headers with size $infoHeaderSize not supported.';
+		}
+		var width = input.readInt32();				// Image width (actual, not padded)
+		var height = input.readInt32();				// Image height
+		var numPlanes = input.readInt16();			// Number of planes
+		var bits = input.readInt16();				// Bits per pixel
+		var compression = input.readInt32();		// Compression type
+		var dataLength = input.readInt32();			// Image data size (includes padding!)
+		input.readInt32();							// Horizontal resolution
+		input.readInt32();							// Vertical resolution
+		var colorsUsed = input.readInt32();			// Colors used (0 when uncompressed)
+		input.readInt32();							// Important colors (0 when uncompressed)
+
+		// If there's no compression, the dataLength may be 0
+		if ( compression == 0 && dataLength == 0 ) dataLength = fileSize - offset;
+
+		var bytesRead = 54; // total read above
+		
+		var colorTable : haxe.io.Bytes = null;
+		if ( bits <= 8 ) {
+			if ( colorsUsed == 0 ) {
+				colorsUsed = Tools.getNumColorsForBitDepth(bits);
+			}
+			var colorTableLength = 4 * colorsUsed;
+			colorTable = haxe.io.Bytes.alloc( colorTableLength );
+			input.readFullBytes( colorTable, 0, colorTableLength );
+			bytesRead += colorTableLength;
+		}
+
+		input.read( offset - bytesRead );
+		
+		var p = haxe.io.Bytes.alloc( dataLength );	
+		
+		// Read Raster Data
+		var paddedStride = Tools.computePaddedStride(width, bits);
+		var topToBottom = false;
+		if ( height < 0 ) { // if bitmap is stored top to bottom
+			topToBottom = true;
+			height = -height;
+		}
+    
+		input.readFullBytes(p, 0, dataLength);
+			
+		return {
+			header: {
+				width: width,
+				height: height,
+				paddedStride: paddedStride,
+				topToBottom: topToBottom,
+				bpp: bits,
+				dataLength: dataLength,
+				compression: compression
+			},
+			pixels: p,
+			colorTable: colorTable
+		}
+	}
+}

--- a/armory/Sources/iron/format/bmp/Tools.hx
+++ b/armory/Sources/iron/format/bmp/Tools.hx
@@ -1,0 +1,256 @@
+/*
+ * format - Haxe File Formats
+ *
+ *  BMP File Format
+ *  Copyright (C) 2007-2009 Trevor McCauley, Baluta Cristian (hx port) & Robert Sköld (format conversion)
+ *
+ * Copyright (c) 2009, The Haxe Project Contributors
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE HAXE PROJECT CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE HAXE PROJECT CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+package iron.format.bmp;
+
+
+class Tools {
+
+	//												  a  r  g  b
+	static var ARGB_MAP(default, never):Array<Int> = [0, 1, 2, 3];
+	static var BGRA_MAP(default, never):Array<Int> = [3, 2, 1, 0];
+
+	static var COLOR_SIZE(default, never):Int = 4;
+	
+	/**
+		Extract BMP pixel data (24bpp in BGR format) and expands it to BGRA, removing any padding in the process.
+	**/
+	inline static public function extractBGRA( bmp : iron.format.bmp.Data ) : haxe.io.Bytes {
+		return _extract32(bmp, BGRA_MAP, 0xFF);
+	}
+
+	/**
+		Extract BMP pixel data (24bpp in BGR format) and converts it to ARGB.
+	**/
+	inline static public function extractARGB( bmp : iron.format.bmp.Data ) : haxe.io.Bytes {
+		return _extract32(bmp, ARGB_MAP, 0xFF);
+	}
+  
+	/**
+		Creates BMP data from bytes in BGRA format for each pixel.
+	**/
+	inline static public function buildFromBGRA( width : Int, height : Int, srcBytes : haxe.io.Bytes, topToBottom : Bool = false ) : Data {
+		return _buildFrom32(width, height, srcBytes, BGRA_MAP, topToBottom);
+	}
+  
+	/**
+		Creates BMP data from bytes in ARGB format for each pixel.
+	**/
+	inline static public function buildFromARGB( width : Int, height : Int, srcBytes : haxe.io.Bytes, topToBottom : Bool = false ) : Data {
+		return _buildFrom32(width, height, srcBytes, ARGB_MAP, topToBottom);
+	}
+
+	inline static public function computePaddedStride(width:Int, bpp:Int):Int {
+		return ((((width * bpp) + 31) & ~31) >> 3);
+	}
+
+	/**
+	 * Gets number of colors for indexed palettes
+	 */
+	inline static public function getNumColorsForBitDepth(bpp:Int):Int {
+		return switch (bpp) {
+			case 1: 2;
+			case 4: 16;
+			case 8: 256;
+			case 16: 65536;
+			default: throw 'Unsupported bpp $bpp';
+		}
+	}
+	
+	
+	// `channelMap` contains indices to map into ARGB (f.e. the mapping for ARGB is [0,1,2,3], while for BGRA is [3,2,1,0])
+	static function _extract32( bmp : iron.format.bmp.Data, channelMap : Array<Int>, alpha : Int = 0xFF) : haxe.io.Bytes {
+		var srcBytes = bmp.pixels;
+		var dstLen = bmp.header.width * bmp.header.height * 4;
+		var dstBytes = haxe.io.Bytes.alloc( dstLen );
+		var srcPaddedStride = bmp.header.paddedStride;
+		
+		var yDir = -1;
+		var dstPos = 0;
+		var srcPos = srcPaddedStride * (bmp.header.height - 1);
+    
+		if ( bmp.header.topToBottom ) {
+			yDir = 1;
+			srcPos = 0;
+		}
+
+		if ( bmp.header.bpp < 8 || bmp.header.bpp == 16 ) {
+			throw 'bpp ${bmp.header.bpp} not supported';
+		}
+
+		var colorTable:haxe.io.Bytes = null;
+		if ( bmp.header.bpp <= 8 ) {
+			var colorTableLength = getNumColorsForBitDepth(bmp.header.bpp);
+			colorTable = haxe.io.Bytes.alloc(colorTableLength * COLOR_SIZE);
+			var definedColorTableLength = Std.int( bmp.colorTable.length / COLOR_SIZE );
+			for( i in 0...definedColorTableLength ) {
+				var b = bmp.colorTable.get( i * COLOR_SIZE);
+				var g = bmp.colorTable.get( i * COLOR_SIZE + 1);
+				var r = bmp.colorTable.get( i * COLOR_SIZE + 2);
+
+				colorTable.set(i * COLOR_SIZE + channelMap[0], alpha);
+				colorTable.set(i * COLOR_SIZE + channelMap[1], r);
+				colorTable.set(i * COLOR_SIZE + channelMap[2], g);
+				colorTable.set(i * COLOR_SIZE + channelMap[3], b);
+			}
+			// We want to have the table the full length in case indices outside the range are present
+			colorTable.fill(definedColorTableLength, colorTableLength - definedColorTableLength, 0);
+			for( i in definedColorTableLength...colorTableLength ) {
+				colorTable.set(i * COLOR_SIZE + channelMap[0], alpha);
+			}
+		}
+
+		switch bmp.header.compression {
+			case 0:
+				while( dstPos < dstLen ) {
+					for( i in 0...bmp.header.width ) {
+						if (bmp.header.bpp == 8) {
+
+							var currentSrcPos = srcPos + i;
+							var index = srcBytes.get(currentSrcPos);
+							dstBytes.blit( dstPos, colorTable, index * COLOR_SIZE, COLOR_SIZE );
+
+						} else if (bmp.header.bpp == 24) {
+
+							var currentSrcPos = srcPos + i * 3;
+							var b = srcBytes.get(currentSrcPos);
+							var g = srcBytes.get(currentSrcPos + 1);
+							var r = srcBytes.get(currentSrcPos + 2);
+							
+							dstBytes.set(dstPos + channelMap[0], alpha);
+							dstBytes.set(dstPos + channelMap[1], r);
+							dstBytes.set(dstPos + channelMap[2], g);
+							dstBytes.set(dstPos + channelMap[3], b);
+
+						} else if (bmp.header.bpp == 32) {
+
+							var currentSrcPos = srcPos + i * 4;
+							var b = srcBytes.get(currentSrcPos);
+							var g = srcBytes.get(currentSrcPos + 1);
+							var r = srcBytes.get(currentSrcPos + 2);
+							
+							dstBytes.set(dstPos + channelMap[0], alpha);
+							dstBytes.set(dstPos + channelMap[1], r);
+							dstBytes.set(dstPos + channelMap[2], g);
+							dstBytes.set(dstPos + channelMap[3], b);
+
+						}
+						dstPos += 4;
+					}
+					srcPos += yDir * srcPaddedStride;
+				}
+			case 1:
+				srcPos = 0;
+				var x = 0;
+				var y = bmp.header.topToBottom ? 0 : bmp.header.height - 1;
+				while( srcPos < bmp.header.dataLength ) {
+					var count = srcBytes.get(srcPos++);
+					var index = srcBytes.get(srcPos++);
+					if ( count == 0 ) {
+						if ( index == 0 ) {
+							x = 0;
+							y += yDir;
+						} else if ( index == 1 ) {
+							break;
+						} else if ( index == 2 ) {
+							x += srcBytes.get(srcPos++);
+							y += srcBytes.get(srcPos++);
+						} else {
+							count = index;
+							for( i in 0...count ) {
+								index = srcBytes.get(srcPos++);
+								dstBytes.blit( COLOR_SIZE * ((x+i) + y * bmp.header.width), colorTable, index * COLOR_SIZE, COLOR_SIZE );
+							}
+							if (srcPos % 2 != 0) srcPos++;
+							x += count;
+						}
+					} else {
+						for( i in 0...count ) {
+							dstBytes.blit( COLOR_SIZE * ((x+i) + y * bmp.header.width), colorTable, index * COLOR_SIZE, COLOR_SIZE );
+						}
+						x += count;
+					}
+				}
+			default:
+				throw 'compression ${bmp.header.compression} not supported';
+		}
+
+		return dstBytes;
+	}
+	
+	// `channelMap` contains indices to map into ARGB (f.e. the mapping for ARGB is [0,1,2,3], while for BGRA is [3,2,1,0])
+	static function _buildFrom32( width : Int, height : Int, srcBytes : haxe.io.Bytes, channelMap : Array<Int>, topToBottom : Bool = false ) : Data {
+		var bpp = 24;
+		var paddedStride = computePaddedStride(width, bpp);
+		var bytesBGR = haxe.io.Bytes.alloc(paddedStride * height);
+		var topToBottom = topToBottom;
+		var dataLength = bytesBGR.length;
+		
+		var dstStride = width * 3;
+		var srcLen = width * height * 4;
+		var yDir = -1;
+		var dstPos = dataLength - paddedStride;
+		var srcPos = 0;
+		
+		if ( topToBottom ) {
+			yDir = 1;
+			dstPos = 0;
+		}
+		
+		while( srcPos < srcLen ) {
+			var i = dstPos;
+			while( i < dstPos + dstStride ) {
+				var r = srcBytes.get(srcPos + channelMap[1]);
+				var g = srcBytes.get(srcPos + channelMap[2]);
+				var b = srcBytes.get(srcPos + channelMap[3]);
+				
+				bytesBGR.set(i++, b);
+				bytesBGR.set(i++, g);
+				bytesBGR.set(i++, r);
+				
+				srcPos += 4;
+			}
+			dstPos += yDir * paddedStride;
+		}
+		
+		return {
+			header: {
+				width: width,
+				height: height,
+				paddedStride: paddedStride,
+				topToBottom: topToBottom,
+				bpp: bpp,
+				dataLength: dataLength,
+				compression: 0
+			},
+			pixels: bytesBGR,
+			colorTable: null
+		}
+	}
+}

--- a/armory/Sources/iron/format/bmp/Writer.hx
+++ b/armory/Sources/iron/format/bmp/Writer.hx
@@ -1,0 +1,74 @@
+/*
+ * format - Haxe File Formats
+ *
+ *  BMP File Format
+ *  Copyright (C) 2007-2009 Robert Sköld
+ *
+ * Copyright (c) 2009, The Haxe Project Contributors
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE HAXE PROJECT CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE HAXE PROJECT CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+package iron.format.bmp;
+
+import iron.format.bmp.Data;
+
+
+class Writer {
+
+	static var DATA_OFFSET : Int = 0x36;
+
+	var output : haxe.io.Output;
+
+	public function new(o) {
+		output = o;
+	}
+	
+	/**
+	 * Specs: http://s223767089.online.de/en/file-format-bmp
+	 */
+	public function write( bmp : Data ) {
+		// Write Header (14 bytes)
+		output.writeString( "BM" );								// Signature
+		output.writeInt32(bmp.pixels.length + DATA_OFFSET );	// FileSize
+		output.writeInt32( 0 );									// Reserved
+		output.writeInt32( DATA_OFFSET );						// Offset
+
+		// Write InfoHeader (40 bytes)
+		output.writeInt32( 40 );								// InfoHeader size
+		output.writeInt32( bmp.header.width );					// Image width
+		var height = bmp.header.height;
+		if (bmp.header.topToBottom) height = -height; 
+		output.writeInt32( height );							// Image height
+		output.writeInt16( 1 );									// Number of planes
+		output.writeInt16( 24 );								// Bits per pixel (24bit RGB)
+		output.writeInt32( 0 );									// Compression type (no compression)
+		output.writeInt32( bmp.header.dataLength );				// Image data size (0 when uncompressed)
+		output.writeInt32( 0x2e30 );							// Horizontal resolution
+		output.writeInt32( 0x2e30 );							// Vertical resolution
+		output.writeInt32( 0 );									// Colors used (0 when uncompressed)
+		output.writeInt32( 0 );									// Important colors (0 when uncompressed)
+
+		// Write Raster Data
+		output.write(bmp.pixels);
+  }
+}

--- a/armory/blender/arm/logicnode/draw/LN_draw_sub_image.py
+++ b/armory/blender/arm/logicnode/draw/LN_draw_sub_image.py
@@ -1,0 +1,47 @@
+from arm.logicnode.arm_nodes import *
+
+
+class DrawSubImageNode(ArmLogicTreeNode):
+    """Draws an image.
+
+    @input Draw: Activate to draw the image on this frame. The input must
+        be (indirectly) called from an `On Render2D` node.
+    @input Image: The filename of the image.
+    @input Color: The color that the image's pixels are multiplied with.
+    @input Left/Center/Right: Horizontal anchor point of the image.
+        0 = Left, 1 = Center, 2 = Right
+    @input Top/Middle/Bottom: Vertical anchor point of the image.
+        0 = Top, 1 = Middle, 2 = Bottom
+    @input X/Y: Position of the anchor point in pixels.
+    @input Width/Height: Size of the sub image in pixels.
+    @input sX/Y: Position of the sub anchor point in pixels.
+    @input sWidth/Height: Size of the image in pixels.
+    @input Angle: Rotation angle in radians. Image will be rotated cloclwiswe
+        at the anchor point.
+
+    @output Out: Activated after the image has been drawn.
+
+    @see [`kha.graphics2.Graphics.drawImage()`](http://kha.tech/api/kha/graphics2/Graphics.html#drawImage).
+    """
+    bl_idname = 'LNDrawSubImageNode'
+    bl_label = 'Draw Sub Image'
+    arm_section = 'draw'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'Draw')
+        self.add_input('ArmStringSocket', 'Image File')
+        self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
+        self.add_input('ArmIntSocket', '0/1/2 = Left/Center/Right', default_value=0)
+        self.add_input('ArmIntSocket', '0/1/2 = Top/Middle/Bottom', default_value=0)
+        self.add_input('ArmFloatSocket', 'X')
+        self.add_input('ArmFloatSocket', 'Y')
+        self.add_input('ArmFloatSocket', 'Width')
+        self.add_input('ArmFloatSocket', 'Height')
+        self.add_input('ArmFloatSocket', 'sX')
+        self.add_input('ArmFloatSocket', 'sY')
+        self.add_input('ArmFloatSocket', 'sWidth')
+        self.add_input('ArmFloatSocket', 'sHeight')
+        self.add_input('ArmFloatSocket', 'Angle')
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/logicnode/native/LN_write_image.py
+++ b/armory/blender/arm/logicnode/native/LN_write_image.py
@@ -1,0 +1,37 @@
+from arm.logicnode.arm_nodes import *
+
+
+class WriteImageNode(ArmLogicTreeNode):
+    """Writes the given image to the given file. If the image
+    already exists, the existing content of the image is overwritten.
+
+    Aspect ratio must match display resolution ratio.
+
+    @input Image File: the name of the image, relative to `Krom.getFilesLocation()`
+    @input Camera: the render target image of the camera to write to the image file.
+    @input Width: width of the image file.
+    @input Height: heigth of the image file.
+    @input sX: sub position of first x pixel of the sub image (0 for start).
+    @input sY: sub position of first y pixel of the sub image (0 for start).
+    @input sWidth: width of the sub image.
+    @input sHeight: height of the sub image.
+
+    @seeNode Read File
+    """
+    bl_idname = 'LNWriteImageNode'
+    bl_label = 'Write Image'
+    arm_section = 'file'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmStringSocket', 'Image File')
+        self.add_input('ArmNodeSocketObject', 'Camera')
+        self.add_input('ArmIntSocket', 'Width')
+        self.add_input('ArmIntSocket', 'Height')
+        self.add_input('ArmIntSocket', 'sX')
+        self.add_input('ArmIntSocket', 'sY')
+        self.add_input('ArmIntSocket', 'sWidth')
+        self.add_input('ArmIntSocket', 'sHeight')
+
+        self.add_output('ArmNodeSocketAction', 'Out')


### PR DESCRIPTION
`Write Image Node` : allows to take a snapshot of a camera and export it as an image file (supports sub image). Uses format/bmp for image formatting. Works for krom and html5. This was a hard one to get done.

`Draw Sub Image Node`: draws a sub image which is a section of the image. So for example the same image can be used showing different sections of the image or you by making some animation like zooming in or moving along the image. 

![image](https://github.com/user-attachments/assets/0943ea15-805c-488b-9abc-4488da1bd5ee)
