### PR TITLE
Framerate and delta fixes

### DIFF
--- a/armory/Sources/armory/logicnode/GetFPSNode.hx
+++ b/armory/Sources/armory/logicnode/GetFPSNode.hx
@@ -8,7 +8,7 @@ class GetFPSNode extends LogicNode {
 
     override function get(from: Int): Dynamic {
         if (from == 0) {
-            var fps = Math.round(1 / iron.system.Time.delta);
+            var fps = Math.round(1 / iron.system.Time.renderDelta);
             if ((fps == Math.POSITIVE_INFINITY) || (fps == Math.NEGATIVE_INFINITY) || (Math.isNaN(fps))) {
                 return 0;
             }

--- a/armory/Sources/armory/logicnode/GetFPSNode.hx
+++ b/armory/Sources/armory/logicnode/GetFPSNode.hx
@@ -8,7 +8,7 @@ class GetFPSNode extends LogicNode {
 
     override function get(from: Int): Dynamic {
         if (from == 0) {
-            var fps = Math.round(1 / iron.system.Time.realDelta);
+            var fps = Math.round(1 / iron.system.Time.delta);
             if ((fps == Math.POSITIVE_INFINITY) || (fps == Math.NEGATIVE_INFINITY) || (Math.isNaN(fps))) {
                 return 0;
             }

--- a/armory/Sources/iron/object/Animation.hx
+++ b/armory/Sources/iron/object/Animation.hx
@@ -130,6 +130,13 @@ class Animation {
 				if (frameIndex == anim.marker_frames[i]) {
 					var ar = markerEvents.get(anim.marker_names[i]);
 					if (ar != null) for (f in ar) f();
+				} else {
+					for (j in 0...(frameIndex - lastFrameIndex)) {
+						if (lastFrameIndex + j + 1 == anim.marker_frames[i]) {
+							var ar = markerEvents.get(anim.marker_names[i]);
+							if (ar != null) for (f in ar) f();
+						}
+					}
 				}
 			}
 			lastFrameIndex = frameIndex;

--- a/armory/Sources/iron/object/ParticleSystem.hx
+++ b/armory/Sources/iron/object/ParticleSystem.hx
@@ -144,7 +144,7 @@ class ParticleSystem {
 		}
 
 		// Animate
-		time += Time.delta * speed;
+		time += Time.renderDelta * speed;
 		lap = Std.int(time / animtime);
 		lapTime = time - lap * animtime;
 		count = Std.int(lapTime / spawnRate);

--- a/armory/Sources/iron/object/ParticleSystem.hx
+++ b/armory/Sources/iron/object/ParticleSystem.hx
@@ -144,7 +144,7 @@ class ParticleSystem {
 		}
 
 		// Animate
-		time += Time.realDelta * Time.scale * speed;
+		time += Time.delta * Time.scale * speed;
 		lap = Std.int(time / animtime);
 		lapTime = time - lap * animtime;
 		count = Std.int(lapTime / spawnRate);

--- a/armory/Sources/iron/object/ParticleSystem.hx
+++ b/armory/Sources/iron/object/ParticleSystem.hx
@@ -144,7 +144,7 @@ class ParticleSystem {
 		}
 
 		// Animate
-		time += Time.delta * Time.scale * speed;
+		time += Time.delta * speed;
 		lap = Std.int(time / animtime);
 		lapTime = time - lap * animtime;
 		count = Std.int(lapTime / spawnRate);

--- a/armory/Sources/iron/object/Tilesheet.hx
+++ b/armory/Sources/iron/object/Tilesheet.hx
@@ -80,7 +80,7 @@ class Tilesheet {
 	function update() {
 		if (!ready || paused || action.start >= action.end) return;
 
-		time += Time.realDelta;
+		time += Time.delta;
 
 		var frameTime = 1 / raw.framerate;
 		var framesToAdvance = 0;

--- a/armory/Sources/iron/object/Tilesheet.hx
+++ b/armory/Sources/iron/object/Tilesheet.hx
@@ -80,7 +80,7 @@ class Tilesheet {
 	function update() {
 		if (!ready || paused || action.start >= action.end) return;
 
-		time += Time.delta;
+		time += Time.renderDelta;
 
 		var frameTime = 1 / raw.framerate;
 		var framesToAdvance = 0;


### PR DESCRIPTION
Depends on #3165 where `iron.system.Time.delta` is properly calculated.

- fix to call animation markers from skipped frames
- use `delta` instead of `realDelta`