### PR TITLE
Fix naming collisions from linked scenes

### DIFF
--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -433,7 +433,7 @@ class ArmoryExporter:
 
             self.bobject_array[bobject] = {
                 "objectType": btype,
-                "structName": arm.utils.asset_name(bobject)
+                "structName": bobject.name if bobject.name in self.scene.objects and bobject.name not in self.scene.collection.children and self.scene.library and bobject.type != 'CAMERA' else arm.utils.asset_name(bobject)
             }
 
             if bobject.type == "ARMATURE":
@@ -864,7 +864,7 @@ class ArmoryExporter:
             # Export the object reference and material references
             objref = bobject.data
             if objref is not None:
-                objname = arm.utils.asset_name(objref)
+                objname = objref.name if objref.name in self.scene.objects and objref.name not in self.scene.collection.children and self.scene.library and objref.type != 'CAMERA' else arm.utils.asset_name(objref)
 
             # LOD
             if bobject.type == 'MESH' and hasattr(objref, 'arm_lodlist') and len(objref.arm_lodlist) > 0:
@@ -1962,7 +1962,7 @@ Make sure the mesh only has tris/quads.""")
             # outside the collection, then instantiate the full object
             # child tree if the collection gets spawned as a whole
             if bobject.parent is None or bobject.parent.name not in collection.objects:
-                asset_name = arm.utils.asset_name(bobject)
+                asset_name = bobject.name if bobject.name in self.scene.objects and bobject.name not in self.scene.collection.children and self.scene.library and bobject.type != 'CAMERA' else arm.utils.asset_name(bobject)
 
                 if collection.library and not collection.name in self.scene.collection.children:
                     # Add external linked objects

--- a/armory/blender/arm/make.py
+++ b/armory/blender/arm/make.py
@@ -144,6 +144,9 @@ def load_external_blends():
                     if scn is not None and scn not in appended_scenes:
                         # make name unique with file name
                         scn.name += "_" + filename.replace(".blend", "")
+                        for obj in scn.objects:
+                            if obj.type != 'CAMERA':
+                                obj.name += "_" + filename
                         appended_scenes.append(scn)
 
                 log.info(f"Loaded external blend: {blend_path}")


### PR DESCRIPTION
Modifiers were only applying on the first detected objects using the same name on different linked scenes. This fix properly applies modifiers to all objects.