### PR TITLE
Include external blend files on build

### DIFF
--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -2472,7 +2472,7 @@ Make sure the mesh only has tris/quads.""")
         world = self.scene.world
 
         if world is not None:
-            world_name = arm.utils.safestr(world.name)
+            world_name = arm.utils.safestr(arm.utils.asset_name(world) if world.library else world.name)
 
             if world_name not in self.world_array:
                 self.world_array.append(world_name)
@@ -2626,7 +2626,7 @@ Make sure the mesh only has tris/quads.""")
 
         if not ArmoryExporter.option_mesh_only:
             if self.scene.camera is not None:
-                self.output['camera_ref'] = self.scene.camera.name
+                self.output['camera_ref'] = arm.utils.asset_name(self.scene.camera) if self.scene.library else self.scene.camera.name
             else:
                 if self.scene.name == arm.utils.get_project_scene_name():
                     log.warn(f'Scene "{self.scene.name}" is missing a camera')
@@ -2650,7 +2650,7 @@ Make sure the mesh only has tris/quads.""")
             self.export_tilesheets()
 
             if self.scene.world is not None:
-                self.output['world_ref'] = arm.utils.safestr(self.scene.world.name)
+                self.output['world_ref'] = arm.utils.safestr(arm.utils.asset_name(self.scene.world) if self.scene.world.library else self.scene.world.name)
 
             if self.scene.use_gravity:
                 self.output['gravity'] = [self.scene.gravity[0], self.scene.gravity[1], self.scene.gravity[2]]
@@ -3438,7 +3438,7 @@ Make sure the mesh only has tris/quads.""")
         if mobile_mat:
             arm_radiance = False
 
-        out_probe = {'name': world.name}
+        out_probe = {'name': arm.utils.asset_name(world) if world.library else world.name}
         if arm_irradiance:
             ext = '' if wrd.arm_minimize else '.json'
             out_probe['irradiance'] = irrsharmonics + '_irradiance' + ext

--- a/armory/blender/arm/make.py
+++ b/armory/blender/arm/make.py
@@ -142,6 +142,7 @@ def load_external_blends():
 
                 for scn in data_to.scenes:
                     if scn is not None and scn not in appended_scenes:
+                        scn.name += "_" + filename.replace('.blend', '')
                         appended_scenes.append(scn)
 
                 log.info(f"Loaded external blend: {filename}")

--- a/armory/blender/arm/make.py
+++ b/armory/blender/arm/make.py
@@ -141,6 +141,18 @@ def load_external_blends():
                     data_to.scenes = list(data_from.scenes)
 
                 for scn in data_to.scenes:
+                    if scn.library and scn.library.filepath == blend_path:
+                        # Check for duplicates (excluding this scene)
+                        duplicate = any(
+                            s is not scn and s.library and s.library.filepath == blend_path
+                            for s in bpy.data.scenes
+                        )
+                        if duplicate:
+                            try:
+                                bpy.data.scenes.remove(scn, do_unlink=True)
+                            except Exception as e:
+                                log.error(f"Failed to remove duplicate scene {scn.name}: {e}")
+                            continue
                     if scn is not None and scn not in appended_scenes:
                         scn.name += "_" + filename.replace('.blend', '')
                         appended_scenes.append(scn)

--- a/armory/blender/arm/make_world.py
+++ b/armory/blender/arm/make_world.py
@@ -59,7 +59,7 @@ def build():
                         break;
 
             #if scene.arm_export and world is not None and world not in worlds:
-            # Only export worlds from enabled scenes and with fake users                
+            # Only export worlds from enabled scenes and with fake users
             if (world.use_fake_user and world.name != 'Arm') or assigned:
                 worlds.append(world)
 
@@ -69,7 +69,7 @@ def build():
                 if rpdat.arm_irradiance:
                     # Plain background color
                     if '_EnvCol' in world.world_defs:
-                        world_name = arm.utils.safestr(world.name)
+                        world_name = arm.utils.safestr(arm.utils.asset_name(world) if world.library else world.name)
                         # Irradiance json file name
                         world.arm_envtex_name = world_name
                         world.arm_envtex_irr_name = world_name
@@ -99,7 +99,7 @@ def build():
 def create_world_shaders(world: bpy.types.World):
     """Creates fragment and vertex shaders for the given world."""
     global shader_datas
-    world_name = arm.utils.safestr(world.name)
+    world_name = arm.utils.safestr(arm.utils.asset_name(world) if world.library else world.name)
     pass_name = 'World_' + world_name
 
     shader_props = {
@@ -160,7 +160,7 @@ def create_world_shaders(world: bpy.types.World):
 
 def build_node_tree(world: bpy.types.World, frag: Shader, vert: Shader, con: ShaderContext):
     """Generates the shader code for the given world."""
-    world_name = arm.utils.safestr(world.name)
+    world_name = arm.utils.safestr(arm.utils.asset_name(world) if world.library else world.name)
     world.world_defs = ''
     rpdat = arm.utils.get_rp()
     wrd = bpy.data.worlds['Arm']
@@ -175,7 +175,7 @@ def build_node_tree(world: bpy.types.World, frag: Shader, vert: Shader, con: Sha
         frag.write('fragColor.rgb = backgroundCol;')
         return
 
-    parser_state = ParserState(ParserContext.WORLD, world.name, world)
+    parser_state = ParserState(ParserContext.WORLD, arm.utils.asset_name(world) if world.library else world.name, world)
     parser_state.con = con
     parser_state.curshader = frag
     parser_state.frag = frag

--- a/armory/blender/arm/props.py
+++ b/armory/blender/arm/props.py
@@ -142,6 +142,8 @@ def init_properties():
     bpy.types.World.arm_project_version = StringProperty(name="Version", description="Exported project version", default="1.0.0", update=assets.invalidate_compiler_cache, set=set_version, get=get_version)
     bpy.types.World.arm_project_version_autoinc = BoolProperty(name="Auto-increment Build Number", description="Auto-increment build number", default=True, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_bundle = StringProperty(name="Bundle", description="Exported project bundle", default="org.armory3d", update=assets.invalidate_compiler_cache, set=set_project_bundle, get=get_project_bundle)
+    # External Blend Files
+    bpy.types.World.arm_external_blends_path = StringProperty(name="External Blends Directory", description="Directory containing external blend files to include in export", default="", subtype='DIR_PATH', update=assets.invalidate_compiler_cache)
     # Android Settings
     bpy.types.World.arm_project_android_sdk_min = IntProperty(name="Minimal Version SDK", description="Minimal Version Android SDK", default=23, min=14, max=30, update=assets.invalidate_compiler_cache)
     bpy.types.World.arm_project_android_sdk_target = IntProperty(name="Target Version SDK", description="Target Version Android SDK", default=26, min=26, max=30, update=assets.invalidate_compiler_cache)

--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -1213,6 +1213,7 @@ class ARM_PT_ProjectModulesPanel(bpy.types.Panel):
 
         layout.prop_search(wrd, 'arm_khafile', bpy.data, 'texts')
         layout.prop(wrd, 'arm_project_root')
+        layout.prop(wrd, 'arm_external_blends_path')
 
 class ArmVirtualInputPanel(bpy.types.Panel):
     bl_label = "Armory Virtual Input"

--- a/armory/blender/arm/write_probes.py
+++ b/armory/blender/arm/write_probes.py
@@ -118,7 +118,8 @@ def render_envmap(target_dir: str, world: bpy.types.World) -> str:
     scene = bpy.data.scenes['_arm_envmap_render']
     scene.world = world
 
-    image_name = f'env_{arm.utils.safesrc(world.name)}.{ENVMAP_EXT}'
+    world_name = arm.utils.asset_name(world) if world.library else world.name
+    image_name = f'env_{arm.utils.safesrc(world_name)}.{ENVMAP_EXT}'
     render_path = os.path.join(target_dir, image_name)
     scene.render.filepath = render_path
 


### PR DESCRIPTION
Armory currently supports linked objects from external blend files, but they need to be manually added in a scene in order to be exported to the `data` directory. With this addition, external blend files and their scenes can be exported without needing to manually link them in Blender, this can help it comes to create game levels.

Instructions:
1) Set the external `blend` file's `Render - Armory Project - Modules - Root` to the main blend file's directory
2) In the main `blend` file, set `Render - Armory Project - Modules - External Blends Directory` to the blend files' directory you want to include in the build process. This will also include subfolders.
3) To reference the scenes in Haxe or Nodes, use `"[SceneName]_[blend_file_name_without_extension]"`

Keeping it as draft since it depends on #3213 and to keep testing.