### PR TITLE
General Material updates

### DIFF
--- a/armory/Sources/iron/RenderPath.hx
+++ b/armory/Sources/iron/RenderPath.hx
@@ -338,7 +338,7 @@ class RenderPath {
 			if (depthDiff != 0) return depthDiff;
 			#end
 
-			return a.materials[0].name >= b.materials[0].name ? 1 : -1;
+			return a.materials[0].shader.sortingOrder >= b.materials[0].shader.sortingOrder ? 1 : -1;
 		});
 	}
 

--- a/armory/Sources/iron/data/SceneFormat.hx
+++ b/armory/Sources/iron/data/SceneFormat.hx
@@ -223,6 +223,7 @@ typedef TShaderData = {
 #end
 	public var name: String;
 	public var sortingOrder: Int;
+	public var nextPass: String;
 	public var contexts: Array<TShaderContext>;
 }
 

--- a/armory/Sources/iron/data/SceneFormat.hx
+++ b/armory/Sources/iron/data/SceneFormat.hx
@@ -222,6 +222,7 @@ typedef TShaderData = {
 @:structInit class TShaderData {
 #end
 	public var name: String;
+	public var sortingOrder: Int;
 	public var contexts: Array<TShaderContext>;
 }
 

--- a/armory/Sources/iron/data/ShaderData.hx
+++ b/armory/Sources/iron/data/ShaderData.hx
@@ -23,6 +23,7 @@ class ShaderData {
 
 	public var name: String;
 	public var sortingOrder: Int;
+	public var nextPass: String;
 	public var raw: TShaderData;
 	public var contexts: Array<ShaderContext> = [];
 
@@ -35,6 +36,7 @@ class ShaderData {
 		this.raw = raw;
 		this.name = raw.name;
 		this.sortingOrder = raw.sortingOrder;
+		this.nextPass = raw.nextPass;
 
 		for (c in raw.contexts) contexts.push(null);
 		var contextsLoaded = 0;

--- a/armory/Sources/iron/data/ShaderData.hx
+++ b/armory/Sources/iron/data/ShaderData.hx
@@ -22,6 +22,7 @@ using StringTools;
 class ShaderData {
 
 	public var name: String;
+	public var sortingOrder: Int;
 	public var raw: TShaderData;
 	public var contexts: Array<ShaderContext> = [];
 
@@ -33,6 +34,7 @@ class ShaderData {
 	public function new(raw: TShaderData, done: ShaderData->Void, overrideContext: TShaderOverride = null) {
 		this.raw = raw;
 		this.name = raw.name;
+		this.sortingOrder = raw.sortingOrder;
 
 		for (c in raw.contexts) contexts.push(null);
 		var contextsLoaded = 0;

--- a/armory/Sources/iron/object/MeshObject.hx
+++ b/armory/Sources/iron/object/MeshObject.hx
@@ -311,7 +311,7 @@ class MeshObject extends Object {
 		// Render mesh
 		var ldata = lod.data;
 
-		// Second pass rendering first (inverse order)
+		// Next pass rendering first (inverse order)
 		renderNextPass(g, context, bindParams, lod);
 
 		for (i in 0...ldata.geom.indexBuffers.length) {

--- a/armory/Sources/iron/object/MeshObject.hx
+++ b/armory/Sources/iron/object/MeshObject.hx
@@ -418,23 +418,18 @@ class MeshObject extends Object {
 		}
 	}
 
-	// Use nextPass property from shader data instead of hardcoded hack
 	function renderNextPass(g: Graphics, context: String, bindParams: Array<String>, lod: MeshObject) {
 		var ldata = lod.data;
-
-		// Check each geometry section for nextPass materials
 		for (i in 0...ldata.geom.indexBuffers.length) {
 			var mi = ldata.geom.materialIndices[i];
 			if (mi >= materials.length) continue;
 
-			var currentMaterial = materials[mi];
+			var currentMaterial: MaterialData = materials[mi];
 			if (currentMaterial == null || currentMaterial.shader == null) continue;
 
-			// Get the nextPass material name from shader data
-			var nextPassName = currentMaterial.shader.nextPass;
-			if (nextPassName == null || nextPassName == "" || nextPassName == "none") continue;
+			var nextPassName: String = currentMaterial.shader.nextPass;
+			if (nextPassName == null || nextPassName == "") continue;
 
-			// Find the material with the specified next pass name
 			var nextMaterial: MaterialData = null;
 			for (mat in materials) {
 				// First try exact match
@@ -452,9 +447,8 @@ class MeshObject extends Object {
 				}
 			}
 
-			if (nextMaterial == null) continue; // Next pass material not found
+			if (nextMaterial == null) continue;
 
-			// Get context for next material
 			var nextMaterialContext: MaterialContext = null;
 			var nextShaderContext: ShaderContext = null;
 
@@ -467,8 +461,6 @@ class MeshObject extends Object {
 			}
 
 			if (nextShaderContext == null) continue;
-
-			// Check context skip for next material
 			if (skipContext(context, nextMaterial)) continue;
 
 			var elems = nextShaderContext.raw.vertex_elements;

--- a/armory/Sources/iron/object/MeshObject.hx
+++ b/armory/Sources/iron/object/MeshObject.hx
@@ -437,10 +437,18 @@ class MeshObject extends Object {
 			// Find the material with the specified next pass name
 			var nextMaterial: MaterialData = null;
 			for (mat in materials) {
-				trace(mat.name);
+				// First try exact match
 				if (mat.name == nextPassName) {
 					nextMaterial = mat;
 					break;
+				}
+				// If no exact match, try to match base name for linked materials
+				if (mat.name.indexOf("_") > 0 && mat.name.substr(mat.name.length - 6) == ".blend") {
+					var baseName = mat.name.substring(0, mat.name.indexOf("_"));
+					if (baseName == nextPassName) {
+						nextMaterial = mat;
+						break;
+					}
 				}
 			}
 

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -2192,6 +2192,9 @@ Make sure the mesh only has tris/quads.""")
             elif material.arm_cull_mode != 'clockwise':
                 o['override_context'] = {}
                 o['override_context']['cull_mode'] = material.arm_cull_mode
+            if material.arm_compare_mode != 'less':
+                o['override_context'] = {}
+                o['override_context']['compare_mode'] = material.arm_compare_mode
 
             o['contexts'] = []
 

--- a/armory/blender/arm/material/make_mesh.py
+++ b/armory/blender/arm/material/make_mesh.py
@@ -66,6 +66,9 @@ def make(context_id, rpasses):
     elif dprepass and not (rpdat.rp_depth_texture and mat.arm_depth_read):
         con['depth_write'] = False
         con['compare_mode'] = 'equal'
+    else:
+        con['depth_write'] = mat.arm_depth_write
+        con['compare_mode'] = mat.arm_compare_mode
 
     attachment_format = 'RGBA32' if '_LDR' in wrd.world_defs else 'RGBA64'
     con['color_attachments'] = [attachment_format, attachment_format]

--- a/armory/blender/arm/material/make_mesh.py
+++ b/armory/blender/arm/material/make_mesh.py
@@ -58,7 +58,6 @@ def make(context_id, rpasses):
         con['alpha_blend_destination'] = mat.arm_blending_destination_alpha
         con['alpha_blend_operation'] = mat.arm_blending_operation_alpha
         con['depth_write'] = False
-        con['compare_mode'] = 'less'
     elif particle:
         pass
     # Depth prepass was performed, exclude mat with depth read that

--- a/armory/blender/arm/material/shader.py
+++ b/armory/blender/arm/material/shader.py
@@ -23,6 +23,7 @@ class ShaderData:
         self.data = {'shader_datas': [self.sd]}
         self.matname = arm.utils.safesrc(arm.utils.asset_name(material))
         self.sd['name'] = self.matname + '_data'
+        self.sd['sortingOrder'] = material.arm_sorting_order
         self.sd['contexts'] = []
 
     def add_context(self, props) -> 'ShaderContext':

--- a/armory/blender/arm/material/shader.py
+++ b/armory/blender/arm/material/shader.py
@@ -24,6 +24,7 @@ class ShaderData:
         self.matname = arm.utils.safesrc(arm.utils.asset_name(material))
         self.sd['name'] = self.matname + '_data'
         self.sd['sortingOrder'] = material.arm_sorting_order
+        self.sd['nextPass'] = material.arm_next_pass
         self.sd['contexts'] = []
 
     def add_context(self, props) -> 'ShaderContext':

--- a/armory/blender/arm/props.py
+++ b/armory/blender/arm/props.py
@@ -437,7 +437,7 @@ def init_properties():
                ('counter_clockwise', 'Back', 'Counter-Clockwise')],
         name="Cull Mode", default='clockwise', description="Draw geometry faces")
     bpy.types.Material.arm_next_pass = StringProperty(
-        name="Next Pass", default='none', description="Next pass for the material", update=assets.invalidate_shader_cache)
+        name="Next Pass", default='', description="Next pass for the material", update=assets.invalidate_shader_cache)
     bpy.types.Material.arm_discard = BoolProperty(name="Alpha Test", default=False, description="Do not render fragments below specified opacity threshold")
     bpy.types.Material.arm_discard_opacity = FloatProperty(name="Mesh Opacity", default=0.2, min=0, max=1)
     bpy.types.Material.arm_discard_opacity_shadows = FloatProperty(name="Shadows Opacity", default=0.1, min=0, max=1)

--- a/armory/blender/arm/props.py
+++ b/armory/blender/arm/props.py
@@ -551,6 +551,7 @@ def init_properties():
     bpy.types.Material.export_uvs = BoolProperty(name="Export UVs", default=False)
     bpy.types.Material.export_vcols = BoolProperty(name="Export VCols", default=False)
     bpy.types.Material.export_tangents = BoolProperty(name="Export Tangents", default=False)
+    bpy.types.Material.arm_sorting_order = IntProperty(name="Sorting Order", default=0)
     bpy.types.Material.arm_skip_context = StringProperty(name="Skip Context", default='')
     bpy.types.Material.arm_material_id = IntProperty(name="ID", default=0)
     bpy.types.NodeSocket.is_uniform = BoolProperty(name="Is Uniform", description="Mark node sockets to be processed as material uniforms", default=False)

--- a/armory/blender/arm/props.py
+++ b/armory/blender/arm/props.py
@@ -413,9 +413,22 @@ def init_properties():
     bpy.types.World.arm_nishita_density = FloatVectorProperty(name="Nishita Density", size=3, default=[1, 1, 1])
     bpy.types.Material.arm_cast_shadow = BoolProperty(name="Cast Shadow", default=True)
     bpy.types.Material.arm_receive_shadow = BoolProperty(name="Receive Shadow", description="Requires forward render path", default=True)
+    bpy.types.Material.arm_depth_write = BoolProperty(name="Write Depth", description="Allow this material to write to the depth buffer", default=True)
     bpy.types.Material.arm_depth_read = BoolProperty(name="Read Depth", description="Allow this material to read from a depth texture which is copied from the depth buffer. The meshes using this material will be drawn after all meshes that don't read from the depth texture", default=False)
     bpy.types.Material.arm_overlay = BoolProperty(name="Overlay", description="Renders the material, unshaded, over other shaded materials", default=False)
     bpy.types.Material.arm_decal = BoolProperty(name="Decal", default=False)
+    bpy.types.Material.arm_compare_mode = EnumProperty(
+        items=[
+            ('always', 'Always', 'Always'),
+            ('never', 'Never', 'Never'),
+            ('less', 'Less', 'Less'),
+            ('less_equal', 'Less Equal', 'Less Equal'),
+            ('greater', 'Greater', 'Greater'),
+            ('greater_equal', 'Greater Equal', 'Greater Equal'),
+            ('equal', 'Equal', 'Equal'),
+            ('not_equal', 'Not Equal', 'Not Equal'),
+        ],
+        name="Compare Mode", default='less', description="Comparison mode for the material")
     bpy.types.Material.arm_two_sided = BoolProperty(name="Two-Sided", description="Flip normal when drawing back-face", default=False)
     bpy.types.Material.arm_ignore_irradiance = BoolProperty(name="Ignore Irradiance", description="Ignore irradiance for material", default=False)
     bpy.types.Material.arm_cull_mode = EnumProperty(

--- a/armory/blender/arm/props.py
+++ b/armory/blender/arm/props.py
@@ -436,6 +436,8 @@ def init_properties():
                ('clockwise', 'Front', 'Clockwise'),
                ('counter_clockwise', 'Back', 'Counter-Clockwise')],
         name="Cull Mode", default='clockwise', description="Draw geometry faces")
+    bpy.types.Material.arm_next_pass = StringProperty(
+        name="Next Pass", default='none', description="Next pass for the material", update=assets.invalidate_shader_cache)
     bpy.types.Material.arm_discard = BoolProperty(name="Alpha Test", default=False, description="Do not render fragments below specified opacity threshold")
     bpy.types.Material.arm_discard_opacity = FloatProperty(name="Mesh Opacity", default=0.2, min=0, max=1)
     bpy.types.Material.arm_discard_opacity_shadows = FloatProperty(name="Shadows Opacity", default=0.1, min=0, max=1)

--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -579,11 +579,13 @@ class ARM_PT_MaterialPropsPanel(bpy.types.Panel):
         columnb.enabled = len(wrd.arm_rplist) > 0 and arm.utils.get_rp().rp_renderer == 'Forward'
         columnb.prop(mat, 'arm_receive_shadow')
         layout.prop(mat, 'arm_ignore_irradiance')
+        layout.prop(mat, 'arm_compare_mode')
         layout.prop(mat, 'arm_two_sided')
         columnb = layout.column()
         columnb.enabled = not mat.arm_two_sided
         columnb.prop(mat, 'arm_cull_mode')
         layout.prop(mat, 'arm_material_id')
+        layout.prop(mat, 'arm_depth_write')
         layout.prop(mat, 'arm_depth_read')
         layout.prop(mat, 'arm_overlay')
         layout.prop(mat, 'arm_decal')

--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -573,6 +573,7 @@ class ARM_PT_MaterialPropsPanel(bpy.types.Panel):
         if mat is None:
             return
 
+        layout.prop(mat, 'arm_sorting_order')
         layout.prop(mat, 'arm_cast_shadow')
         columnb = layout.column()
         wrd = bpy.data.worlds['Arm']

--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -505,13 +505,13 @@ class ARM_OT_NextPassMaterialSelector(bpy.types.Operator):
         layout = popup.layout
 
         # Add 'None' option
-        op = layout.operator("arm.set_next_pass_material", text="None")
+        op = layout.operator("arm.set_next_pass_material", text="")
         op.material_name = ""
 
         # Add materials from the current object's material slots
         if context.object and hasattr(context.object, 'material_slots'):
             for slot in context.object.material_slots:
-                if slot.material is not None:
+                if (slot.material is not None and slot.material != context.material):
                     op = layout.operator("arm.set_next_pass_material", text=slot.material.name)
                     op.material_name = slot.material.name
 

--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -627,12 +627,9 @@ class ARM_PT_MaterialPropsPanel(bpy.types.Panel):
         columnb = layout.column()
         columnb.enabled = not mat.arm_two_sided
         columnb.prop(mat, 'arm_cull_mode')
-
-        # Next Pass material selection with dynamic dropdown
         row = layout.row(align=True)
         row.prop(mat, 'arm_next_pass', text="Next Pass")
         row.operator('arm.next_pass_material_selector', text='', icon='MATERIAL')
-
         layout.prop(mat, 'arm_material_id')
         layout.prop(mat, 'arm_depth_write')
         layout.prop(mat, 'arm_depth_read')


### PR DESCRIPTION
Changes:
- exposed `Compare Mode`
- exposed `Write Depth`
- added `Sorting Order` so when `Render - Renderer - Draw Order` is set to `Shader`, they get sorted by index instead of by name
- added `Next Pass`, this draws before the main pass

With these changes, effects making objects to be seen behind walls can be achieved easily, without having to write custom shaders. Also `Render - Renderer - Ovelays` and `Material - Armory Props - Overlay` may not be needed, since the overlay can be achieved with `Material - Armory Props - Compare Mode - Always`.