### PR TITLE
new Draw/Image/Color Nodes

### DIFF
--- a/armory/Sources/armory/logicnode/DrawImageNode.hx
+++ b/armory/Sources/armory/logicnode/DrawImageNode.hx
@@ -31,7 +31,7 @@ class DrawImageNode extends LogicNode {
 
 		RenderToTexture.g.rotate(angle, x, y);
 
-		if (imgName != lastImgName) {
+		if (imgName != lastImgName || img == null) {
 			// Load new image
 			lastImgName = imgName;
 			iron.data.Data.getImage(imgName, (image: Image) -> {

--- a/armory/Sources/armory/logicnode/DrawImageRenderNode.hx
+++ b/armory/Sources/armory/logicnode/DrawImageRenderNode.hx
@@ -73,30 +73,28 @@ class DrawImageRenderNode extends LogicNode {
 
 		img = camera.renderTarget;
 
-		if (inputs[15].get()){
+		if (inputs[15].get() || kha.Image.renderTargetsInvertedY()) {
 
 			img = kha.Image.createRenderTarget(iron.App.w(), iron.App.h(),
 				kha.graphics4.TextureFormat.RGBA32,
 				kha.graphics4.DepthStencilFormat.NoDepthAndStencil);
 
 			img.g2.begin(true, Color.Transparent);
-
 			img.g2.color = Color.White;
-			img.g2.drawImage(camera.renderTarget, 0, 0);
 
-			if (kha.Image.renderTargetsInvertedY()){
-				img.g2.scale(1, -1);
-				img.g2.translate(0, iron.App.h());
+			if (kha.Image.renderTargetsInvertedY()) {
+				img.g2.drawScaledImage(camera.renderTarget, 0, iron.App.h(), iron.App.w(), -iron.App.h());
+			} else {
+				img.g2.drawImage(camera.renderTarget, 0, 0);
 			}
-			else
-				img.g2.scale(1, 1);
 
-			for (f in @:privateAccess iron.App.traitRenders2D){
-		    	f(img.g2);
-		    }
-		    
-		    img.g2.end();
-
+			if (inputs[15].get()) {
+				for (f in @:privateAccess iron.App.traitRenders2D) {
+					f(img.g2);
+				}
+			}
+			
+			img.g2.end();
 		}
 
 		camera.renderTarget = oldRT;

--- a/armory/Sources/armory/logicnode/DrawImageRenderNode.hx
+++ b/armory/Sources/armory/logicnode/DrawImageRenderNode.hx
@@ -1,0 +1,109 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+import kha.Image;
+import kha.Color;
+import armory.renderpath.RenderToTexture;
+
+class DrawImageRenderNode extends LogicNode {
+	var img: Image;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+
+		if (from == 1)
+			tree.notifyOnRender(render);
+		else {
+
+		RenderToTexture.ensure2DContext("DrawImageRenderNode");
+
+		final colorVec: Vec4 = inputs[3].get();
+		final anchorH: Int = inputs[4].get();
+		final anchorV: Int = inputs[5].get();
+		final x: Float = inputs[6].get();
+		final y: Float = inputs[7].get();
+		final width: Float = inputs[8].get();
+		final height: Float = inputs[9].get();
+		final sx: Float = inputs[10].get();
+		final sy: Float = inputs[11].get();
+		final swidth: Float = inputs[12].get();
+		final sheight: Float = inputs[13].get();
+		final angle: Float = inputs[14].get();
+
+		final drawx = x - 0.5 * width * anchorH;
+		final drawy = y - 0.5 * height * anchorV;
+
+		RenderToTexture.g.rotate(angle, x, y);
+
+		RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
+
+		if (img != null){
+			RenderToTexture.g.color = 0xff000000;
+			RenderToTexture.g.fillRect(drawx, drawy,  width, height);
+			RenderToTexture.g.color = 0xffffffff;
+			RenderToTexture.g.drawScaledSubImage(img, sx, sy, swidth, sheight, drawx, drawy, width, height);
+		}
+
+		RenderToTexture.g.rotate(-angle, x, y);
+
+		runOutput(0);
+
+		}
+
+	}
+
+	function render(g: kha.graphics4.Graphics) {
+
+		var camera = inputs[2].get();
+
+		img = kha.Image.createRenderTarget(iron.App.w(), iron.App.h(),
+			kha.graphics4.TextureFormat.RGBA32,
+			kha.graphics4.DepthStencilFormat.NoDepthAndStencil);
+
+		final sceneCam = iron.Scene.active.camera;
+		final oldRT = camera.renderTarget;
+
+		iron.Scene.active.camera = camera;
+		camera.renderTarget = img;
+
+		camera.renderFrame(g);
+
+		img = camera.renderTarget;
+
+		if (inputs[15].get()){
+
+			img = kha.Image.createRenderTarget(iron.App.w(), iron.App.h(),
+				kha.graphics4.TextureFormat.RGBA32,
+				kha.graphics4.DepthStencilFormat.NoDepthAndStencil);
+
+			img.g2.begin(true, Color.Transparent);
+
+			img.g2.color = Color.White;
+			img.g2.drawImage(camera.renderTarget, 0, 0);
+
+			if (kha.Image.renderTargetsInvertedY()){
+				img.g2.scale(1, -1);
+				img.g2.translate(0, iron.App.h());
+			}
+			else
+				img.g2.scale(1, 1);
+
+			for (f in @:privateAccess iron.App.traitRenders2D){
+		    	f(img.g2);
+		    }
+		    
+		    img.g2.end();
+
+		}
+
+		camera.renderTarget = oldRT;
+		iron.Scene.active.camera = sceneCam;
+
+		tree.removeRender(render);
+
+	}
+
+}

--- a/armory/Sources/armory/logicnode/DrawImageRenderNode.hx
+++ b/armory/Sources/armory/logicnode/DrawImageRenderNode.hx
@@ -38,12 +38,10 @@ class DrawImageRenderNode extends LogicNode {
 
 		RenderToTexture.g.rotate(angle, x, y);
 
-		RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
-
 		if (img != null){
 			RenderToTexture.g.color = 0xff000000;
 			RenderToTexture.g.fillRect(drawx, drawy,  width, height);
-			RenderToTexture.g.color = 0xffffffff;
+			RenderToTexture.g.color = RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
 			RenderToTexture.g.drawScaledSubImage(img, sx, sy, swidth, sheight, drawx, drawy, width, height);
 		}
 

--- a/armory/Sources/armory/logicnode/DrawSubImageNode.hx
+++ b/armory/Sources/armory/logicnode/DrawSubImageNode.hx
@@ -32,8 +32,6 @@ class DrawSubImageNode extends LogicNode {
 
 		final drawx = x - 0.5 * width * anchorH;
 		final drawy = y - 0.5 * height * anchorV;
-		final sdrawx = sx - 0.5 * swidth * anchorH;
-		final sdrawy = sy - 0.5 * sheight * anchorV;
 
 		RenderToTexture.g.rotate(angle, x, y);
 
@@ -51,7 +49,7 @@ class DrawSubImageNode extends LogicNode {
 		}
 
 		RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
-		RenderToTexture.g.drawScaledSubImage(img, sdrawx, sdrawy, swidth, sheight, drawx, drawy, width, height);
+		RenderToTexture.g.drawScaledSubImage(img, sx, sy, swidth, sheight, drawx, drawy, width, height);
 		RenderToTexture.g.rotate(-angle, x, y);
 
 		runOutput(0);

--- a/armory/Sources/armory/logicnode/DrawSubImageNode.hx
+++ b/armory/Sources/armory/logicnode/DrawSubImageNode.hx
@@ -14,7 +14,7 @@ class DrawSubImageNode extends LogicNode {
 	}
 
 	override function run(from: Int) {
-		RenderToTexture.ensure2DContext("DrawImageNode");
+		RenderToTexture.ensure2DContext("DrawSubImageNode");
 
 		final imgName: String = inputs[1].get();
 		final colorVec: Vec4 = inputs[2].get();

--- a/armory/Sources/armory/logicnode/DrawSubImageNode.hx
+++ b/armory/Sources/armory/logicnode/DrawSubImageNode.hx
@@ -35,7 +35,7 @@ class DrawSubImageNode extends LogicNode {
 
 		RenderToTexture.g.rotate(angle, x, y);
 
-		if (imgName != lastImgName) {
+		if (imgName != lastImgName || img == null) {
 			// Load new image
 			lastImgName = imgName;
 			iron.data.Data.getImage(imgName, (image: Image) -> {

--- a/armory/Sources/armory/logicnode/DrawToImageNode.hx
+++ b/armory/Sources/armory/logicnode/DrawToImageNode.hx
@@ -1,0 +1,71 @@
+package armory.logicnode;
+
+import kha.Color;
+import iron.math.Vec4;
+import armory.renderpath.RenderToTexture;
+
+class DrawToImageNode extends LogicNode {
+
+	var img: kha.Image = null;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+	}
+
+	override function run(from: Int) {
+		var file: String = inputs[1].get();
+		var colorVec: Vec4 = inputs[2].get();
+
+		img = kha.Image.createRenderTarget(inputs[3].get(), inputs[4].get(),
+			kha.graphics4.TextureFormat.RGBA32,
+			kha.graphics4.DepthStencilFormat.NoDepthAndStencil);
+
+		RenderToTexture.ensureEmptyRenderTarget("DrawToImageNode");
+		img.g2.begin();
+		RenderToTexture.g = img.g2;
+		RenderToTexture.g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
+		RenderToTexture.g.fillRect(0, 0, img.width, img.height);
+		runOutput(0);
+		RenderToTexture.g = null;
+		img.g2.end();
+
+		var pixels = img.getPixels();
+
+		var tx = inputs[5].get();
+		var ty = inputs[6].get();
+		var tw = inputs[7].get();
+		var th = inputs[8].get();
+
+		var bo = new haxe.io.BytesOutput();
+		var rgb = haxe.io.Bytes.alloc(tw * th * 4);
+		for (j in ty...ty + th) {
+			for (i in tx...tx + tw) {
+				var l = j * img.width + i;
+				var m =  (j - ty) * tw + i - tx;
+
+				//ARGB 0xff
+				rgb.set(m * 4 + 0, pixels.get(l * 4 + 3));
+				rgb.set(m * 4 + 1, pixels.get(l * 4 + 0)); 
+				rgb.set(m * 4 + 2, pixels.get(l * 4 + 1));
+				rgb.set(m * 4 + 3, pixels.get(l * 4 + 2));
+			}
+		}
+
+		var imgwriter = new iron.format.bmp.Writer(bo);
+		imgwriter.write(iron.format.bmp.Tools.buildFromARGB(tw, th, rgb));
+
+		#if kha_krom
+		Krom.fileSaveBytes(Krom.getFilesLocation() +  "/" + file, bo.getBytes().getData());
+
+		#elseif kha_html5
+		var blob = new js.html.Blob([bo.getBytes().getData()], {type: "application"});
+        var url = js.html.URL.createObjectURL(blob);
+        var a = cast(js.Browser.document.createElement("a"), js.html.AnchorElement);
+        a.href = url;
+        a.download = file;
+        a.click();
+        js.html.URL.revokeObjectURL(url);
+		#end
+	}
+
+}

--- a/armory/Sources/armory/logicnode/DrawToScreenNode.hx
+++ b/armory/Sources/armory/logicnode/DrawToScreenNode.hx
@@ -1,0 +1,75 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+import kha.Image;
+import kha.Color;
+import armory.renderpath.RenderToTexture;
+
+class DrawToScreenNode extends LogicNode {
+	var img: Image;
+	var colorVec: Vec4;
+	var anchorH: Int;
+	var anchorV: Int;
+	var x: Float;
+	var y: Float;
+	var width: Float;
+	var height: Float;
+	var sx: Float;
+	var sy: Float;
+	var swidth: Float;
+	var sheight: Float;
+	var angle: Float;
+
+	var drawx: Float;
+	var drawy: Float;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+
+		tree.notifyOnRender2D(render2D);
+		
+	}
+
+	override function run(from: Int) {
+
+		if (img == null)
+			img = kha.Image.createRenderTarget(inputs[1].get(), inputs[2].get(),
+				kha.graphics4.TextureFormat.RGBA32,
+				kha.graphics4.DepthStencilFormat.NoDepthAndStencil);
+
+		RenderToTexture.ensureEmptyRenderTarget("DrawToScreenNode");
+		img.g2.begin(inputs[15].get(), Color.Transparent);
+		RenderToTexture.g = img.g2;
+		runOutput(0);
+		RenderToTexture.g = null;
+		img.g2.end();
+
+	}
+
+	function render2D(g:kha.graphics2.Graphics) {
+
+		if (img == null) return;
+
+		colorVec = inputs[3].get();
+		anchorH = inputs[4].get();
+		anchorV = inputs[5].get();
+		x = inputs[6].get();
+		y = inputs[7].get();
+		width = inputs[8].get();
+		height = inputs[9].get();
+		sx = inputs[10].get();
+		sy = inputs[11].get();
+		swidth = inputs[12].get();
+		sheight = inputs[13].get();
+		angle = inputs[14].get();
+
+		drawx = x - 0.5 * width * anchorH;
+		drawy = y - 0.5 * height * anchorV;
+		
+		g.rotate(angle, x, y);
+		g.color = Color.fromFloats(colorVec.x, colorVec.y, colorVec.z, colorVec.w);
+		g.drawScaledSubImage(img, sx, sy, swidth, sheight, drawx, drawy, width, height);
+		g.rotate(-angle, x, y);
+	}
+
+}

--- a/armory/Sources/armory/logicnode/GetImageColorNode.hx
+++ b/armory/Sources/armory/logicnode/GetImageColorNode.hx
@@ -1,0 +1,88 @@
+package armory.logicnode;
+
+import iron.math.Vec4;
+import kha.Color;
+import kha.Image;
+
+class GetImageColorNode extends LogicNode {
+
+	public var property0: String;
+	var renderTarget: Image = null;
+
+	public function new(tree: LogicTree) {
+		super(tree);
+		renderTarget = Image.createRenderTarget(iron.App.w(), iron.App.h(), kha.graphics4.TextureFormat.RGBA32,
+			kha.graphics4.DepthStencilFormat.NoDepthAndStencil);
+	}
+
+	override function get(from: Int): Dynamic {
+
+		var i: Int;
+		var j: Int;
+
+		if (property0 == 'Image'){
+			i = inputs[1].get();
+			j = inputs[2].get();
+		} else {
+			i = inputs[0].get();
+			j = inputs[1].get();
+		}
+
+		renderTarget.g2.begin(true, Color.Transparent);
+
+		renderTarget.g2.color = Color.White;
+
+		if (property0 == 'Render' || property0 == 'Render&Render2D'){
+			if (armory.renderpath.RenderPathCreator.finalTarget != null){
+				var img: Image = iron.RenderPath.active.renderTargets.get("buf").image;
+				renderTarget.g2.drawScaledImage(img, 0, 0, iron.App.w(), iron.App.h());
+			}
+		}
+
+		if (Image.renderTargetsInvertedY()){
+			renderTarget.g2.scale(1, -1);
+			renderTarget.g2.translate(0, renderTarget.height);
+		}
+
+		if (property0 == 'Image'){
+			var img: Image;
+			iron.data.Data.getImage(inputs[0].get(), (image: Image) -> {
+				img = image;
+			});
+			if(img != null)
+				renderTarget.g2.drawScaledImage(img, 0, 0, img.width, img.height);
+		}
+
+		if (property0.indexOf('2D') > 0)
+			for (f in @:privateAccess iron.App.traitRenders2D)
+		    	f(renderTarget.g2);
+
+		if (Image.renderTargetsInvertedY()){
+			renderTarget.g2.scale(1, -1);
+			renderTarget.g2.translate(0, renderTarget.height);
+		}
+
+	    renderTarget.g2.end();
+
+	    var pixels = renderTarget.getPixels();
+
+		var k = j * renderTarget.width + i;
+		
+		#if kha_krom
+		var l = k;
+		#elseif kha_html5
+		var l = (renderTarget.height - j) * renderTarget.width + i;
+		#end
+
+		var r = pixels.get(l * 4 + 0)/255;
+		var g = pixels.get(l * 4 + 1)/255;
+		var b =	pixels.get(l * 4 + 2)/255;
+		var a = pixels.get(l * 4 + 3)/255;
+
+		var v = new Vec4(r, g, b, a);
+		
+		return v;
+
+	}
+
+}

--- a/armory/Sources/armory/logicnode/GetImageColorNode.hx
+++ b/armory/Sources/armory/logicnode/GetImageColorNode.hx
@@ -28,6 +28,13 @@ class GetImageColorNode extends LogicNode {
 			j = inputs[1].get();
 		}
 
+		trace(renderTarget.width, renderTarget.height);
+
+		if (i < 0 || j < 0) return null;
+
+		if (property0 != 'Image')
+			if (i > renderTarget.width || j > renderTarget.height) return null;
+
 		renderTarget.g2.begin(true, Color.Transparent);
 
 		renderTarget.g2.color = Color.White;
@@ -49,7 +56,10 @@ class GetImageColorNode extends LogicNode {
 			iron.data.Data.getImage(inputs[0].get(), (image: Image) -> {
 				img = image;
 			});
-			if(img != null)
+			if (img == null || i > img.width || j > img.height){
+				renderTarget.g2.end();
+				return null;
+			} else
 				renderTarget.g2.drawScaledImage(img, 0, 0, img.width, img.height);
 		}
 

--- a/armory/Sources/armory/logicnode/WriteImageNode.hx
+++ b/armory/Sources/armory/logicnode/WriteImageNode.hx
@@ -1,6 +1,7 @@
 package armory.logicnode;
 
 import iron.object.CameraObject;
+import kha.Color;
 
 class WriteImageNode extends LogicNode {
 
@@ -42,6 +43,34 @@ class WriteImageNode extends LogicNode {
 
 		camera.renderTarget = oldRT;
 		iron.Scene.active.camera = sceneCam;
+
+		if (inputs[9].get()){
+
+			tex = kha.Image.createRenderTarget(inputs[3].get(), inputs[4].get(),
+				kha.graphics4.TextureFormat.RGBA32,
+				kha.graphics4.DepthStencilFormat.NoDepthAndStencil);
+
+			tex.g2.begin(true, Color.Transparent);
+
+			tex.g2.color = Color.White;
+			tex.g2.drawScaledImage(renderTarget, 0, 0, inputs[3].get(), inputs[4].get());
+
+			var scl = inputs[3].get() / iron.App.w();
+
+			if (kha.Image.renderTargetsInvertedY()){
+				tex.g2.scale(scl, -scl);
+				tex.g2.translate(0, inputs[4].get());
+			}
+			else
+				tex.g2.scale(scl, scl);
+
+			for (f in @:privateAccess iron.App.traitRenders2D){
+		    	f(tex.g2);
+		    }
+		    
+		    tex.g2.end();
+
+		}
 
 		var pixels = tex.getPixels();
 

--- a/armory/Sources/iron/data/Data.hx
+++ b/armory/Sources/iron/data/Data.hx
@@ -416,7 +416,7 @@ class Data {
 		var loading = loadingBlobs.get(file); // Is already being loaded
 		if (loading != null) {
 			loading.push(done);
-			return;
+			//return;
 		}
 
 		loadingBlobs.set(file, [done]); // Start loading
@@ -452,7 +452,7 @@ class Data {
 		var loading = loadingImages.get(file);
 		if (loading != null) {
 			loading.push(done);
-			return;
+			//return;
 		}
 
 		loadingImages.set(file, [done]);

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -523,7 +523,7 @@ class ArmoryExporter:
         o['material_refs'].append(arm.utils.asset_name(material))
 
     def export_particle_system_ref(self, psys: bpy.types.ParticleSystem, out_object):
-        if psys.settings.instance_object is None or psys.settings.render_type != 'OBJECT' or not psys.settings.instance_object.arm_export or not bpy.data.objects[out_object['name']].modifiers[psys.name].show_render:
+        if psys.settings.instance_object is None or psys.settings.render_type != 'OBJECT' or not psys.settings.instance_object.arm_export:
             return
 
         self.particle_system_array[psys.settings] = {"structName": psys.settings.name}
@@ -903,8 +903,7 @@ class ArmoryExporter:
                     out_object['particle_refs'] = []
                     out_object['render_emitter'] = bobject.show_instancer_for_render
                     for i in range(num_psys):
-                        if bobject.modifiers[bobject.particle_systems[i].name].show_render:
-                            self.export_particle_system_ref(bobject.particle_systems[i], out_object)
+                        self.export_particle_system_ref(bobject.particle_systems[i], out_object)
 
                 aabb = bobject.data.arm_aabb
                 if aabb[0] == 0 and aabb[1] == 0 and aabb[2] == 0:
@@ -2272,21 +2271,7 @@ Make sure the mesh only has tris/quads.""")
     def export_particle_systems(self):
         if len(self.particle_system_array) > 0:
             self.output['particle_datas'] = []
-
         for particleRef in self.particle_system_array.items():
-
-            padd = False;
-
-            for obj in self.output['objects']:
-                if 'particle_refs' in obj:
-                    for pref in obj['particle_refs']:
-                        if pref['particle'] == particleRef[1]["structName"]:
-                            if bpy.data.objects[obj['name']].modifiers[pref['name']].show_render == True:
-                                padd = True;
-
-            if not padd:
-                continue;
-
             psettings = particleRef[0]
 
             if psettings is None:

--- a/armory/blender/arm/logicnode/draw/LN_draw_image_render.py
+++ b/armory/blender/arm/logicnode/draw/LN_draw_image_render.py
@@ -1,12 +1,14 @@
 from arm.logicnode.arm_nodes import *
 
 
-class DrawSubImageNode(ArmLogicTreeNode):
-    """Draws an image.
+class DrawImageRenderNode(ArmLogicTreeNode):
+    """Draws an image render target.
 
     @input Draw: Activate to draw the image on this frame. The input must
         be (indirectly) called from an `On Render2D` node.
-    @input Image: The filename of the image.
+
+    @input In: Activate to retrieve the imaga render target.
+    @input Camera: the render target image of the camera.
     @input Color: The color that the image's pixels are multiplied with.
     @input Left/Center/Right: Horizontal anchor point of the image.
         0 = Left, 1 = Center, 2 = Right
@@ -14,23 +16,25 @@ class DrawSubImageNode(ArmLogicTreeNode):
         0 = Top, 1 = Middle, 2 = Bottom
     @input X/Y: Position of the anchor point in pixels.
     @input Width/Height: Size of the image in pixels.
-    @input sX/sY: Position of the sub anchor point in pixels.
+    @input sX/Y: Position of the sub anchor point in pixels.
     @input sWidth/sHeight: Size of the sub image in pixels.
     @input Angle: Rotation angle in radians. Image will be rotated cloclwiswe
         at the anchor point.
+    @input Render2D: include Render 2D draws.
 
     @output Out: Activated after the image has been drawn.
 
     @see [`kha.graphics2.Graphics.drawImage()`](http://kha.tech/api/kha/graphics2/Graphics.html#drawImage).
     """
-    bl_idname = 'LNDrawSubImageNode'
-    bl_label = 'Draw Sub Image'
+    bl_idname = 'LNDrawImageRenderNode'
+    bl_label = 'Draw Image Render'
     arm_section = 'draw'
     arm_version = 1
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'Draw')
-        self.add_input('ArmStringSocket', 'Image File')
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmNodeSocketObject', 'Camera')
         self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
         self.add_input('ArmIntSocket', '0/1/2 = Left/Center/Right', default_value=0)
         self.add_input('ArmIntSocket', '0/1/2 = Top/Middle/Bottom', default_value=0)
@@ -43,5 +47,6 @@ class DrawSubImageNode(ArmLogicTreeNode):
         self.add_input('ArmFloatSocket', 'sWidth')
         self.add_input('ArmFloatSocket', 'sHeight')
         self.add_input('ArmFloatSocket', 'Angle')
+        self.add_input('ArmBoolSocket', 'Render2D')
 
         self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/logicnode/draw/LN_draw_to_image.py
+++ b/armory/blender/arm/logicnode/draw/LN_draw_to_image.py
@@ -1,41 +1,37 @@
 from arm.logicnode.arm_nodes import *
 
 
-class WriteImageNode(ArmLogicTreeNode):
-    """Writes the given image to the given file. If the image
+class DrawToImageNode(ArmLogicTreeNode):
+    """Writes the given draw image to the given file. If the image
     already exists, the existing content of the image is overwritten.
 
-    Aspect ratio must match display resolution ratio.
-
-    Render2D flag to include render draws.
-
     @input Image File: the name of the image
-    @input Camera: the render target image of the camera to write to the image file.
+    @input Color: The color that the image's pixels are multiplied with.
     @input Width: width of the image file.
     @input Height: heigth of the image file.
     @input sX: sub position of first x pixel of the sub image (0 for start).
     @input sY: sub position of first y pixel of the sub image (0 for start).
     @input sWidth: width of the sub image.
     @input sHeight: height of the sub image.
-    @input Render2D: include Render 2D draws.
 
-    @seeNode Read File
+    WARNING: Calling getPixels() on a renderTarget with non-standard non-POT dimensions 
+    can cause a system crash. Ensure renderTarget resolution is a power of two
+    (e.g., 256x256) or a common standard resolution (e.g., 1920x1080).
     """
-    bl_idname = 'LNWriteImageNode'
-    bl_label = 'Write Image'
-    arm_section = 'file'
+    bl_idname = 'LNDrawToImageNode'
+    bl_label = 'Draw To Image'
+    arm_section = 'draw'
     arm_version = 1
 
     def arm_init(self, context):
         self.add_input('ArmNodeSocketAction', 'In')
         self.add_input('ArmStringSocket', 'Image File')
-        self.add_input('ArmNodeSocketObject', 'Camera')
+        self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
         self.add_input('ArmIntSocket', 'Width')
         self.add_input('ArmIntSocket', 'Height')
         self.add_input('ArmIntSocket', 'sX')
         self.add_input('ArmIntSocket', 'sY')
         self.add_input('ArmIntSocket', 'sWidth')
         self.add_input('ArmIntSocket', 'sHeight')
-        self.add_input('ArmBoolSocket', 'Render2D')
 
         self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/logicnode/draw/LN_draw_to_screen.py
+++ b/armory/blender/arm/logicnode/draw/LN_draw_to_screen.py
@@ -1,0 +1,50 @@
+from arm.logicnode.arm_nodes import *
+
+
+class DrawToScreenNode(ArmLogicTreeNode):
+    """Draws a Render Target image to screen.
+
+    @input In: Activate to draw the Render Target image to screen.
+    @input Draw Width/Height: Size of the Render Target image in pixels.
+    @input Image: The filename of the image.
+    @input Color: The color that the image's pixels are multiplied with.
+    @input Left/Center/Right: Horizontal anchor point of the image.
+        0 = Left, 1 = Center, 2 = Right
+    @input Top/Middle/Bottom: Vertical anchor point of the image.
+        0 = Top, 1 = Middle, 2 = Bottom
+    @input X/Y: Position of the anchor point in pixels.
+    @input Width/Height: Size of the sub image in pixels.
+    @input sX/Y: Position of the sub anchor point in pixels.
+    @input sWidth/Height: Size of the image in pixels.
+    @input Angle: Rotation angle in radians. Image will be rotated cloclwiswe
+        at the anchor point.
+    @input Clear Image: Clear the image before drawing to it
+
+    @output Out: Activated after the image has been drawn.
+
+    @see [`kha.graphics2.Graphics.drawImage()`](http://kha.tech/api/kha/graphics2/Graphics.html#drawImage).
+    """
+    bl_idname = 'LNDrawToScreenNode'
+    bl_label = 'Draw To Screen'
+    arm_section = 'draw'
+    arm_version = 1
+
+    def arm_init(self, context):
+        self.add_input('ArmNodeSocketAction', 'In')
+        self.add_input('ArmIntSocket', 'Draw Width')
+        self.add_input('ArmIntSocket', 'Draw Height')
+        self.add_input('ArmColorSocket', 'Color', default_value=[1.0, 1.0, 1.0, 1.0])
+        self.add_input('ArmIntSocket', '0/1/2 = Left/Center/Right', default_value=0)
+        self.add_input('ArmIntSocket', '0/1/2 = Top/Middle/Bottom', default_value=0)
+        self.add_input('ArmFloatSocket', 'X')
+        self.add_input('ArmFloatSocket', 'Y')
+        self.add_input('ArmFloatSocket', 'Width')
+        self.add_input('ArmFloatSocket', 'Height')
+        self.add_input('ArmFloatSocket', 'sX')
+        self.add_input('ArmFloatSocket', 'sY')
+        self.add_input('ArmFloatSocket', 'sWidth')
+        self.add_input('ArmFloatSocket', 'sHeight')
+        self.add_input('ArmFloatSocket', 'Angle')
+        self.add_input('ArmBoolSocket', 'Clear Image')
+
+        self.add_output('ArmNodeSocketAction', 'Out')

--- a/armory/blender/arm/logicnode/input/LN_get_image_color.py
+++ b/armory/blender/arm/logicnode/input/LN_get_image_color.py
@@ -1,0 +1,44 @@
+from arm.logicnode.arm_nodes import *
+
+
+class GetImageColorNode(ArmLogicTreeNode):
+    """Gets Color of the pixel in X,Y position of: input Image, Render, Render2D and Render+Render2D.
+
+    @input X: pixel position regarding width.
+    @input Y: pixel position regarding height.
+
+    @output Color: Color of the pixel in X,Y position.
+
+    WARNING: Calling getPixels() on a renderTarget with non-standard non-POT dimensions 
+    can cause a system crash. Ensure renderTarget resolution is a power of two
+    (e.g., 256x256) or a common standard resolution (e.g., 1920x1080).
+
+    """
+    bl_idname = 'LNGetImageColorNode'
+    bl_label = 'Get Image Color'
+    arm_version = 1
+
+    def remove_extra_inputs(self, context):
+        while len(self.inputs) > 0:
+            self.inputs.remove(self.inputs[-1])
+        if self.property0 == 'Image':
+            self.add_input('ArmStringSocket', 'Image')
+        self.add_input('ArmIntSocket', 'X')
+        self.add_input('ArmIntSocket', 'Y')
+
+    property0: HaxeEnumProperty(
+    'property0',
+    items = [('Image', 'Image', 'Image'),
+             ('Render2D', 'Render2D', 'Render2D'),
+             ('Render', 'Render', 'Render'),
+             ('Render&Render2D', 'Render&Render2D', 'Render&Render2D')],
+    name='', default='Image', update=remove_extra_inputs)
+
+    def arm_init(self, context):
+        self.add_input('ArmStringSocket', 'Image')
+        self.add_input('ArmIntSocket', 'X')
+        self.add_input('ArmIntSocket', 'Y')
+        self.add_output('ArmColorSocket', 'Color')
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, 'property0')


### PR DESCRIPTION
New nodes include:

- Draw Image Render: allows to draw the renders as an image
<img width="205" height="483" alt="image" src="https://github.com/user-attachments/assets/98a999d5-fdfb-4d93-9452-ae449f2f56bd" />

- Draw To Image: allows to save the draws as a file image (as the write image but only for some render2d)
<img width="185" height="303" alt="image" src="https://github.com/user-attachments/assets/d9759404-3376-4990-9cd2-56ca411c135c" />

- Draw To Screen: allows to draw all the draws as an image (render2d to image)
<img width="192" height="478" alt="image" src="https://github.com/user-attachments/assets/89f66f1c-eeb0-4081-a337-e9de487c5a66" />

- Get Image Color: retrieves the color of the pixel at position x y of an image (render, render2d, etc)
<img width="364" height="196" alt="image" src="https://github.com/user-attachments/assets/f5b26a06-0aa4-47f0-854e-28cdf0667628" />

Updates:
- Write Image: added option to include render2d
- Draw Image/Sub Image: added condition to load images created at runtime
- Load Blob: added condition to load files created at runtime

Fixes:
- draw Sub Image: fix for anchor V/H