### PR TITLE
fix world errors

### DIFF
--- a/armory/Sources/armory/logicnode/SetWorldNode.hx
+++ b/armory/Sources/armory/logicnode/SetWorldNode.hx
@@ -1,5 +1,7 @@
 package armory.logicnode;
 
+import iron.data.SceneFormat;
+
 class SetWorldNode extends LogicNode {
 
 	public function new(tree: LogicTree) {
@@ -10,25 +12,6 @@ class SetWorldNode extends LogicNode {
 		var world: String = inputs[1].get();
 
 		if (world != null){
-
-			//check if world shader data exists
-			var file: String = 'World_'+world+'_data';
-			#if arm_json
-				file += ".json";
-			#elseif arm_compress
-				file += ".lz4";
-			#else
-				file += '.arm';
-			#end
-
-			var exists: Bool = false;
-		
-			iron.data.Data.getBlob(file, function(b: kha.Blob) {
-				if (b != null) exists = true;
-			});
-
-			assert(Error, exists == true, "World must be either associated to a scene or have fake user");
-
 			iron.Scene.active.raw.world_ref = world;
 			var npath = armory.renderpath.RenderPathCreator.get();
 			npath.loadShader("shader_datas/World_" + world + "/World_" + world);

--- a/armory/blender/arm/logicnode/world/LN_set_world.py
+++ b/armory/blender/arm/logicnode/world/LN_set_world.py
@@ -1,7 +1,10 @@
 from arm.logicnode.arm_nodes import *
 
 class SetWorldNode(ArmLogicTreeNode):
-    """Sets the World of the active scene."""
+    """Sets the World of the active scene.
+
+    World must be either associated to a scene or have fake user."""
+
     bl_idname = 'LNSetWorldNode'
     bl_label = 'Set World'
     arm_version = 1

--- a/armory/blender/arm/make_renderpath.py
+++ b/armory/blender/arm/make_renderpath.py
@@ -40,13 +40,15 @@ def add_world_defs():
     if rpdat.rp_hdr == False:
         wrd.world_defs += '_LDR'
 
-    if arm.utils.get_active_scene().world.arm_light_ies_texture == True:
-        wrd.world_defs += '_LightIES'
-        assets.add_embedded_data('iestexture.png')
+    if arm.utils.get_active_scene().world is not None:
+        print('entre')
+        if arm.utils.get_active_scene().world.arm_light_ies_texture:
+            wrd.world_defs += '_LightIES'
+            assets.add_embedded_data('iestexture.png')
 
-    if arm.utils.get_active_scene().world.arm_light_clouds_texture == True:
-        wrd.world_defs += '_LightClouds'
-        assets.add_embedded_data('cloudstexture.png')
+        if arm.utils.get_active_scene().world.arm_light_clouds_texture:
+            wrd.world_defs += '_LightClouds'
+            assets.add_embedded_data('cloudstexture.png')
 
     if rpdat.rp_renderer == 'Deferred':
         assets.add_khafile_def('arm_deferred')

--- a/armory/blender/arm/make_renderpath.py
+++ b/armory/blender/arm/make_renderpath.py
@@ -41,7 +41,6 @@ def add_world_defs():
         wrd.world_defs += '_LDR'
 
     if arm.utils.get_active_scene().world is not None:
-        print('entre')
         if arm.utils.get_active_scene().world.arm_light_ies_texture:
             wrd.world_defs += '_LightIES'
             assets.add_embedded_data('iestexture.png')


### PR DESCRIPTION
- I removed the validation in the setWorld node because it did not work on html5 even though the world did exist. So I moved the assert message to the node description.
- I added a condition so scenes without worlds can compile if there is only one scene or is the scene set in the launch properties.