### PR TITLE
Fix linked particle's render object vertex shader export

### DIFF
--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -644,7 +644,10 @@ class ArmoryExporter:
                 continue
 
             for slot in bobject.material_slots:
-                if slot.material is None or slot.material.library is not None:
+                if slot.material is None:
+                    continue
+                if slot.material.library is not None:
+                    slot.material.arm_particle_flag = True
                     continue
                 if slot.material.name.endswith('_armpart'):
                     continue


### PR DESCRIPTION
Linked materials from Particle System's object didn't export. This PR fixes that.