### PR TITLE
Add SetLightShadowNode for controlling light shadows

### DIFF
--- a/armory/Sources/armory/logicnode/SetLightShadowNode.hx
+++ b/armory/Sources/armory/logicnode/SetLightShadowNode.hx
@@ -1,0 +1,21 @@
+package armory.logicnode;
+
+import iron.object.LightObject;
+
+class SetLightShadowNode extends LogicNode {
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var light: LightObject = inputs[1].get();
+		var shadow: Bool = inputs[2].get();
+
+		if (light == null) return;
+
+		light.data.raw.cast_shadow = shadow;
+
+		runOutput(0);
+	}
+}

--- a/armory/blender/arm/logicnode/light/LN_set_light_shadow.py
+++ b/armory/blender/arm/logicnode/light/LN_set_light_shadow.py
@@ -1,0 +1,14 @@
+from arm.logicnode.arm_nodes import *
+
+class SetLightShadowNode(ArmLogicTreeNode):
+    """Sets the shadow boolean of the given light."""
+    bl_idname = 'LNSetLightShadowNode'
+    bl_label = 'Set Light Shadow'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Light')
+        self.add_input('ArmBoolSocket', 'Shadow')
+
+        self.add_output('ArmNodeSocketAction', 'Out')


### PR DESCRIPTION
Introduces SetLightShadowNode in both Haxe and Python to allow toggling the shadow property of a light object via logic nodes. This enables users to programmatically enable or disable shadows on lights within the logic node system.

![image](https://github.com/user-attachments/assets/2edf4861-3394-4c30-b8e1-15852141d77e)

![image](https://github.com/user-attachments/assets/b5f6137e-1c2d-4d30-b9c6-764ee76fb4c5)
