### PR TITLE
add material texture filter node

### DIFF
--- a/armory/Sources/armory/logicnode/SetMaterialTextureFilterNode.hx
+++ b/armory/Sources/armory/logicnode/SetMaterialTextureFilterNode.hx
@@ -1,0 +1,55 @@
+package armory.logicnode;
+
+import iron.object.MeshObject;
+import iron.data.MaterialData;
+
+class SetMaterialTextureFilterNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var object: MeshObject = inputs[1].get();
+		var mat: MaterialData = inputs[2].get();
+		var slot: Int = inputs[3].get();
+		var name: String = inputs[4].get();
+		var filter: Int = inputs[5].get();
+
+		if (object == null) return;
+		if (slot >= object.materials.length) return;
+
+		var mo = cast(object, iron.object.MeshObject);
+
+		for (i => node in mo.materials[slot].contexts[0].raw.bind_textures)
+			if (node.name == name){
+				var moImgt = mo.materials[slot].contexts[0].raw.bind_textures[i];
+				switch(filter){
+					case 0: //Linear
+						moImgt.min_filter = null;
+						moImgt.mag_filter = null;
+						moImgt.mipmap_filter = null;
+						moImgt.generate_mipmaps = null;
+					case 1: //Closest
+						moImgt.min_filter = 'point';
+						moImgt.mag_filter = 'point';
+						moImgt.mipmap_filter = null;
+						moImgt.generate_mipmaps = null;
+					case 2: //Cubic
+						moImgt.min_filter = null;
+						moImgt.mag_filter = null;
+						moImgt.mipmap_filter = 'linear';
+						moImgt.generate_mipmaps = true;
+					case 3: //Smart
+						moImgt.min_filter = 'anisotropic';
+						moImgt.mag_filter = null;
+						moImgt.mipmap_filter = 'linear';
+						moImgt.generate_mipmaps = true;
+				}
+
+				break;
+			}
+
+		runOutput(0);
+	}
+}

--- a/armory/blender/arm/logicnode/material/LN_set_object_material_filter_texture.py
+++ b/armory/blender/arm/logicnode/material/LN_set_object_material_filter_texture.py
@@ -1,0 +1,23 @@
+from arm.logicnode.arm_nodes import *
+
+class SetMaterialTextureFilterNode(ArmLogicTreeNode):
+    """Sets texture filter interpolation."""
+    bl_idname = 'LNSetMaterialTextureFilterNode'
+    bl_label = 'Set Object Material Texture Filter'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmDynamicSocket', 'Material')
+        self.add_input('ArmIntSocket', 'Slot')
+        self.add_input('ArmStringSocket', 'Node')
+        self.add_input('ArmIntSocket', 'Texture Filter')
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+    def draw_buttons(self, context, layout):
+        layout.label(text='Tex Filter 0: Linear')
+        layout.label(text='Tex Filter 1: Closest')
+        layout.label(text='Tex Filter 2: Cubic')
+        layout.label(text='Tex Filter 3: Smart')

--- a/armory/blender/arm/props_renderpath.py
+++ b/armory/blender/arm/props_renderpath.py
@@ -449,9 +449,10 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_ssrs: BoolProperty(name="SSRS", description="Screen-space ray-traced shadows", default=False, update=assets.invalidate_shader_cache)
     arm_micro_shadowing: BoolProperty(name="Micro Shadowing", description="Use the shaders' occlusion parameter to compute micro shadowing for the scene's sun lamp. This option is not available for render paths using mobile or solid material models", default=False, update=assets.invalidate_shader_cache)
     arm_texture_filter: EnumProperty(
-        items=[('Anisotropic', 'Anisotropic', 'Anisotropic'),
-               ('Linear', 'Linear', 'Linear'),
+        items=[('Linear', 'Linear', 'Linear'),
                ('Point', 'Closest', 'Point'),
+               ('Cubic', 'Cubic', 'Cubic'),
+               ('Anisotropic', 'Smart', 'Anisotropic'),
                ('Manual', 'Manual', 'Manual')],
         name="Texture Filtering", description="Set Manual to honor interpolation setting on Image Texture node", default='Anisotropic')
     arm_material_model: EnumProperty(


### PR DESCRIPTION
I added a node for changing image texture interpolation:

![image](https://github.com/user-attachments/assets/a8de9fce-59e2-454f-8350-4599a8b7306e)

![image](https://github.com/user-attachments/assets/c93d958c-c5df-4eed-b77e-ad35f3045b88)

I also modified the texture filtering names and order to match according the image texture (anisotropic to smart)

![image](https://github.com/user-attachments/assets/828602ee-b952-4e08-a46d-39995f2ab82c)

A possible addition later could be a property in the node for changing all the image texture at once or just the selected one (simil to the texture filtering in the renderer. And a get texture filter node.

