### PR TITLE
Add fixedUpdate for Physics

### DIFF
--- a/armory/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
+++ b/armory/Sources/armory/trait/physics/bullet/PhysicsWorld.hx
@@ -116,9 +116,9 @@ class PhysicsWorld extends Trait {
 		conMap = new Map();
 		active = this;
 
-		// Ensure physics are updated first in the lateUpdate list
-		_lateUpdate = [lateUpdate];
-		@:privateAccess iron.App.traitLateUpdates.insert(0, lateUpdate);
+		// Ensure physics are updated first in the fixedUpdate list
+		_fixedUpdate = [fixedUpdate];
+		@:privateAccess iron.App.traitFixedUpdates.insert(0, fixedUpdate);
 
 		setDebugDrawMode(debugDrawMode);
 
@@ -277,7 +277,7 @@ class PhysicsWorld extends Trait {
 		return rb;
 	}
 
-	function lateUpdate() {
+	function fixedUpdate() {
 		var t = Time.delta * timeScale;
 		if (t == 0.0) return; // Simulation paused
 
@@ -291,9 +291,9 @@ class PhysicsWorld extends Trait {
 		var fixedTime = 1.0 / 60;
 
 		//This condition must be satisfied to not loose time
-		var currMaxSteps = t < (fixedTime * maxSteps) ? maxSteps : 1;
+		var currMaxSteps = t < (Time.fixedStep * maxSteps) ? maxSteps : 1;
 
-		world.stepSimulation(t, currMaxSteps, fixedTime);
+		world.stepSimulation(t, currMaxSteps, Time.fixedStep);
 		updateContacts();
 
 		for (rb in rbMap) { @:privateAccess try { rb.physicsUpdate(); } catch(e:haxe.Exception) { trace(e.message); } } // HACK: see this recommendation: https://github.com/armory3d/armory/issues/3044#issuecomment-2558199944.

--- a/armory/Sources/iron/App.hx
+++ b/armory/Sources/iron/App.hx
@@ -12,6 +12,7 @@ class App {
 	static var traitInits: Array<Void->Void> = [];
 	static var traitUpdates: Array<Void->Void> = [];
 	static var traitLateUpdates: Array<Void->Void> = [];
+	static var traitFixedUpdates: Array<Void->Void> = [];
 	static var traitRenders: Array<kha.graphics4.Graphics->Void> = [];
 	static var traitRenders2D: Array<kha.graphics2.Graphics->Void> = [];
 	public static var framebuffer: kha.Framebuffer;
@@ -23,6 +24,8 @@ class App {
 	public static var renderPathTime: Float;
 	public static var endFrameCallbacks: Array<Void->Void> = [];
 	#end
+	static var last = 0.0;
+	static var time = 0.0;
 	static var lastw = -1;
 	static var lasth = -1;
 	public static var onResize: Void->Void = null;
@@ -41,6 +44,7 @@ class App {
 		traitInits = [];
 		traitUpdates = [];
 		traitLateUpdates = [];
+		traitFixedUpdates = [];
 		traitRenders = [];
 		traitRenders2D = [];
 		if (onResets != null) for (f in onResets) f();
@@ -75,6 +79,13 @@ class App {
 		while (i < l) {
 			traitLateUpdates[i]();
 			l <= traitLateUpdates.length ? i++ : l = traitLateUpdates.length;
+		}
+
+		time += iron.system.Time.realTime() - last;
+		last = iron.system.Time.realTime();
+		while (time >= iron.system.Time.fixedStep) {
+			for (f in traitFixedUpdates) f();
+			time -= iron.system.Time.fixedStep;
 		}
 
 		if (onEndFrames != null) for (f in onEndFrames) f();
@@ -170,6 +181,14 @@ class App {
 
 	public static function removeLateUpdate(f: Void->Void) {
 		traitLateUpdates.remove(f);
+	}
+
+	public static function notifyOnFixedUpdate(f: Void->Void) {
+		traitFixedUpdates.push(f);
+	}
+
+	public static function removeFixedUpdate(f: Void->Void) {
+		traitFixedUpdates.remove(f);
 	}
 
 	public static function notifyOnRender(f: kha.graphics4.Graphics->Void) {

--- a/armory/Sources/iron/Trait.hx
+++ b/armory/Sources/iron/Trait.hx
@@ -16,6 +16,7 @@ class Trait {
 	var _remove: Array<Void->Void> = null;
 	var _update: Array<Void->Void> = null;
 	var _lateUpdate: Array<Void->Void> = null;
+	var _fixedUpdate: Array<Void->Void> = null;
 	var _render: Array<kha.graphics4.Graphics->Void> = null;
 	var _render2D: Array<kha.graphics2.Graphics->Void> = null;
 
@@ -85,6 +86,23 @@ class Trait {
 	public function removeLateUpdate(f: Void->Void) {
 		_lateUpdate.remove(f);
 		App.removeLateUpdate(f);
+	}
+
+    /**
+      Add fixed game logic handler.
+    **/
+	public function notifyOnFixedUpdate(f: Void->Void) {
+		if (_fixedUpdate == null) _fixedUpdate = [];
+		_fixedUpdate.push(f);
+		App.notifyOnFixedUpdate(f);
+	}
+
+    /**
+      Remove fixed game logic handler.
+    **/
+	public function removeFixedUpdate(f: Void->Void) {
+		_fixedUpdate.remove(f);
+		App.removeFixedUpdate(f);
 	}
 
     /**

--- a/armory/Sources/iron/system/Time.hx
+++ b/armory/Sources/iron/system/Time.hx
@@ -7,6 +7,11 @@ class Time {
 		if (frequency == null) initFrequency();
 		return 1 / frequency;
 	}
+	// TODO: set physics step from Blender's editor
+	public static var fixedStep(get, never): Float;
+	static function get_fixedStep(): Float {
+		return 1 / 60;
+	}
 
 	public static var scale = 1.0;
 	public static var delta(get, never): Float;


### PR DESCRIPTION
This adds fixedUpdate to call physics logic from traits with fixed time steps. This keeps the physics running at the same speed regardless of the game's framerate. This doesn't have interpolation yet.