### PR TITLE
General fixes

### DIFF
--- a/armory/Sources/armory/system/Starter.hx
+++ b/armory/Sources/armory/system/Starter.hx
@@ -56,8 +56,8 @@ class Starter {
 						#if arm_patch
 						iron.Scene.getRenderPath = getRenderPath;
 						#end
-						#if arm_draworder_shader
-						iron.RenderPath.active.drawOrder = iron.RenderPath.DrawOrder.Shader;
+						#if arm_draworder_index
+						iron.RenderPath.active.drawOrder = iron.RenderPath.DrawOrder.Index;
 						#end // else Distance
 					});
 				});

--- a/armory/Sources/iron/RenderPath.hx
+++ b/armory/Sources/iron/RenderPath.hx
@@ -331,14 +331,18 @@ class RenderPath {
 		});
 	}
 
-	public static function sortMeshesShader(meshes: Array<MeshObject>) {
+	public static function sortMeshesIndex(meshes: Array<MeshObject>) {
 		meshes.sort(function(a, b): Int {
 			#if rp_depth_texture
 			var depthDiff = boolToInt(a.depthRead) - boolToInt(b.depthRead);
 			if (depthDiff != 0) return depthDiff;
 			#end
 
-			return a.materials[0].shader.sortingOrder >= b.materials[0].shader.sortingOrder ? 1 : -1;
+			if (a.data.sortingIndex != b.data.sortingIndex) {
+				return a.data.sortingIndex > b.data.sortingIndex ? 1 : -1;
+			}
+
+			return a.data.name >= b.data.name ? 1 : -1;
 		});
 	}
 
@@ -399,7 +403,7 @@ class RenderPath {
 			#if arm_batch
 			sortMeshesDistance(Scene.active.meshBatch.nonBatched);
 			#else
-			drawOrder == DrawOrder.Shader ? sortMeshesShader(meshes) : sortMeshesDistance(meshes);
+			drawOrder == DrawOrder.Index ? sortMeshesIndex(meshes) : sortMeshesDistance(meshes);
 			#end
 			meshesSorted = true;
 		}
@@ -914,6 +918,6 @@ class CachedShaderContext {
 
 @:enum abstract DrawOrder(Int) from Int {
 	var Distance = 0; // Early-z
-	var Shader = 1; // Less state changes
+	var Index = 1; // Less state changes
 	// var Mix = 2; // Distance buckets sorted by shader
 }

--- a/armory/Sources/iron/data/MeshData.hx
+++ b/armory/Sources/iron/data/MeshData.hx
@@ -9,6 +9,7 @@ import iron.data.SceneFormat;
 class MeshData {
 
 	public var name: String;
+	public var sortingIndex: Int;
 	public var raw: TMeshData;
 	public var format: TSceneFormat;
 	public var geom: Geometry;
@@ -23,6 +24,7 @@ class MeshData {
 	public function new(raw: TMeshData, done: MeshData->Void) {
 		this.raw = raw;
 		this.name = raw.name;
+		this.sortingIndex = raw.sorting_index;
 
 		if (raw.scale_pos != null) scalePos = raw.scale_pos;
 		if (raw.scale_tex != null) scaleTex = raw.scale_tex;

--- a/armory/Sources/iron/data/SceneFormat.hx
+++ b/armory/Sources/iron/data/SceneFormat.hx
@@ -49,6 +49,7 @@ typedef TMeshData = {
 @:structInit class TMeshData {
 #end
 	public var name: String;
+	public var sorting_index: Int;
 	public var vertex_arrays: Array<TVertexArray>;
 	public var index_arrays: Array<TIndexArray>;
 	@:optional public var dynamic_usage: Null<Bool>;
@@ -222,8 +223,7 @@ typedef TShaderData = {
 @:structInit class TShaderData {
 #end
 	public var name: String;
-	public var sortingOrder: Int;
-	public var nextPass: String;
+	public var next_pass: String;
 	public var contexts: Array<TShaderContext>;
 }
 

--- a/armory/Sources/iron/data/ShaderData.hx
+++ b/armory/Sources/iron/data/ShaderData.hx
@@ -22,7 +22,6 @@ using StringTools;
 class ShaderData {
 
 	public var name: String;
-	public var sortingOrder: Int;
 	public var nextPass: String;
 	public var raw: TShaderData;
 	public var contexts: Array<ShaderContext> = [];
@@ -35,8 +34,7 @@ class ShaderData {
 	public function new(raw: TShaderData, done: ShaderData->Void, overrideContext: TShaderOverride = null) {
 		this.raw = raw;
 		this.name = raw.name;
-		this.sortingOrder = raw.sortingOrder;
-		this.nextPass = raw.nextPass;
+		this.nextPass = raw.next_pass;
 
 		for (c in raw.contexts) contexts.push(null);
 		var contextsLoaded = 0;

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -1711,6 +1711,7 @@ Make sure the mesh only has tris/quads.""")
             tangdata = np.array(tangdata, dtype='<i2')
 
         # Output
+        o['sorting_index'] = bobject.arm_sorting_index
         o['vertex_arrays'] = []
         o['vertex_arrays'].append({ 'attrib': 'pos', 'values': pdata, 'data': 'short4norm' })
         o['vertex_arrays'].append({ 'attrib': 'nor', 'values': ndata, 'data': 'short2norm' })

--- a/armory/blender/arm/exporter_opt.py
+++ b/armory/blender/arm/exporter_opt.py
@@ -129,7 +129,7 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
         # Shape keys UV are exported separately, so reduce UV count by 1
         num_uv_layers -= 1
         morph_uv_index = self.get_morph_uv_index(bobject.data)
-    has_tex = self.get_export_uvs(export_mesh) or num_uv_layers > 0
+    has_tex = self.get_export_uvs(export_mesh) or num_uv_layers > 0 # FIXME: this should use an `and` instead of `or`. Workaround to completely ignore if the mesh has the `export_uvs` flag. Only checking the `uv_layers` to bypass issues with materials in linked objects.
     if self.has_baked_material(bobject, export_mesh.materials):
         has_tex = True
     has_tex1 = has_tex and num_uv_layers > 1

--- a/armory/blender/arm/exporter_opt.py
+++ b/armory/blender/arm/exporter_opt.py
@@ -335,6 +335,7 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
         tangdata = np.array(tangdata, dtype='<i2')
 
     # Output
+    o['sorting_index'] = bobject.arm_sorting_index
     o['vertex_arrays'] = []
     o['vertex_arrays'].append({ 'attrib': 'pos', 'values': pdata, 'data': 'short4norm' })
     o['vertex_arrays'].append({ 'attrib': 'nor', 'values': ndata, 'data': 'short2norm' })

--- a/armory/blender/arm/exporter_opt.py
+++ b/armory/blender/arm/exporter_opt.py
@@ -129,7 +129,7 @@ def export_mesh_data(self, export_mesh: bpy.types.Mesh, bobject: bpy.types.Objec
         # Shape keys UV are exported separately, so reduce UV count by 1
         num_uv_layers -= 1
         morph_uv_index = self.get_morph_uv_index(bobject.data)
-    has_tex = self.get_export_uvs(export_mesh) and num_uv_layers > 0
+    has_tex = self.get_export_uvs(export_mesh) or num_uv_layers > 0
     if self.has_baked_material(bobject, export_mesh.materials):
         has_tex = True
     has_tex1 = has_tex and num_uv_layers > 1
@@ -427,7 +427,7 @@ def export_skin(self, bobject, armature, vert_list, o):
             bone_weight_array[count] = bv[0] * 32767
             bone_index_array[count] = bv[1]
             count += 1
-        
+
         if total_weight not in (0.0, 1.0):
             normalizer = 1.0 / total_weight
             for i in range(bone_count):

--- a/armory/blender/arm/material/shader.py
+++ b/armory/blender/arm/material/shader.py
@@ -23,8 +23,7 @@ class ShaderData:
         self.data = {'shader_datas': [self.sd]}
         self.matname = arm.utils.safesrc(arm.utils.asset_name(material))
         self.sd['name'] = self.matname + '_data'
-        self.sd['sortingOrder'] = material.arm_sorting_order
-        self.sd['nextPass'] = material.arm_next_pass
+        self.sd['next_pass'] = material.arm_next_pass
         self.sd['contexts'] = []
 
     def add_context(self, props) -> 'ShaderContext':

--- a/armory/blender/arm/props.py
+++ b/armory/blender/arm/props.py
@@ -349,6 +349,7 @@ def init_properties():
         description='Whether to use instancing to draw the children of this object. If enabled, this option defines what attributes may vary between the instances',
         update=assets.invalidate_instance_cache,
         override={'LIBRARY_OVERRIDABLE'})
+    bpy.types.Object.arm_sorting_index = IntProperty(name="Sorting Index", description="Sorting index for the Render's Draw Order", default=0, override={'LIBRARY_OVERRIDABLE'})
     bpy.types.Object.arm_export = BoolProperty(name="Export", description="Export object data", default=True, override={'LIBRARY_OVERRIDABLE'})
     bpy.types.Object.arm_spawn = BoolProperty(name="Spawn", description="Auto-add this object when creating scene", default=True, override={'LIBRARY_OVERRIDABLE'})
     bpy.types.Object.arm_mobile = BoolProperty(name="Mobile", description="Object moves during gameplay", default=False, override={'LIBRARY_OVERRIDABLE'})
@@ -553,7 +554,6 @@ def init_properties():
     bpy.types.Material.export_uvs = BoolProperty(name="Export UVs", default=False)
     bpy.types.Material.export_vcols = BoolProperty(name="Export VCols", default=False)
     bpy.types.Material.export_tangents = BoolProperty(name="Export Tangents", default=False)
-    bpy.types.Material.arm_sorting_order = IntProperty(name="Sorting Order", default=0)
     bpy.types.Material.arm_skip_context = StringProperty(name="Skip Context", default='')
     bpy.types.Material.arm_material_id = IntProperty(name="ID", default=0)
     bpy.types.NodeSocket.is_uniform = BoolProperty(name="Is Uniform", description="Mark node sockets to be processed as material uniforms", default=False)

--- a/armory/blender/arm/props_renderpath.py
+++ b/armory/blender/arm/props_renderpath.py
@@ -434,7 +434,7 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     rp_draw_order: EnumProperty(
         items=[('Auto', 'Auto', 'Auto'),
                ('Distance', 'Distance', 'Distance'),
-               ('Shader', 'Shader', 'Shader')],
+               ('Index', 'Index', 'Index')],
         name='Draw Order', description='Sort objects', default='Auto', update=assets.invalidate_compiled_data)
     rp_depth_texture: BoolProperty(name="Depth Texture", description="Current render-path state", default=False)
     rp_depth_texture_state: EnumProperty(

--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -62,6 +62,7 @@ class ARM_PT_ObjectPropsPanel(bpy.types.Panel):
             return
 
         col = layout.column()
+        col.prop(obj, 'arm_sorting_index')
         col.prop(obj, 'arm_export')
         if not obj.arm_export:
             return
@@ -615,7 +616,6 @@ class ARM_PT_MaterialPropsPanel(bpy.types.Panel):
         if mat is None:
             return
 
-        layout.prop(mat, 'arm_sorting_order')
         layout.prop(mat, 'arm_cast_shadow')
         columnb = layout.column()
         wrd = bpy.data.worlds['Arm']

--- a/armory/blender/arm/write_data.py
+++ b/armory/blender/arm/write_data.py
@@ -336,8 +336,8 @@ project.addSources('Sources');
             elif rpdat.arm_particles == 'CPU':
                 assets.add_khafile_def('arm_cpu_particles')
 
-        if rpdat.rp_draw_order == 'Shader':
-            assets.add_khafile_def('arm_draworder_shader')
+        if rpdat.rp_draw_order == 'Index':
+            assets.add_khafile_def('arm_draworder_index')
 
         if arm.utils.get_viewport_controls() == 'azerty':
             assets.add_khafile_def('arm_azerty')


### PR DESCRIPTION
- workaround to fix UV coordinates for linked materials when `Render - Armory Exporter - Optimize Data` is enabled
- move `sorting_order` from materials/shaders to `sorting_index` to mesh objects, since RenderPath sort meshes and not materials
- sort mesh objects by name if they have the same index
- changed `Render - Armory Render Path - DrawOrder - Shader` to `Render - Armory Render Path - DrawOrder - Index`

Thanks to @t3du for the insight.