### PR TITLE
Show world name in debug console

### DIFF
--- a/armory/Sources/armory/trait/internal/DebugConsole.hx
+++ b/armory/Sources/armory/trait/internal/DebugConsole.hx
@@ -280,7 +280,12 @@ class DebugConsole extends Trait {
 
 					function drawObjectNameInList(object: iron.object.Object, selected: Bool) {
 						var _y = ui._y;
-						ui.text(object.uid+'_'+object.name);
+						
+						if (object.parent.name == 'Root')
+							ui.text(object.uid+'_'+object.name+' ('+iron.Scene.active.raw.world_ref+')');
+						else
+							ui.text(object.uid+'_'+object.name);
+
 
 						if (object == iron.Scene.active.camera) {
 							var tagWidth = 100;


### PR DESCRIPTION
Since now the world can be changed.

![image](https://github.com/user-attachments/assets/dc0d87a9-20c1-434b-af21-264689005e75)
