### PR TITLE
Ies Texture and Cloud Texture: improvements

### DIFF
--- a/armory/blender/arm/make_renderpath.py
+++ b/armory/blender/arm/make_renderpath.py
@@ -40,11 +40,11 @@ def add_world_defs():
     if rpdat.rp_hdr == False:
         wrd.world_defs += '_LDR'
 
-    if arm.utils.get_active_scene().arm_light_ies_texture == True:
+    if arm.utils.get_active_scene().world.arm_light_ies_texture == True:
         wrd.world_defs += '_LightIES'
         assets.add_embedded_data('iestexture.png')
 
-    if arm.utils.get_active_scene().arm_light_clouds_texture == True:
+    if arm.utils.get_active_scene().world.arm_light_clouds_texture == True:
         wrd.world_defs += '_LightClouds'
         assets.add_embedded_data('cloudstexture.png')
 

--- a/armory/blender/arm/make_renderpath.py
+++ b/armory/blender/arm/make_renderpath.py
@@ -40,11 +40,11 @@ def add_world_defs():
     if rpdat.rp_hdr == False:
         wrd.world_defs += '_LDR'
 
-    if wrd.arm_light_ies_texture != '':
+    if wrd.arm_light_ies_texture == True:
         wrd.world_defs += '_LightIES'
         assets.add_embedded_data('iestexture.png')
 
-    if wrd.arm_light_clouds_texture != '':
+    if wrd.arm_light_clouds_texture == True:
         wrd.world_defs += '_LightClouds'
         assets.add_embedded_data('cloudstexture.png')
 

--- a/armory/blender/arm/make_renderpath.py
+++ b/armory/blender/arm/make_renderpath.py
@@ -40,11 +40,11 @@ def add_world_defs():
     if rpdat.rp_hdr == False:
         wrd.world_defs += '_LDR'
 
-    if wrd.arm_light_ies_texture == True:
+    if arm.utils.get_active_scene().arm_light_ies_texture == True:
         wrd.world_defs += '_LightIES'
         assets.add_embedded_data('iestexture.png')
 
-    if wrd.arm_light_clouds_texture == True:
+    if arm.utils.get_active_scene().arm_light_clouds_texture == True:
         wrd.world_defs += '_LightClouds'
         assets.add_embedded_data('cloudstexture.png')
 

--- a/armory/blender/arm/props.py
+++ b/armory/blender/arm/props.py
@@ -505,8 +505,10 @@ def init_properties():
     bpy.types.Light.arm_clip_end = FloatProperty(name="Clip End", default=50.0)
     bpy.types.Light.arm_fov = FloatProperty(name="Field of View", default=0.84)
     bpy.types.Light.arm_shadows_bias = FloatProperty(name="Bias", description="Depth offset to fight shadow acne", default=1.0)
-    bpy.types.World.arm_light_ies_texture = StringProperty(name="IES Texture", default="")
-    bpy.types.World.arm_light_clouds_texture = StringProperty(name="Clouds Texture", default="")
+
+    # For world
+    bpy.types.World.arm_light_ies_texture = BoolProperty(name="IES Texture (iestexture.png)", default=False, update=assets.invalidate_compiler_cache)
+    bpy.types.World.arm_light_clouds_texture = BoolProperty(name="Clouds Texture (cloudstexture.png)", default=False, update=assets.invalidate_compiler_cache)
 
     bpy.types.World.arm_rpcache_list = CollectionProperty(type=bpy.types.PropertyGroup)
     bpy.types.World.arm_scripts_list = CollectionProperty(type=bpy.types.PropertyGroup)

--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -275,8 +275,6 @@ class ARM_PT_DataPropsPanel(bpy.types.Panel):
             layout.prop(obj.data, 'arm_clip_end')
             layout.prop(obj.data, 'arm_fov')
             layout.prop(obj.data, 'arm_shadows_bias')
-            layout.prop(wrd, 'arm_light_ies_texture')
-            layout.prop(wrd, 'arm_light_clouds_texture')
         elif obj.type == 'SPEAKER':
             layout.prop(obj.data, 'arm_play_on_start')
             layout.prop(obj.data, 'arm_loop')
@@ -299,6 +297,9 @@ class ARM_PT_WorldPropsPanel(bpy.types.Panel):
         world = context.world
         if world is None:
             return
+
+        layout.prop(world, 'arm_light_ies_texture')
+        layout.prop(world, 'arm_light_clouds_texture')
 
         layout.prop(world, 'arm_use_clouds')
         col = layout.column(align=True)


### PR DESCRIPTION
Both texture use was confusing because it was a world property under a light menu section. And only 1 texture can be used in a world, which can have different lights and all of them uses the same texture. 

Besides, the name of the texture which can not be changed was not visible for reference.

The property was defined as a string but was used as a boolean.

I also modified the world reference: is always using worlds['Arm'] instead of get_active_scene().world (context world or play/export scene config world).

![image](https://github.com/user-attachments/assets/a526e9d7-a516-4713-bb1b-82367cb85c45)
