### PR TITLE
Restore VR code

### DIFF
--- a/armory/Sources/iron/RenderPath.hx
+++ b/armory/Sources/iron/RenderPath.hx
@@ -519,11 +519,43 @@ class RenderPath {
 	}
 
 	#if (kha_krom && arm_vr)
-	public function drawStereo(drawMeshes: Int->Void) {
-		for (eye in 0...2) {
-			Krom.vrBeginRender(eye);
-			drawMeshes(eye);
-			Krom.vrEndRender(eye);
+	public function drawStereo(drawMeshes: Void->Void) {
+		var vr = kha.vr.VrInterface.instance;
+		var appw = iron.App.w();
+		var apph = iron.App.h();
+		var halfw = Std.int(appw / 2);
+		var g = currentG;
+
+		if (vr != null && vr.IsPresenting()) {
+			// Left eye
+			Scene.active.camera.V.setFrom(Scene.active.camera.leftV);
+			Scene.active.camera.P.self = vr.GetProjectionMatrix(0);
+			g.viewport(0, 0, halfw, apph);
+			drawMeshes();
+
+			// Right eye
+			begin(g, additionalTargets);
+			Scene.active.camera.V.setFrom(Scene.active.camera.rightV);
+			Scene.active.camera.P.self = vr.GetProjectionMatrix(1);
+			g.viewport(halfw, 0, halfw, apph);
+			drawMeshes();
+		}
+		else { // Simulate
+			Scene.active.camera.buildProjection(halfw / apph);
+
+			// Left eye
+			g.viewport(0, 0, halfw, apph);
+			drawMeshes();
+
+			// Right eye
+			begin(g, additionalTargets);
+			Scene.active.camera.transform.move(Scene.active.camera.right(), 0.032);
+			Scene.active.camera.buildMatrix();
+			g.viewport(halfw, 0, halfw, apph);
+			drawMeshes();
+
+			Scene.active.camera.transform.move(Scene.active.camera.right(), -0.032);
+			Scene.active.camera.buildMatrix();
 		}
 	}
 	#end

--- a/armory/Sources/iron/RenderPath.hx
+++ b/armory/Sources/iron/RenderPath.hx
@@ -518,7 +518,7 @@ class RenderPath {
 		return Reflect.field(kha.Shaders, handle + "_comp");
 	}
 
-	#if (kha_krom && arm_vr)
+	#if arm_vr
 	public function drawStereo(drawMeshes: Void->Void) {
 		var vr = kha.vr.VrInterface.instance;
 		var appw = iron.App.w();

--- a/armory/Sources/iron/object/CameraObject.hx
+++ b/armory/Sources/iron/object/CameraObject.hx
@@ -31,10 +31,20 @@ class CameraObject extends Object {
 	static var vcenter = new Vec4();
 	static var vup = new Vec4();
 
+	#if arm_vr
+	var helpMat = Mat4.identity();
+	public var leftV = Mat4.identity();
+	public var rightV = Mat4.identity();
+	#end
+
 	public function new(data: CameraData) {
 		super();
 
 		this.data = data;
+
+		#if arm_vr
+		iron.system.VR.initButton();
+		#end
 
 		buildProjection();
 
@@ -116,6 +126,25 @@ class CameraObject extends Object {
 
 		V.getInverse(transform.world);
 		VP.multmats(P, V);
+
+		#if arm_vr
+		var vr = kha.vr.VrInterface.instance;
+		if (vr != null && vr.IsPresenting()) {
+			leftV.setFrom(V);
+			helpMat.self = vr.GetViewMatrix(0);
+			leftV.multmat(helpMat);
+
+			rightV.setFrom(V);
+			helpMat.self = vr.GetViewMatrix(1);
+			rightV.multmat(helpMat);
+		}
+		else {
+			leftV.setFrom(V);
+		}
+		VP.multmats(P, leftV);
+		#else
+		VP.multmats(P, V);
+		#end
 
 		if (data.raw.frustum_culling) {
 			buildViewFrustum(VP, frustumPlanes);

--- a/armory/Sources/iron/object/LightObject.hx
+++ b/armory/Sources/iron/object/LightObject.hx
@@ -154,7 +154,11 @@ class LightObject extends Object {
 	}
 
 	public function setCascade(camera: CameraObject, cascade: Int) {
+		#if arm_vr
+		m.setFrom(camera.leftV);
+		#else
 		m.setFrom(camera.V);
+		#end
 
 		#if arm_csm
 		if (camSlicedP == null) {

--- a/armory/Sources/iron/system/VR.hx
+++ b/armory/Sources/iron/system/VR.hx
@@ -1,0 +1,52 @@
+package iron.system;
+
+import iron.math.Mat4;
+
+#if arm_vr
+class VR {
+
+	static var undistortionMatrix: Mat4 = null;
+
+	public function new() {}
+
+	public static function getUndistortionMatrix(): Mat4 {
+		if (undistortionMatrix == null) {
+			undistortionMatrix = Mat4.identity();
+		}
+
+		return undistortionMatrix;
+	}
+
+	public static function getMaxRadiusSq(): Float {
+		return 0.0;
+	}
+
+	public static function initButton() {
+		function vrDownListener(index: Int, x: Float, y: Float) {
+			var vr = kha.vr.VrInterface.instance;
+			if (vr == null || !vr.IsVrEnabled() || vr.IsPresenting()) return;
+			var w: Float = iron.App.w();
+			var h: Float = iron.App.h();
+			if (x < w - 150 || y < h - 150) return;
+			vr.onVRRequestPresent();
+		}
+
+		function vrRender2D(g: kha.graphics2.Graphics) {
+			var vr = kha.vr.VrInterface.instance;
+			if (vr == null || !vr.IsVrEnabled() || vr.IsPresenting()) return;
+			var w: Float = iron.App.w();
+			var h: Float = iron.App.h();
+			g.color = 0xffff0000;
+			g.fillRect(w - 150, h - 150, 140, 140);
+		}
+
+		kha.input.Mouse.get().notify(vrDownListener, null, null, null);
+		iron.App.notifyOnRender2D(vrRender2D);
+
+		var vr = kha.vr.VrInterface.instance; // Straight to VR (Oculus Carmel)
+		if (vr != null && vr.IsVrEnabled()) {
+			vr.onVRRequestPresent();
+		}
+	}
+}
+#end


### PR DESCRIPTION
Actual code of VR fails:

![image](https://github.com/user-attachments/assets/519bc177-9b67-4b58-8fec-df5ad4199360)

I think it is best to restore the old code which at least works:

![image](https://github.com/user-attachments/assets/ef9919e0-4ec9-47e2-8147-e2e9573f43c3)

If not then let's disable the VR option.
