### PR TITLE
fix scene exposure setting

### DIFF
--- a/armory/blender/arm/make_renderpath.py
+++ b/armory/blender/arm/make_renderpath.py
@@ -229,7 +229,7 @@ def build():
                 wrd.compo_defs += '_CGrain'
             if rpdat.arm_sharpen:
                 wrd.compo_defs += '_CSharpen'
-            if bpy.data.scenes[0].view_settings.exposure != 0.0:
+            if arm.utils.get_active_scene().view_settings.exposure != 0.0:
                 wrd.compo_defs += '_CExposure'
             if rpdat.arm_fog:
                 wrd.compo_defs += '_CFog'

--- a/armory/blender/arm/write_data.py
+++ b/armory/blender/arm/write_data.py
@@ -728,9 +728,9 @@ const vec3 compoLetterboxColor = vec3(""" + str(round(rpdat.arm_letterbox_color[
 """const float compoSharpenStrength = """ + str(round(rpdat.arm_sharpen_strength * 100) / 100) + """;
 """)
 
-        if bpy.data.scenes[0].view_settings.exposure != 0.0:
+        if arm.utils.get_active_scene().view_settings.exposure != 0.0:
             f.write(
-"""const float compoExposureStrength = """ + str(round(bpy.data.scenes[0].view_settings.exposure * 100) / 100) + """;
+"""const float compoExposureStrength = """ + str(round(arm.utils.get_active_scene().view_settings.exposure * 100) / 100) + """;
 """)
 
         if rpdat.arm_fog:


### PR DESCRIPTION
Exposure setting was `bpy.data.scenes[0]` pointing always to scene 0 disregarding context scene or play or export scene options so I changed to `arm.utils.get_active_scene()`

The same happens a lot for `bpy.data.worlds['Arm']` is hardcoded world instead of using `arm.utils.get_active_scene().world`. 
@luboslenco is that ok?