### PR TITLE
Post Process Node Updates

### DIFF
--- a/armory/Shaders/blur_bilat_blend_pass/blur_bilat_blend_pass.frag.glsl
+++ b/armory/Shaders/blur_bilat_blend_pass/blur_bilat_blend_pass.frag.glsl
@@ -3,6 +3,10 @@
 
 #include "compiled.inc"
 
+#ifdef _CPostprocess
+uniform vec4 PPComp17;
+#endif
+
 uniform sampler2D tex;
 uniform vec2 dir;
 uniform vec2 screenSize;
@@ -45,6 +49,12 @@ void main() {
 		res += factor * col;
 	}
 
+	#ifdef _CPostprocess
+		vec3 AirColor = vec3(PPComp17.x, PPComp17.y, PPComp17.z);
+	#else
+		vec3 AirColor = volumAirColor;
+	#endif
+
 	res /= sumfactor;
-	fragColor = vec4(volumAirColor * res, 1.0);
+	fragColor = vec4(AirColor * res, 1.0);
 }

--- a/armory/Shaders/blur_bilat_blend_pass/blur_bilat_blend_pass.json
+++ b/armory/Shaders/blur_bilat_blend_pass/blur_bilat_blend_pass.json
@@ -19,6 +19,11 @@
 				{
 					"name": "screenSize",
 					"link": "_screenSize"
+				},
+				{
+					"name": "PPComp17",
+					"link": "_PPComp17",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],

--- a/armory/Shaders/compositor_pass/compositor_pass.json
+++ b/armory/Shaders/compositor_pass/compositor_pass.json
@@ -235,6 +235,16 @@
 					"name": "PPComp15",
 					"link": "_PPComp15",
 					"ifdef": ["_CPostprocess"]
+				},
+				{
+					"name": "PPComp16",
+					"link": "_PPComp16",
+					"ifdef": ["_CPostprocess"]
+				},
+				{
+					"name": "PPComp18",
+					"link": "_PPComp18",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],

--- a/armory/Shaders/histogram_pass/histogram_pass.frag.glsl
+++ b/armory/Shaders/histogram_pass/histogram_pass.frag.glsl
@@ -2,13 +2,22 @@
 
 #include "compiled.inc"
 
+#ifdef _CPostprocess
+uniform vec3 PPComp8;
+#endif
+
 uniform sampler2D tex;
 
 in vec2 texCoord;
 out vec4 fragColor;
 
 void main() {
-	fragColor.a = 0.01 * autoExposureSpeed;
+	#ifdef _CPostprocess
+		fragColor.a = 0.01 * PPComp8.z;
+	#else
+		fragColor.a = 0.01 * autoExposureSpeed;
+	#endif
+
 	fragColor.rgb = textureLod(tex, vec2(0.5, 0.5), 0.0).rgb +
 					textureLod(tex, vec2(0.2, 0.2), 0.0).rgb +
 					textureLod(tex, vec2(0.8, 0.2), 0.0).rgb +

--- a/armory/Shaders/histogram_pass/histogram_pass.json
+++ b/armory/Shaders/histogram_pass/histogram_pass.json
@@ -8,7 +8,13 @@
 			"blend_source": "source_alpha",
 			"blend_destination": "inverse_source_alpha",
 			"blend_operation": "add",
-			"links": [],
+			"links": [
+				{
+					"name": "PPComp8",
+					"link": "_PPComp8",
+					"ifdef": ["_CPostprocess"]
+				}
+			],
 			"texture_params": [],
 			"vertex_shader": "../include/pass.vert.glsl",
 			"fragment_shader": "histogram_pass.frag.glsl"

--- a/armory/Shaders/volumetric_light/volumetric_light.frag.glsl
+++ b/armory/Shaders/volumetric_light/volumetric_light.frag.glsl
@@ -11,6 +11,11 @@
 #include "std/light_common.glsl"
 #endif
 
+#ifdef _CPostprocess
+uniform vec3 PPComp11;
+uniform vec4 PPComp17;
+#endif
+
 uniform sampler2D gbufferD;
 uniform sampler2D snoise;
 
@@ -87,7 +92,15 @@ out float fragColor;
 const float tScat = 0.08;
 const float tAbs = 0.0;
 const float tExt = tScat + tAbs;
-const float stepLen = 1.0 / volumSteps;
+
+#ifdef _CPostprocess
+	float stepLen = 1.0 / int(PPComp11.y);
+	float AirTurbidity = PPComp17.w;
+#else
+	const float stepLen = 1.0 / volumSteps;
+	float AirTurbidity = volumAirTurbidity;
+#endif
+
 const float lighting = 0.4;
 
 void rayStep(inout vec3 curPos, inout float curOpticalDepth, inout float scatteredLightAmount, float stepLenWorld, vec3 viewVecNorm) {
@@ -162,5 +175,5 @@ void main() {
 		rayStep(curPos, curOpticalDepth, scatteredLightAmount, stepLenWorld, viewVecNorm);
 	}
 
-	fragColor = scatteredLightAmount * volumAirTurbidity;
+	fragColor = scatteredLightAmount * AirTurbidity;
 }

--- a/armory/Shaders/volumetric_light/volumetric_light.json
+++ b/armory/Shaders/volumetric_light/volumetric_light.json
@@ -140,6 +140,16 @@
 					"link": "_biasLightWorldViewProjectionMatrixSpot3",
 					"ifndef": ["_ShadowMapAtlas"],
 					"ifdef": ["_Spot", "_ShadowMap"]
+				},
+				{
+					"name": "PPComp11",
+					"link": "_PPComp11",
+					"ifdef": ["_CPostprocess"]
+				},
+				{
+					"name": "PPComp17",
+					"link": "_PPComp17",
+					"ifdef": ["_CPostprocess"]
 				}
 			],
 			"texture_params": [],

--- a/armory/Sources/armory/logicnode/AutoExposureGetNode.hx
+++ b/armory/Sources/armory/logicnode/AutoExposureGetNode.hx
@@ -8,8 +8,8 @@ class AutoExposureGetNode extends LogicNode {
 
 	override function get(from:Int):Dynamic {
 		return switch (from) {
-			case 0: armory.renderpath.Postprocess.auto_exposure[0];
-			case 1: armory.renderpath.Postprocess.auto_exposure[1];
+			case 0: armory.renderpath.Postprocess.auto_exposure_uniforms[0];
+			case 1: armory.renderpath.Postprocess.auto_exposure_uniforms[1];
 			default: 0.0;
 		}
 	}

--- a/armory/Sources/armory/logicnode/AutoExposureGetNode.hx
+++ b/armory/Sources/armory/logicnode/AutoExposureGetNode.hx
@@ -1,0 +1,16 @@
+package armory.logicnode;
+
+class AutoExposureGetNode extends LogicNode {
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function get(from:Int):Dynamic {
+		return switch (from) {
+			case 0: armory.renderpath.Postprocess.auto_exposure[0];
+			case 1: armory.renderpath.Postprocess.auto_exposure[1];
+			default: 0.0;
+		}
+	}
+}

--- a/armory/Sources/armory/logicnode/AutoExposureSetNode.hx
+++ b/armory/Sources/armory/logicnode/AutoExposureSetNode.hx
@@ -7,8 +7,8 @@ class AutoExposureSetNode extends LogicNode {
 	}
 
 	override function run(from:Int) {
-        armory.renderpath.Postprocess.auto_exposure[0] = inputs[1].get();
-        armory.renderpath.Postprocess.auto_exposure[1] = inputs[2].get();
+        armory.renderpath.Postprocess.auto_exposure_uniforms[0] = inputs[1].get();
+        armory.renderpath.Postprocess.auto_exposure_uniforms[1] = inputs[2].get();
 
 		runOutput(0);
 	}

--- a/armory/Sources/armory/logicnode/AutoExposureSetNode.hx
+++ b/armory/Sources/armory/logicnode/AutoExposureSetNode.hx
@@ -1,0 +1,15 @@
+package armory.logicnode;
+
+class AutoExposureSetNode extends LogicNode {
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function run(from:Int) {
+        armory.renderpath.Postprocess.auto_exposure[0] = inputs[1].get();
+        armory.renderpath.Postprocess.auto_exposure[1] = inputs[2].get();
+
+		runOutput(0);
+	}
+}

--- a/armory/Sources/armory/logicnode/CameraSetNode.hx
+++ b/armory/Sources/armory/logicnode/CameraSetNode.hx
@@ -39,6 +39,8 @@ class CameraSetNode extends LogicNode {
 				armory.renderpath.Postprocess.camera_uniforms[12] = inputs[1].get();//Sharpen
 			case 'Vignette':
 				armory.renderpath.Postprocess.camera_uniforms[13] = inputs[1].get();//Vignette
+			case 'Exposure':
+				armory.renderpath.Postprocess.exposure[0] = inputs[1].get();//Exposure
 			default: 
 				null;
 			}

--- a/armory/Sources/armory/logicnode/CameraSetNode.hx
+++ b/armory/Sources/armory/logicnode/CameraSetNode.hx
@@ -40,7 +40,7 @@ class CameraSetNode extends LogicNode {
 			case 'Vignette':
 				armory.renderpath.Postprocess.camera_uniforms[13] = inputs[1].get();//Vignette
 			case 'Exposure':
-				armory.renderpath.Postprocess.exposure[0] = inputs[1].get();//Exposure
+				armory.renderpath.Postprocess.exposure_uniforms[0] = inputs[1].get();//Exposure
 			default: 
 				null;
 			}

--- a/armory/Sources/armory/logicnode/CameraSetNode.hx
+++ b/armory/Sources/armory/logicnode/CameraSetNode.hx
@@ -2,25 +2,46 @@ package armory.logicnode;
 
 class CameraSetNode extends LogicNode {
 
+	public var property0: String;
+
 	public function new(tree:LogicTree) {
 		super(tree);
 	}
 
 	override function run(from:Int) {
-		armory.renderpath.Postprocess.camera_uniforms[0] = inputs[1].get();//Camera: F-Number
-		armory.renderpath.Postprocess.camera_uniforms[1] = inputs[2].get();//Camera: Shutter time
-		armory.renderpath.Postprocess.camera_uniforms[2] = inputs[3].get();//Camera: ISO
-		armory.renderpath.Postprocess.camera_uniforms[3] = inputs[4].get();//Camera: Exposure Compensation
-		armory.renderpath.Postprocess.camera_uniforms[4] = inputs[5].get();//Fisheye Distortion
-		armory.renderpath.Postprocess.camera_uniforms[5] = inputs[6].get();//DoF AutoFocus §§ If true, it ignores the DoF Distance setting
-		armory.renderpath.Postprocess.camera_uniforms[6] = inputs[7].get();//DoF Distance
-		armory.renderpath.Postprocess.camera_uniforms[7] = inputs[8].get();//DoF Focal Length mm
-		armory.renderpath.Postprocess.camera_uniforms[8] = inputs[9].get();//DoF F-Stop
-		armory.renderpath.Postprocess.camera_uniforms[9] = inputs[10].get();//Tonemapping Method
-		armory.renderpath.Postprocess.camera_uniforms[10] = inputs[11].get();//Distort
-		armory.renderpath.Postprocess.camera_uniforms[11] = inputs[12].get();//Film Grain
-		armory.renderpath.Postprocess.camera_uniforms[12] = inputs[13].get();//Sharpen
-		armory.renderpath.Postprocess.camera_uniforms[13] = inputs[14].get();//Vignette
+
+		switch (property0) {
+			case 'F-stop':
+				armory.renderpath.Postprocess.camera_uniforms[0] = inputs[1].get();//Camera: F-Number
+			case 'Shutter Time':	
+				armory.renderpath.Postprocess.camera_uniforms[1] = inputs[1].get();//Camera: Shutter time
+			case 'ISO':
+				armory.renderpath.Postprocess.camera_uniforms[2] = inputs[1].get();//Camera: ISO
+			case 'Exposure Compensation':
+				armory.renderpath.Postprocess.camera_uniforms[3] = inputs[1].get();//Camera: Exposure Compensation
+			case 'Fisheye Distortion':
+				armory.renderpath.Postprocess.camera_uniforms[4] = inputs[1].get();//Fisheye Distortion
+			case 'Auto Focus':
+				armory.renderpath.Postprocess.camera_uniforms[5] = inputs[1].get();//DoF AutoFocus §§ If true, it ignores the DoF Distance setting
+			case 'DoF Distance':
+				armory.renderpath.Postprocess.camera_uniforms[6] = inputs[1].get();//DoF Distance
+			case 'DoF Length':
+				armory.renderpath.Postprocess.camera_uniforms[7] = inputs[1].get();//DoF Focal Length mm
+			case 'DoF F-Stop':
+				armory.renderpath.Postprocess.camera_uniforms[8] = inputs[1].get();//DoF F-Stop
+			case 'Tonemapping':
+				armory.renderpath.Postprocess.camera_uniforms[9] = inputs[1].get();//Tonemapping Method
+			case 'Distort':
+				armory.renderpath.Postprocess.camera_uniforms[10] = inputs[1].get();//Distort
+			case 'Film Grain':
+				armory.renderpath.Postprocess.camera_uniforms[11] = inputs[1].get();//Film Grain
+			case 'Sharpen':
+				armory.renderpath.Postprocess.camera_uniforms[12] = inputs[1].get();//Sharpen
+			case 'Vignette':
+				armory.renderpath.Postprocess.camera_uniforms[13] = inputs[1].get();//Vignette
+			default: 
+				null;
+			}
 
 		runOutput(0);
 	}

--- a/armory/Sources/armory/logicnode/SharpenGetNode.hx
+++ b/armory/Sources/armory/logicnode/SharpenGetNode.hx
@@ -1,0 +1,17 @@
+package armory.logicnode;
+
+class SharpenGetNode extends LogicNode {
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function get(from:Int):Dynamic {
+		return switch (from) {
+			case 0: armory.renderpath.Postprocess.sharpen_uniforms[0];
+			case 1: armory.renderpath.Postprocess.sharpen_uniforms[1][0];
+			case 2: armory.renderpath.Postprocess.camera_uniforms[12];
+			default: 0.0;
+		}
+	}
+}

--- a/armory/Sources/armory/logicnode/SharpenSetNode.hx
+++ b/armory/Sources/armory/logicnode/SharpenSetNode.hx
@@ -1,0 +1,18 @@
+package armory.logicnode;
+
+class SharpenSetNode extends LogicNode {
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function run(from:Int) {
+        armory.renderpath.Postprocess.sharpen_uniforms[0][0] = inputs[1].get().x;
+        armory.renderpath.Postprocess.sharpen_uniforms[0][1] = inputs[1].get().y;
+        armory.renderpath.Postprocess.sharpen_uniforms[0][2] = inputs[1].get().z;
+        armory.renderpath.Postprocess.sharpen_uniforms[1][0] = inputs[2].get();
+        armory.renderpath.Postprocess.camera_uniforms[12] = inputs[3].get();
+
+		runOutput(0);
+	}
+}

--- a/armory/Sources/armory/logicnode/VolumetricFogGetNode.hx
+++ b/armory/Sources/armory/logicnode/VolumetricFogGetNode.hx
@@ -1,0 +1,17 @@
+package armory.logicnode;
+
+class VolumetricFogGetNode extends LogicNode {
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function get(from:Int):Dynamic {
+		return switch (from) {
+			case 0: armory.renderpath.Postprocess.volumetric_fog_uniforms[0];
+			case 1: armory.renderpath.Postprocess.volumetric_fog_uniforms[1][0];
+			case 2: armory.renderpath.Postprocess.volumetric_fog_uniforms[2][0];
+			default: 0.0;
+		}
+	}
+}

--- a/armory/Sources/armory/logicnode/VolumetricFogSetNode.hx
+++ b/armory/Sources/armory/logicnode/VolumetricFogSetNode.hx
@@ -1,0 +1,18 @@
+package armory.logicnode;
+
+class VolumetricFogSetNode extends LogicNode {
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function run(from:Int) {
+        armory.renderpath.Postprocess.volumetric_fog_uniforms[0][0] = inputs[1].get().x;
+        armory.renderpath.Postprocess.volumetric_fog_uniforms[0][1] = inputs[1].get().y;
+        armory.renderpath.Postprocess.volumetric_fog_uniforms[0][2] = inputs[1].get().z;
+        armory.renderpath.Postprocess.volumetric_fog_uniforms[1][0] = inputs[2].get();
+        armory.renderpath.Postprocess.volumetric_fog_uniforms[2][0] = inputs[3].get();
+
+		runOutput(0);
+	}
+}

--- a/armory/Sources/armory/logicnode/VolumetricLightGetNode.hx
+++ b/armory/Sources/armory/logicnode/VolumetricLightGetNode.hx
@@ -1,0 +1,17 @@
+package armory.logicnode;
+
+class VolumetricLightGetNode extends LogicNode {
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function get(from:Int):Dynamic {
+		return switch (from) {
+			case 0: armory.renderpath.Postprocess.volumetric_light_uniforms[0];
+			case 1: armory.renderpath.Postprocess.volumetric_light_uniforms[1][0];
+			case 2: armory.renderpath.Postprocess.volumetric_light_uniforms[2][0];
+			default: 0.0;
+		}
+	}
+}

--- a/armory/Sources/armory/logicnode/VolumetricLightSetNode.hx
+++ b/armory/Sources/armory/logicnode/VolumetricLightSetNode.hx
@@ -1,0 +1,18 @@
+package armory.logicnode;
+
+class VolumetricLightSetNode extends LogicNode {
+
+	public function new(tree:LogicTree) {
+		super(tree);
+	}
+
+	override function run(from:Int) {
+        armory.renderpath.Postprocess.volumetric_light_uniforms[0][0] = inputs[1].get().x;
+        armory.renderpath.Postprocess.volumetric_light_uniforms[0][1] = inputs[1].get().y;
+        armory.renderpath.Postprocess.volumetric_light_uniforms[0][2] = inputs[1].get().z;
+        armory.renderpath.Postprocess.volumetric_light_uniforms[1][0] = inputs[2].get();
+        armory.renderpath.Postprocess.volumetric_light_uniforms[2][0] = inputs[3].get();
+
+		runOutput(0);
+	}
+}

--- a/armory/Sources/armory/renderpath/Postprocess.hx
+++ b/armory/Sources/armory/renderpath/Postprocess.hx
@@ -110,11 +110,11 @@ class Postprocess {
 		32					//1: Samples
 	];
 
-	public static var exposure = [
+	public static var exposure_uniforms = [
 		1 					//0: Exposure
 	];
 
-	public static var auto_exposure = [
+	public static var auto_exposure_uniforms = [
 		1, 					//0: Auto Exposure Strength
 		1 					//1: Auto Exposure Speed
 	];
@@ -313,9 +313,9 @@ class Postprocess {
 			v.z = lenstexture_uniforms[4]; //Expo
 		case "_PPComp8":
 			v = iron.object.Uniforms.helpVec;
-			v.x = exposure[0];	   //Exposure
-			v.y = auto_exposure[0]; //Auto Exposure Strength
-			v.z = auto_exposure[1]; //Auto Exposure Speed
+			v.x = exposure_uniforms[0];	   //Exposure
+			v.y = auto_exposure_uniforms[0]; //Auto Exposure Strength
+			v.z = auto_exposure_uniforms[1]; //Auto Exposure Speed
 		case "_PPComp9":
 			v = iron.object.Uniforms.helpVec;
 			v.x = ssr_uniforms[0]; //Step

--- a/armory/Sources/armory/renderpath/Postprocess.hx
+++ b/armory/Sources/armory/renderpath/Postprocess.hx
@@ -54,8 +54,13 @@ class Postprocess {
 		0,					//9: Tonemapping Method
 		2.0,				//10: Distort
 		2.0,				//11: Film Grain
-		0.25,				//12: Sharpen
+		0.25,				//12: Sharpen Strength
 		0.7					//13: Vignette
+	];
+
+	public static var sharpen_uniforms = [
+		[0.0, 0.0, 0.0],	//0: Sharpen Color
+		[2.5]				//1: Sharpen Size
 	];
 
 	public static var tonemapper_uniforms = [
@@ -104,6 +109,28 @@ class Postprocess {
 		2.0,				//0: Strength
 		32					//1: Samples
 	];
+
+	public static var exposure = [
+		1 					//0: Exposure
+	];
+
+	public static var auto_exposure = [
+		1, 					//0: Auto Exposure Strength
+		1 					//1: Auto Exposure Speed
+	];
+
+	public static var volumetric_light_uniforms = [
+		[1.0, 1.0, 1.0], 	//0: Volumetric Light Air Color
+		[1.0], 				//1: Volumetric Light Air Turbidity
+		[20.0]				//2: Volumetric Light Steps
+	];
+
+	public static var volumetric_fog_uniforms = [
+		[0.5, 0.6, 0.7], 	//0: Volumetric Fog Color
+		[0.25], 			//1: Volumetric Fog Amount A
+		[50.0]				//2: Volumetric Fog Amount B
+	];
+
 
 	public static function vec3Link(object: Object, mat: MaterialData, link: String): iron.math.Vec4 {
 		var v:Vec4 = null;
@@ -284,6 +311,11 @@ class Postprocess {
 			v.x = lenstexture_uniforms[2]; //Lum min
 			v.y = lenstexture_uniforms[3]; //Lum max
 			v.z = lenstexture_uniforms[4]; //Expo
+		case "_PPComp8":
+			v = iron.object.Uniforms.helpVec;
+			v.x = exposure[0];	   //Exposure
+			v.y = auto_exposure[0]; //Auto Exposure Strength
+			v.z = auto_exposure[1]; //Auto Exposure Speed
 		case "_PPComp9":
 			v = iron.object.Uniforms.helpVec;
 			v.x = ssr_uniforms[0]; //Step
@@ -297,8 +329,8 @@ class Postprocess {
 		case "_PPComp11":
 			v = iron.object.Uniforms.helpVec;
 			v.x = bloom_uniforms[2]; // Bloom Strength
-			v.y = 0; // Unused
-			v.z = 0; // Unused
+			v.y = volumetric_light_uniforms[2][0]; //Volumetric Light Steps
+			v.z = volumetric_fog_uniforms[2][0]; //Volumetric Fog Amount B
 		case "_PPComp12":
 			v = iron.object.Uniforms.helpVec;
 			v.x = ssao_uniforms[0]; //SSAO Strength
@@ -338,6 +370,24 @@ class Postprocess {
 			v.y = letterbox_uniforms[0][1];
 			v.z = letterbox_uniforms[0][2];
 			v.w = letterbox_uniforms[1][0]; //Size
+		case "_PPComp16":
+			v = iron.object.Uniforms.helpVec;
+			v.x = sharpen_uniforms[0][0]; //Color
+			v.y = sharpen_uniforms[0][1];
+			v.z = sharpen_uniforms[0][2];
+			v.w = sharpen_uniforms[1][0]; //Size
+		case "_PPComp17":
+			v = iron.object.Uniforms.helpVec;
+			v.x = volumetric_light_uniforms[0][0]; //Air Color
+			v.y = volumetric_light_uniforms[0][1];
+			v.z = volumetric_light_uniforms[0][2];
+			v.w = volumetric_light_uniforms[1][0]; //Air Turbidity
+		case "_PPComp18":
+			v = iron.object.Uniforms.helpVec;
+			v.x = volumetric_fog_uniforms[0][0]; //Color
+			v.y = volumetric_fog_uniforms[0][1];
+			v.z = volumetric_fog_uniforms[0][2];
+			v.w = volumetric_fog_uniforms[1][0]; //Amount A
 		}
 
 		return v;

--- a/armory/blender/arm/logicnode/postprocess/LN_get_auto_exposure_settings.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_get_auto_exposure_settings.py
@@ -1,0 +1,11 @@
+from arm.logicnode.arm_nodes import *
+
+class AutoExposureGetNode(ArmLogicTreeNode):
+    """Returns the auto exposure post-processing settings."""
+    bl_idname = 'LNAutoExposureGetNode'
+    bl_label = 'Get Auto Exposure Settings'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_output('ArmFloatSocket', 'Strength')
+        self.add_output('ArmFloatSocket', 'Speed')

--- a/armory/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_get_camera_post_process.py
@@ -21,6 +21,7 @@ class CameraGetNode(ArmLogicTreeNode):
         self.add_output('ArmFloatSocket', 'Film Grain')#11
         self.add_output('ArmFloatSocket', 'Sharpen')#12
         self.add_output('ArmFloatSocket', 'Vignette')#13
+        self.add_output('ArmFloatSocket', 'Exposure')#14
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
         if self.arm_version not in (0, 3):

--- a/armory/blender/arm/logicnode/postprocess/LN_get_sharpen_settings.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_get_sharpen_settings.py
@@ -1,0 +1,12 @@
+from arm.logicnode.arm_nodes import *
+
+class SharpenGetNode(ArmLogicTreeNode):
+    """Returns the sharpen post-processing settings."""
+    bl_idname = 'LNSharpenGetNode'
+    bl_label = 'Get Sharpen Settings'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_output('ArmColorSocket', 'Color')
+        self.add_output('ArmFloatSocket', 'Size')
+        self.add_output('ArmFloatSocket', 'Strength')

--- a/armory/blender/arm/logicnode/postprocess/LN_get_volumetric_fog_settings.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_get_volumetric_fog_settings.py
@@ -1,0 +1,12 @@
+from arm.logicnode.arm_nodes import *
+
+class VolumetricFogGetNode(ArmLogicTreeNode):
+    """Returns the volumetric fog post-processing settings."""
+    bl_idname = 'LNVolumetricFogGetNode'
+    bl_label = 'Get Volumetric Fog Settings'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_output('ArmColorSocket', 'Color')
+        self.add_output('ArmFloatSocket', 'Amount A')
+        self.add_output('ArmFloatSocket', 'Amount B')

--- a/armory/blender/arm/logicnode/postprocess/LN_get_volumetric_light_settings.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_get_volumetric_light_settings.py
@@ -1,0 +1,12 @@
+from arm.logicnode.arm_nodes import *
+
+class VolumetricLightGetNode(ArmLogicTreeNode):
+    """Returns the volumetric light post-processing settings."""
+    bl_idname = 'LNVolumetricLightGetNode'
+    bl_label = 'Get Volumetric Light Settings'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_output('ArmColorSocket', 'Air Color')
+        self.add_output('ArmFloatSocket', 'Air Turbidity')
+        self.add_output('ArmIntSocket', 'Steps')

--- a/armory/blender/arm/logicnode/postprocess/LN_set_auto_exposure_settings.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_set_auto_exposure_settings.py
@@ -1,0 +1,14 @@
+from arm.logicnode.arm_nodes import *
+
+class AutoExposureSetNode(ArmLogicTreeNode):
+    """Set the sharpen post-processing settings."""
+    bl_idname = 'LNAutoExposureSetNode'
+    bl_label = 'Set Auto Exposure Settings'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmFloatSocket', 'Strength', default_value=1)
+        self.add_input('ArmFloatSocket', 'Speed', default_value=1)
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
@@ -37,6 +37,8 @@ class CameraSetNode(ArmLogicTreeNode):
             self.add_input('ArmFloatSocket', 'Sharpen', default_value=0.25)#12
         if self.property0 == 'Vignette':    
             self.add_input('ArmFloatSocket', 'Vignette', default_value=0.7)#13
+        if self.property0 == 'Exposure':    
+            self.add_input('ArmFloatSocket', 'Exposure', default_value=1)#14
 
 
     property0: HaxeEnumProperty(
@@ -54,7 +56,8 @@ class CameraSetNode(ArmLogicTreeNode):
              ('Distort', 'Distort', 'Distort'),
              ('Film Grain', 'Film Grain', 'Film Grain'),
              ('Sharpen', 'Sharpen', 'Sharpen'),
-             ('Vignette', 'Vignette', 'Vignette')],
+             ('Vignette', 'Vignette', 'Vignette'),
+             ('Exposure', 'Exposure', 'Exposure')],
     name='', default='F-stop', update=remove_extra_inputs)
 
 

--- a/armory/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_set_camera_post_process.py
@@ -4,26 +4,68 @@ class CameraSetNode(ArmLogicTreeNode):
     """Set the post-processing effects of a camera."""
     bl_idname = 'LNCameraSetNode'
     bl_label = 'Set Camera Post Process'
-    arm_version = 4
+    arm_version = 5
+
+    def remove_extra_inputs(self, context):
+        while len(self.inputs) > 1:
+                self.inputs.remove(self.inputs[-1])
+        if self.property0 == 'F-stop':
+            self.add_input('ArmFloatSocket', 'F-stop', default_value=1.0)#0
+        if self.property0 == 'Shutter Time':
+            self.add_input('ArmFloatSocket', 'Shutter Time', default_value=2.8333)#1
+        if self.property0 == 'ISO':           
+            self.add_input('ArmFloatSocket', 'ISO', default_value=100.0)#2
+        if self.property0 == 'Exposure Compensation':           
+            self.add_input('ArmFloatSocket', 'Exposure Compensation', default_value=0.0)#3
+        if self.property0 == 'Fisheye Distortion':           
+            self.add_input('ArmFloatSocket', 'Fisheye Distortion', default_value=0.01)#4
+        if self.property0 == 'Auto Focus':
+            self.add_input('ArmBoolSocket', 'Auto Focus', default_value=True)#5
+        if self.property0 == 'DoF Distance':
+            self.add_input('ArmFloatSocket', 'DoF Distance', default_value=10.0)#6
+        if self.property0 == 'DoF Length': 
+            self.add_input('ArmFloatSocket', 'DoF Length', default_value=160.0)#7
+        if self.property0 == 'DoF F-Stop':    
+            self.add_input('ArmFloatSocket', 'DoF F-Stop', default_value=128.0)#8
+        if self.property0 == 'Tonemapping':   
+            self.add_input('ArmBoolSocket', 'Tonemapping', default_value=False)#9
+        if self.property0 == 'Distort':    
+            self.add_input('ArmFloatSocket', 'Distort', default_value=2.0)#10
+        if self.property0 == 'Film Grain':    
+            self.add_input('ArmFloatSocket', 'Film Grain', default_value=2.0)#11
+        if self.property0 == 'Sharpen':    
+            self.add_input('ArmFloatSocket', 'Sharpen', default_value=0.25)#12
+        if self.property0 == 'Vignette':    
+            self.add_input('ArmFloatSocket', 'Vignette', default_value=0.7)#13
+
+
+    property0: HaxeEnumProperty(
+    'property0',
+    items = [('F-stop', 'F-stop', 'F-stop'),
+             ('Shutter Time', 'Shutter Time', 'Shutter Time'),
+             ('ISO', 'ISO', 'ISO'),
+             ('Exposure Compensation', 'Exposure Compensation', 'Exposure Compensation'),
+             ('Fisheye Distortion', 'Fisheye Distortion', 'Fisheye Distortion'),
+             ('Auto Focus', 'Auto Focus', 'Auto Focus'),
+             ('DoF Distance', 'DoF Distance', 'DoF Distance'),
+             ('DoF Length', 'DoF Length', 'DoF Length'),
+             ('DoF F-Stop', 'DoF F-Stop', 'DoF F-Stop'),
+             ('Tonemapping', 'Tonemapping', 'Tonemapping'),
+             ('Distort', 'Distort', 'Distort'),
+             ('Film Grain', 'Film Grain', 'Film Grain'),
+             ('Sharpen', 'Sharpen', 'Sharpen'),
+             ('Vignette', 'Vignette', 'Vignette')],
+    name='', default='F-stop', update=remove_extra_inputs)
+
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmFloatSocket', 'F-stop', default_value=1.0)#0
-        self.add_input('ArmFloatSocket', 'Shutter Time', default_value=2.8333)#1
-        self.add_input('ArmFloatSocket', 'ISO', default_value=100.0)#2
-        self.add_input('ArmFloatSocket', 'Exposure Compensation', default_value=0.0)#3
-        self.add_input('ArmFloatSocket', 'Fisheye Distortion', default_value=0.01)#4
-        self.add_input('ArmBoolSocket', 'Auto Focus', default_value=True)#5
-        self.add_input('ArmFloatSocket', 'DoF Distance', default_value=10.0)#6
-        self.add_input('ArmFloatSocket', 'DoF Length', default_value=160.0)#7
-        self.add_input('ArmFloatSocket', 'DoF F-Stop', default_value=128.0)#8
-        self.add_input('ArmBoolSocket', 'Tonemapping', default_value=False)#9
-        self.add_input('ArmFloatSocket', 'Distort', default_value=2.0)#10
-        self.add_input('ArmFloatSocket', 'Film Grain', default_value=2.0)#11
-        self.add_input('ArmFloatSocket', 'Sharpen', default_value=0.25)#12
-        self.add_input('ArmFloatSocket', 'Vignette', default_value=0.7)#13
 
         self.add_output('ArmNodeSocketAction', 'Out')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')
 
     def get_replacement_node(self, node_tree: bpy.types.NodeTree):
         if self.arm_version not in range(0, 4):

--- a/armory/blender/arm/logicnode/postprocess/LN_set_sharpen_settings.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_set_sharpen_settings.py
@@ -1,0 +1,15 @@
+from arm.logicnode.arm_nodes import *
+
+class SharpenSetNode(ArmLogicTreeNode):
+    """Set the sharpen post-processing settings."""
+    bl_idname = 'LNSharpenSetNode'
+    bl_label = 'Set Sharpen Settings'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmColorSocket', 'Color', default_value=[0.0, 0.0, 0.0, 1.0])
+        self.add_input('ArmFloatSocket', 'Size', default_value=2.5)
+        self.add_input('ArmFloatSocket', 'Strength', default_value=0.25)
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/logicnode/postprocess/LN_set_volumetric_fog_settings.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_set_volumetric_fog_settings.py
@@ -1,0 +1,15 @@
+from arm.logicnode.arm_nodes import *
+
+class VolumetricFogSetNode(ArmLogicTreeNode):
+    """Set the volumetric fog post-processing settings."""
+    bl_idname = 'LNVolumetricFogSetNode'
+    bl_label = 'Set Volumetric Fog Settings'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmColorSocket', 'Color', default_value=[0.5, 0.6, 0.7, 1.0])
+        self.add_input('ArmFloatSocket', 'Amount A', default_value=0.25)
+        self.add_input('ArmFloatSocket', 'Amount B', default_value=0.50)
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/logicnode/postprocess/LN_set_volumetric_light_settings.py
+++ b/armory/blender/arm/logicnode/postprocess/LN_set_volumetric_light_settings.py
@@ -1,0 +1,15 @@
+from arm.logicnode.arm_nodes import *
+
+class VolumetricLightSetNode(ArmLogicTreeNode):
+    """Set the volumetric light post-processing settings."""
+    bl_idname = 'LNVolumetricLightSetNode'
+    bl_label = 'Set Volumetric Light Settings'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmColorSocket', 'Air Color', default_value=[1.0, 1.0, 1.0, 1.0])
+        self.add_input('ArmFloatSocket', 'Air Turbidity', default_value=1)
+        self.add_input('ArmIntSocket', 'Steps', default_value=20)
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/props_renderpath.py
+++ b/armory/blender/arm/props_renderpath.py
@@ -602,6 +602,8 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_grain: BoolProperty(name="Film Grain", default=False, update=assets.invalidate_shader_cache)
     arm_grain_strength: FloatProperty(name="Strength", default=2.0, update=assets.invalidate_shader_cache)
     arm_sharpen: BoolProperty(name="Sharpen", default=False, update=assets.invalidate_shader_cache)
+    arm_sharpen_color: FloatVectorProperty(name="Color", size=3, default=[0, 0, 0], subtype='COLOR', min=0, max=1, update=assets.invalidate_shader_cache)
+    arm_sharpen_size: FloatProperty(name="Size", default=2.5, update=assets.invalidate_shader_cache)
     arm_sharpen_strength: FloatProperty(name="Strength", default=0.25, update=assets.invalidate_shader_cache)
     arm_fog: BoolProperty(name="Volumetric Fog", default=False, update=assets.invalidate_shader_cache)
     arm_fog_color: FloatVectorProperty(name="Color", size=3, subtype='COLOR', default=[0.5, 0.6, 0.7], min=0, max=1, update=assets.invalidate_shader_cache)

--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -1946,9 +1946,17 @@ class ARM_PT_RenderPathCompositorPanel(bpy.types.Panel):
         layout.separator()
 
         col = layout.column()
+        col.prop(rpdat, 'arm_sharpen')
+        col = col.column(align=True)
+        col.enabled = rpdat.arm_sharpen
+        col.prop(rpdat, 'arm_sharpen_color')
+        col.prop(rpdat, 'arm_sharpen_size')
+        col.prop(rpdat, 'arm_sharpen_strength')
+        layout.separator()
+
+        col = layout.column()
         draw_conditional_prop(col, 'Distort', rpdat, 'arm_distort', 'arm_distort_strength')
         draw_conditional_prop(col, 'Film Grain', rpdat, 'arm_grain', 'arm_grain_strength')
-        draw_conditional_prop(col, 'Sharpen', rpdat, 'arm_sharpen', 'arm_sharpen_strength')
         draw_conditional_prop(col, 'Vignette', rpdat, 'arm_vignette', 'arm_vignette_strength')
         layout.separator()
 

--- a/armory/blender/arm/write_data.py
+++ b/armory/blender/arm/write_data.py
@@ -726,8 +726,8 @@ const vec3 compoLetterboxColor = vec3(""" + str(round(rpdat.arm_letterbox_color[
         if rpdat.arm_sharpen:
             f.write(
 """const float compoSharpenStrength = """ + str(round(rpdat.arm_sharpen_strength * 100) / 100) + """;
-   const float compoSharpenSize = """ + str(round(rpdat.arm_sharpen_size * 100) / 100) + """;
-   const vec3 compoSharpenColor = vec3(""" + str(round(rpdat.arm_sharpen_color[0] * 100) / 100) + """, """ + str(round(rpdat.arm_sharpen_color[1] * 100) / 100) + """, """ + str(round(rpdat.arm_sharpen_color[2] * 100) / 100) + """);
+const float compoSharpenSize = """ + str(round(rpdat.arm_sharpen_size * 100) / 100) + """;
+const vec3 compoSharpenColor = vec3(""" + str(round(rpdat.arm_sharpen_color[0] * 100) / 100) + """, """ + str(round(rpdat.arm_sharpen_color[1] * 100) / 100) + """, """ + str(round(rpdat.arm_sharpen_color[2] * 100) / 100) + """);
 """)
 
         if bpy.data.scenes[0].view_settings.exposure != 0.0:

--- a/armory/blender/arm/write_data.py
+++ b/armory/blender/arm/write_data.py
@@ -726,6 +726,8 @@ const vec3 compoLetterboxColor = vec3(""" + str(round(rpdat.arm_letterbox_color[
         if rpdat.arm_sharpen:
             f.write(
 """const float compoSharpenStrength = """ + str(round(rpdat.arm_sharpen_strength * 100) / 100) + """;
+   const float compoSharpenSize = """ + str(round(rpdat.arm_sharpen_size * 100) / 100) + """;
+   const vec3 compoSharpenColor = vec3(""" + str(round(rpdat.arm_sharpen_color[0] * 100) / 100) + """, """ + str(round(rpdat.arm_sharpen_color[1] * 100) / 100) + """, """ + str(round(rpdat.arm_sharpen_color[2] * 100) / 100) + """);
 """)
 
         if bpy.data.scenes[0].view_settings.exposure != 0.0:


### PR DESCRIPTION
Modified `Set Camera PP Node` so values can be individually changed.

From this:
![image](https://github.com/user-attachments/assets/d59ed044-24d2-43ca-893a-96548a229b8c)

To this:
![image](https://github.com/user-attachments/assets/3e8b16e0-1a1a-4ae7-8199-9060f99ebe1f)

Improved Sharpen PP and Node to add Color and Size:
![image](https://github.com/user-attachments/assets/05ec1eff-13d1-4cdb-9879-430fc6069eac)

Added PP set/get Nodes for:
- Volumetric Light
- Volumetric Fog
- Sharpen
- Auto Exposure
- Exposure

![image](https://github.com/user-attachments/assets/8a451c97-3970-41ec-a0bf-eb0bb92a140a)

Next Steps: 
- Clouds and Water PP.
- More options for Distort.
