### PR TITLE
Set/get World Node

### DIFF
--- a/armory/Sources/armory/logicnode/GetWorldNode.hx
+++ b/armory/Sources/armory/logicnode/GetWorldNode.hx
@@ -1,26 +1,13 @@
 package armory.logicnode;
 
-import iron.object.Object;
-import iron.math.Vec4;
-
 class GetWorldNode extends LogicNode {
-
-	public var property0: String;
 
 	public function new(tree: LogicTree) {
 		super(tree);
 	}
 
 	override function get(from: Int): Dynamic {
-		var object: Object = inputs[0].get();
-
-		if (object == null) return null;
-
-		return switch (property0) {
-			case "Right": object.transform.world.right();
-			case "Look": object.transform.world.look();
-			case "Up": object.transform.world.up();
-			default: null;
-		}
+		trace(iron.Scene.active.world);
+		return iron.Scene.active.raw.world_ref;
 	}
 }

--- a/armory/Sources/armory/logicnode/GetWorldOrientationNode.hx
+++ b/armory/Sources/armory/logicnode/GetWorldOrientationNode.hx
@@ -1,0 +1,26 @@
+package armory.logicnode;
+
+import iron.object.Object;
+import iron.math.Vec4;
+
+class GetWorldOrientationNode extends LogicNode {
+
+	public var property0: String;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var object: Object = inputs[0].get();
+
+		if (object == null) return null;
+
+		return switch (property0) {
+			case "Right": object.transform.world.right();
+			case "Look": object.transform.world.look();
+			case "Up": object.transform.world.up();
+			default: null;
+		}
+	}
+}

--- a/armory/Sources/armory/logicnode/SetWorldNode.hx
+++ b/armory/Sources/armory/logicnode/SetWorldNode.hx
@@ -1,0 +1,40 @@
+package armory.logicnode;
+
+class SetWorldNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var world: String = inputs[1].get();
+
+		if (world != null){
+
+			//check if world shader data exists
+			var file: String = 'World_'+world+'_data';
+			#if arm_json
+				file += ".json";
+			#elseif arm_compress
+				file += ".lz4";
+			#else
+				file += '.arm';
+			#end
+
+			var exists: Bool = false;
+		
+			iron.data.Data.getBlob(file, function(b: kha.Blob) {
+				if (b != null) exists = true;
+			});
+
+			assert(Error, exists == true, "World must be either associated to a scene or have fake user");
+
+			iron.Scene.active.raw.world_ref = world;
+			var npath = armory.renderpath.RenderPathCreator.get();
+			npath.loadShader("shader_datas/World_" + world + "/World_" + world);
+			iron.RenderPath.setActive(npath);
+		}
+
+		runOutput(0);
+	}
+}

--- a/armory/blender/arm/logicnode/transform/LN_get_world_orientation.py
+++ b/armory/blender/arm/logicnode/transform/LN_get_world_orientation.py
@@ -1,8 +1,8 @@
 from arm.logicnode.arm_nodes import *
 
-class GetWorldNode(ArmLogicTreeNode):
+class GetWorldOrientationNode(ArmLogicTreeNode):
     """Returns the world orientation of the given object."""
-    bl_idname = 'LNGetWorldNode'
+    bl_idname = 'LNGetWorldOrientationNode'
     bl_label = 'Get World Orientation'
     arm_section = 'rotation'
     arm_version = 1

--- a/armory/blender/arm/logicnode/world/LN_get_world.py
+++ b/armory/blender/arm/logicnode/world/LN_get_world.py
@@ -1,0 +1,10 @@
+from arm.logicnode.arm_nodes import *
+
+class SetWorldNode(ArmLogicTreeNode):
+    """Gets the World of the active scene."""
+    bl_idname = 'LNGetWorldNode'
+    bl_label = 'Get World'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_output('ArmStringSocket', 'World')

--- a/armory/blender/arm/logicnode/world/LN_set_world.py
+++ b/armory/blender/arm/logicnode/world/LN_set_world.py
@@ -1,0 +1,13 @@
+from arm.logicnode.arm_nodes import *
+
+class SetWorldNode(ArmLogicTreeNode):
+    """Sets the World of the active scene."""
+    bl_idname = 'LNSetWorldNode'
+    bl_label = 'Set World'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmStringSocket', 'World')
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/make_world.py
+++ b/armory/blender/arm/make_world.py
@@ -47,11 +47,20 @@ def build():
 
     with write_probes.setup_envmap_render():
 
-        for scene in bpy.data.scenes:
-            world = scene.world
+        #for scene in bpy.data.scenes:
+        for world in bpy.data.worlds:
+            #world = scene.world
 
-            # Only export worlds from enabled scenes and only once per world
-            if scene.arm_export and world is not None and world not in worlds:
+            assigned = False;
+            for scene in bpy.data.scenes:
+                if scene.arm_export and scene.world is not None:
+                    if scene.world.name == world.name:
+                        assigned = True;
+                        break;
+
+            #if scene.arm_export and world is not None and world not in worlds:
+            # Only export worlds from enabled scenes and with fake users                
+            if (world.use_fake_user and world.name != 'Arm') or assigned:
                 worlds.append(world)
 
                 world.arm_envtex_name = ''


### PR DESCRIPTION
These nodes allow to change the world scene at runtime.

![image](https://github.com/user-attachments/assets/f7a82831-2e93-473a-bd1b-f141ddb8f1f9)

I had to modify the name of the get world orientation node because it was called "get world" but only in the haxe file.

I also modified the world export: so now worlds that have a fake user or are associated to scenes are exported (excluding 'Arm'). So there is no need to have an empty scene just to export the world.

This was a hard one to get. Finally I can add this to the rest of the world nodes that I've made.


