### PR TITLE
shutdown node

### DIFF
--- a/armory/Sources/armory/logicnode/ShutdownNode.hx
+++ b/armory/Sources/armory/logicnode/ShutdownNode.hx
@@ -8,5 +8,6 @@ class ShutdownNode extends LogicNode {
 
 	override function run(from: Int) {
 		kha.System.stop();
+        runOutput(0);
 	}
 }


### PR DESCRIPTION
ShutdownNode has the output in the node definition but not in the haxe code.

Turns out it really triggers the nodes after it when in windows.