### PR TITLE
More linked assets fixes

### DIFF
--- a/armory/blender/arm/make.py
+++ b/armory/blender/arm/make.py
@@ -179,13 +179,10 @@ def clear_external_scenes():
     appended_scenes = []
 
 def export_data(fp, sdk_path):
-    # Reload all libraries to retrieve updated data without having to restart Blender
+    # Reload all libraries to retrieve updated data without needing to restart Blender
     for lib in bpy.data.libraries:
-        try:
-            lib.reload()
-            log.info(f"Reloaded: {lib.filepath}")
-        except Exception as e:
-            log.error(f"Failed to reload {lib.filepath}: {e}")
+        lib.reload()
+        log.info(f"Reloaded: {lib.filepath}")
 
     load_external_blends()
 

--- a/armory/blender/arm/make.py
+++ b/armory/blender/arm/make.py
@@ -179,6 +179,14 @@ def clear_external_scenes():
     appended_scenes = []
 
 def export_data(fp, sdk_path):
+    # Reload all libraries to retrieve updated data without having to restart Blender
+    for lib in bpy.data.libraries:
+        try:
+            lib.reload()
+            log.info(f"Reloaded: {lib.filepath}")
+        except Exception as e:
+            log.error(f"Failed to reload {lib.filepath}: {e}")
+
     load_external_blends()
 
     wrd = bpy.data.worlds['Arm']


### PR DESCRIPTION
Fixes:
- reload all linked libraries on build to get their most recent changes without needing to restart Blender
- fully clean up external blends from the `Libraries` outliner