### PR TITLE
Camera Render Filter

### DIFF
--- a/armory/Sources/armory/logicnode/GetCameraRenderFilterNode.hx
+++ b/armory/Sources/armory/logicnode/GetCameraRenderFilterNode.hx
@@ -1,0 +1,19 @@
+package armory.logicnode;
+
+import iron.object.MeshObject;
+import iron.object.CameraObject;
+
+class GetCameraRenderFilterNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function get(from: Int): Dynamic {
+		var mo: MeshObject = cast inputs[0].get();
+
+		if (mo == null) return null;
+		
+		return mo.cameraList;
+	}
+}

--- a/armory/Sources/armory/logicnode/SetCameraRenderFilterNode.hx
+++ b/armory/Sources/armory/logicnode/SetCameraRenderFilterNode.hx
@@ -1,0 +1,38 @@
+package armory.logicnode;
+
+import iron.object.MeshObject;
+import iron.object.CameraObject;
+
+class SetCameraRenderFilterNode extends LogicNode {
+
+	public var property0: String;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var mo: MeshObject = cast inputs[1].get();
+		var camera: CameraObject = inputs[2].get();
+		
+		assert(Error, Std.isOfType(camera, CameraObject), "Camera must be a camera object!");
+		
+		if (camera == null || mo == null) return;
+		
+		if (property0 == 'Add'){
+			if (mo.cameraList == null || mo.cameraList.indexOf(camera.name) == -1){
+				if (mo.cameraList == null) mo.cameraList = [];
+				mo.cameraList.push(camera.name);
+			}
+		}
+		else{
+			if (mo.cameraList != null){
+				mo.cameraList.remove(camera.name);
+				if (mo.cameraList.length == 0)
+					mo.cameraList = null;
+			}
+		}
+
+		runOutput(0);
+	}
+}

--- a/armory/Sources/iron/Scene.hx
+++ b/armory/Sources/iron/Scene.hx
@@ -796,6 +796,13 @@ class Scene {
 			if (o.tilesheet_ref != null) {
 				cast(object, MeshObject).setupTilesheet(sceneName, o.tilesheet_ref, o.tilesheet_action_ref);
 			}
+
+
+			if (o.camera_list != null){
+				trace(o.name, o.camera_list);
+				cast(object, MeshObject).cameraList = o.camera_list;
+			}
+
 			returnObject(object, o, done);
 		});
 	}

--- a/armory/Sources/iron/Scene.hx
+++ b/armory/Sources/iron/Scene.hx
@@ -799,7 +799,6 @@ class Scene {
 
 
 			if (o.camera_list != null){
-				trace(o.name, o.camera_list);
 				cast(object, MeshObject).cameraList = o.camera_list;
 			}
 

--- a/armory/Sources/iron/data/SceneFormat.hx
+++ b/armory/Sources/iron/data/SceneFormat.hx
@@ -441,6 +441,7 @@ typedef TObj = {
 	@:optional public var traits: Array<TTrait>;
 	@:optional public var properties: Array<TProperty>;
 	@:optional public var vertex_groups: Array<TVertex_groups>;
+	@:optional public var camera_list: Array<String>;
 	@:optional public var constraints: Array<TConstraint>;
 	@:optional public var dimensions: Float32Array; // Geometry objects
 	@:optional public var object_actions: Array<String>;

--- a/armory/Sources/iron/object/MeshObject.hx
+++ b/armory/Sources/iron/object/MeshObject.hx
@@ -24,6 +24,7 @@ class MeshObject extends Object {
 	public var render_emitter = true;
 	#end
 	public var cameraDistance: Float;
+	public var cameraList: Array<String> = null;
 	public var screenSize = 0.0;
 	public var frustumCulling = true;
 	public var activeTilesheet: Tilesheet = null;
@@ -235,6 +236,8 @@ class MeshObject extends Object {
 		if (cullMesh(context, Scene.active.camera, RenderPath.active.light)) return;
 		var meshContext = raw != null ? context == "mesh" : false;
 
+		if (cameraList != null && cameraList.indexOf(Scene.active.camera.name) < 0) return;
+
 		#if arm_particles
 		if (raw != null && raw.is_particle && particleOwner == null) return; // Instancing not yet set-up by particle system owner
 		if (particleSystems != null && meshContext) {
@@ -245,6 +248,8 @@ class MeshObject extends Object {
 					Scene.active.spawnObject(psys.data.raw.instance_object, null, function(o: Object) {
 						if (o != null) {
 							var c: MeshObject = cast o;
+							c.cameraList = this.cameraList;
+							//trace(c);
 							particleChildren.push(c);
 							c.particleOwner = this;
 							c.particleIndex = particleChildren.length - 1;

--- a/armory/Sources/iron/object/MeshObject.hx
+++ b/armory/Sources/iron/object/MeshObject.hx
@@ -249,7 +249,6 @@ class MeshObject extends Object {
 						if (o != null) {
 							var c: MeshObject = cast o;
 							c.cameraList = this.cameraList;
-							//trace(c);
 							particleChildren.push(c);
 							c.particleOwner = this;
 							c.particleIndex = particleChildren.length - 1;

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -819,6 +819,16 @@ class ArmoryExporter:
                     out_object['vertex_groups'].append(out_vertex_groups)
 
 
+            if len(bobject.arm_camera_list) > 0:
+                out_camera_list = []
+                for camera in bobject.arm_camera_list:
+                    if camera.arm_camera_object_ptr != None:
+                        out_camera_list.append(camera.arm_camera_object_ptr.name)
+
+                if len(out_camera_list) > 0:
+                    out_object['camera_list'] = out_camera_list
+
+
             if len(bobject.arm_propertylist) > 0:
                 out_object['properties'] = []
                 for proplist_item in bobject.arm_propertylist:

--- a/armory/blender/arm/logicnode/object/LN_get_camera_render_filter.py
+++ b/armory/blender/arm/logicnode/object/LN_get_camera_render_filter.py
@@ -1,0 +1,15 @@
+from arm.logicnode.arm_nodes import *
+
+class GetCameraRenderFilterNode(ArmLogicTreeNode):
+    """
+    Gets Camera Render Filter array with the names of the cameras
+    that can render the mesh. If null all cameras can render the mesh.
+    """
+    bl_idname = 'LNGetCameraRenderFilterNode'
+    bl_label = 'Get Object Camera Render Filter'
+    arm_section = 'camera'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_output('ArmNodeSocketArray', 'Array')

--- a/armory/blender/arm/logicnode/object/LN_set_camera_render_filter.py
+++ b/armory/blender/arm/logicnode/object/LN_set_camera_render_filter.py
@@ -1,0 +1,29 @@
+from arm.logicnode.arm_nodes import *
+
+class SetCameraRenderFilterNode(ArmLogicTreeNode):
+    """
+    Sets Camera Render Filter array with the names of the cameras
+    that can render the mesh. If null all cameras can render the mesh.
+    A camera can be added or removed from the arraw list.
+    """
+    bl_idname = 'LNSetCameraRenderFilterNode'
+    bl_label = 'Set Object Camera Render Filter'
+    arm_section = 'camera'
+    arm_version = 1
+
+    property0: HaxeEnumProperty(
+    'property0',
+    items = [('Add', 'Add', 'Add'),
+             ('Remove', 'Remove', 'Remove')],
+    name='', default='Add', update='')
+
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Object')
+        self.add_input('ArmNodeSocketObject', 'Camera')
+
+        self.add_output('ArmNodeSocketAction', 'Out')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')

--- a/armory/blender/arm/props_camera_render_filter.py
+++ b/armory/blender/arm/props_camera_render_filter.py
@@ -1,0 +1,141 @@
+import bpy
+from bpy.props import *
+
+class ARM_UL_CameraList(bpy.types.UIList):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        layout.prop_search(item, "arm_camera_object_ptr", bpy.data, "objects", text="", icon='VIEW_CAMERA')
+
+class ARM_CameraListItem(bpy.types.PropertyGroup):
+    arm_camera_object_ptr: bpy.props.PointerProperty(
+        type=bpy.types.Object,
+        name="Camera Object",
+        poll=lambda self, obj_to_check: obj_to_check.type == 'CAMERA' and \
+                                     (bpy.context.object is None or \
+                                      not hasattr(bpy.context.object, 'arm_camera_list') or \
+                                      (obj_to_check.name not in [
+                                          item.arm_camera_object_ptr.name
+                                          for item in bpy.context.object.arm_camera_list
+                                          if item.arm_camera_object_ptr and item != self
+                                      ]))
+    )
+
+class ARM_PT_ArmoryCameraRenderFilter(bpy.types.Panel):
+    bl_label = "Armory Camera Render Filter"
+    bl_idname = "ARM_PT_ArmoryCameraRenderFilter"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "data"
+
+    @classmethod
+    def poll(cls, context):
+        return context.object is not None and context.object.type == 'MESH'
+
+    def draw(self, context):
+        layout = self.layout
+        obj = context.object
+
+        row = layout.row()
+
+        col = row.column()
+        col.template_list(
+            "ARM_UL_CameraList",
+            "",
+            obj,
+            "arm_camera_list",
+            obj,
+            "arm_active_camera_index",
+            rows=5
+        )
+
+        col = row.column(align=True)
+        col.operator("arm.add_camera", icon='ADD', text="")
+
+        if obj.arm_camera_list and obj.arm_active_camera_index >= 0 and obj.arm_active_camera_index < len(obj.arm_camera_list):
+            op_remove = col.operator("arm.remove_camera", icon='REMOVE', text="")
+            op_remove.arm_index = obj.arm_active_camera_index
+
+            op_up = col.operator("arm.move_camera", icon='TRIA_UP', text="")
+            op_up.arm_index = obj.arm_active_camera_index
+            op_up.direction = 'UP'
+
+            op_down = col.operator("arm.move_camera", icon='TRIA_DOWN', text="")
+            op_down.arm_index = obj.arm_active_camera_index
+            op_down.direction = 'DOWN'
+
+class ARM_OT_AddCamera(bpy.types.Operator):
+    bl_idname = "arm.add_camera"
+    bl_label = "Add Camera"
+
+    def execute(self, context):
+        obj = context.object
+        
+        new_item = obj.arm_camera_list.add()
+        obj.arm_active_camera_index = len(obj.arm_camera_list) - 1
+        
+        return {'FINISHED'}
+
+class ARM_OT_RemoveCamera(bpy.types.Operator):
+    bl_idname = "arm.remove_camera"
+    bl_label = "Remove Camera"
+
+    arm_index: bpy.props.IntProperty()
+
+    def execute(self, context):
+        obj = context.object
+        if self.arm_index < len(obj.arm_camera_list):
+            obj.arm_camera_list.remove(self.arm_index)
+            if obj.arm_active_camera_index >= len(obj.arm_camera_list):
+                obj.arm_active_camera_index = len(obj.arm_camera_list) - 1
+        return {'FINISHED'}
+
+class ARM_OT_MoveCamera(bpy.types.Operator):
+    bl_idname = "arm.move_camera"
+    bl_label = "Move Camera"
+
+    arm_index: bpy.props.IntProperty()
+    direction: bpy.props.EnumProperty(
+        items=[('UP', "Up", "Move camera up"),
+               ('DOWN', "Down", "Move camera down")],
+        default='UP'
+    )
+
+    def execute(self, context):
+        obj = context.object
+        camera_list = obj.arm_camera_list
+        target_index = -1
+
+        if self.direction == 'UP':
+            if self.arm_index > 0:
+                target_index = self.arm_index - 1
+        elif self.direction == 'DOWN':
+            if self.arm_index < len(camera_list) - 1:
+                target_index = self.arm_index + 1
+
+        if target_index != -1:
+            camera_list.move(self.arm_index, target_index)
+            obj.arm_active_camera_index = target_index
+        return {'FINISHED'}
+
+def register():
+    bpy.utils.register_class(ARM_UL_CameraList)
+    bpy.utils.register_class(ARM_CameraListItem)
+    bpy.utils.register_class(ARM_PT_ArmoryCameraRenderFilter)
+    bpy.utils.register_class(ARM_OT_AddCamera)
+    bpy.utils.register_class(ARM_OT_RemoveCamera)
+    bpy.utils.register_class(ARM_OT_MoveCamera)
+    
+    bpy.types.Object.arm_camera_list = bpy.props.CollectionProperty(type=ARM_CameraListItem)
+    bpy.types.Object.arm_active_camera_index = bpy.props.IntProperty(name="Active Camera Index", default=-1)
+
+def unregister():
+    bpy.utils.unregister_class(ARM_UL_CameraList)
+    bpy.utils.unregister_class(ARM_CameraListItem)
+    bpy.utils.unregister_class(ARM_PT_ArmoryCameraRenderFilter)
+    bpy.utils.unregister_class(ARM_OT_AddCamera)
+    bpy.utils.unregister_class(ARM_OT_RemoveCamera)
+    bpy.utils.unregister_class(ARM_OT_MoveCamera)
+    
+    if hasattr(bpy.types.Object, "arm_camera_list"):
+        del bpy.types.Object.arm_camera_list
+    if hasattr(bpy.types.Object, "arm_active_camera_index"):
+        del bpy.types.Object.arm_active_camera_index

--- a/armory/blender/start.py
+++ b/armory/blender/start.py
@@ -15,6 +15,7 @@ import arm.props_properties
 import arm.props_collision_filter_mask
 import arm.props
 import arm.props_ui
+import arm.props_camera_render_filter
 import arm.handlers
 import arm.utils
 import arm.keymap
@@ -42,6 +43,7 @@ if arm.is_reload(__name__):
     arm.props_collision_filter_mask = arm.reload_module(arm.props_collision_filter_mask)
     arm.props = arm.reload_module(arm.props)
     arm.props_ui = arm.reload_module(arm.props_ui)
+    arm.props_camera_render_filter = arm.reload_module(arm.props_camera_render_filter)
     arm.handlers = arm.reload_module(arm.handlers)
     arm.utils = arm.reload_module(arm.utils)
     arm.keymap = arm.reload_module(arm.keymap)
@@ -65,6 +67,7 @@ def register(local_sdk=False):
     arm.props_properties.register()
     arm.props.register()
     arm.props_ui.register()
+    arm.props_camera_render_filter.register()
     arm.nodes_logic.register()
     arm.nodes_material.register()
     arm.keymap.register()
@@ -96,3 +99,4 @@ def unregister():
     arm.props_renderpath.unregister()
     arm.props_properties.unregister()
     arm.props_collision_filter_mask.unregister()
+    arm.props_camera_render_filter.unregister()


### PR DESCRIPTION
`Camera Render Filter` allows to render objects from selected cameras which means only that cameras can see the object. It also affects the object particles.

If an object doesn't have a camera list assigned by default all cameras can render the object:


![image](https://github.com/user-attachments/assets/f1687c77-56f8-46d6-88a6-409f1bd77b60)


There is a get node for retrieving the camera list array and also a set node for adding or removing a camera from the list array:

![image](https://github.com/user-attachments/assets/0952a7d0-7cbc-4b87-a866-158071deea2c)


Here is an example: only 1 scene and 3 cameras. Every camera sees a different combination of objects. But they are all present at the same time in the scene.


https://github.com/user-attachments/assets/ee9e4ce6-7332-474b-97f3-1001e10b1922

