### PR TITLE
Fixes with CPU Particles and timing

### DIFF
--- a/armory/Sources/iron/system/Time.hx
+++ b/armory/Sources/iron/system/Time.hx
@@ -38,11 +38,11 @@ class Time {
 	}
 
 	public static inline function time(): Float {
-		return kha.Scheduler.time();
+		return kha.Scheduler.time() * scale;
 	}
 
 	public static inline function realTime(): Float {
-		return kha.Scheduler.realTime();
+		return kha.Scheduler.realTime() * scale;
 	}
 
 	public static function update() {

--- a/armory/Sources/iron/system/Tween.hx
+++ b/armory/Sources/iron/system/Tween.hx
@@ -94,34 +94,34 @@ class Tween {
 
 				// Way too much Reflect trickery..
 				var ps = Reflect.fields(a.props);
-				for (i in 0...ps.length) {
-					var p = ps[i];
+				for (j in 0...ps.length) {
+					var p = ps[j];
 					var k = a._time / a.duration;
 					if (k > 1) k = 1;
 
-					if (a._comps[i] == 1) {
-						var fromVal: Float = a._x[i];
+					if (a._comps[j] == 1) {
+						var fromVal: Float = a._x[j];
 						var toVal: Float = Reflect.getProperty(a.props, p);
 						var val: Float = fromVal + (toVal - fromVal) * eases[a.ease](k);
 						Reflect.setProperty(a.target, p, val);
 					}
-					else { // _comps[i] == 4
+					else { // _comps[j] == 4
 						var obj = Reflect.getProperty(a.props, p);
 						var toX: Float = Reflect.getProperty(obj, "x");
 						var toY: Float = Reflect.getProperty(obj, "y");
 						var toZ: Float = Reflect.getProperty(obj, "z");
 						var toW: Float = Reflect.getProperty(obj, "w");
-						if (a._normalize[i]) {
-							var qdot = (a._x[i] * toX) + (a._y[i] * toY) + (a._z[i] * toZ) + (a._w[i] * toW);
+						if (a._normalize[j]) {
+							var qdot = (a._x[j] * toX) + (a._y[j] * toY) + (a._z[j] * toZ) + (a._w[j] * toW);
 							if (qdot < 0.0) {
 								toX = -toX; toY = -toY; toZ = -toZ; toW = -toW;
 							}
 						}
-						var x: Float = a._x[i] + (toX - a._x[i]) * eases[a.ease](k);
-						var y: Float = a._y[i] + (toY - a._y[i]) * eases[a.ease](k);
-						var z: Float = a._z[i] + (toZ - a._z[i]) * eases[a.ease](k);
-						var w: Float = a._w[i] + (toW - a._w[i]) * eases[a.ease](k);
-						if (a._normalize[i]) {
+						var x: Float = a._x[j] + (toX - a._x[j]) * eases[a.ease](k);
+						var y: Float = a._y[j] + (toY - a._y[j]) * eases[a.ease](k);
+						var z: Float = a._z[j] + (toZ - a._z[j]) * eases[a.ease](k);
+						var w: Float = a._w[j] + (toW - a._w[j]) * eases[a.ease](k);
+						if (a._normalize[j]) {
 							var l = Math.sqrt(x * x + y * y + z * z + w * w);
 							if (l > 0.0) {
 								l = 1.0 / l;


### PR DESCRIPTION
I noticed the `iron.system.Tween` class has its timer slowed down when using a CPU Particle System with a color scale ramp, since each single particle was registering a `TAnim` for its scale over time. Now handling the scale over time inside ParticleSystemCPU instead so the `Tween` class doesn't get over-saturated.

Re-added scale on `iron.system.Time`. I forgot why I removed them from deltas back when I was updating the physics modules.

Changed index from `i` to `j` in the `Tween`'s animation properties loop.