### PR TITLE
Clear linked scenes from blend file when build process gets interrupted

### DIFF
--- a/armory/blender/arm/props_ui.py
+++ b/armory/blender/arm/props_ui.py
@@ -1278,6 +1278,7 @@ class ArmoryStopButton(bpy.types.Operator):
         elif state.proc_build != None:
             state.proc_build.terminate()
             state.proc_build = None
+        make.clear_external_scenes()
 
         arm.write_probes.check_last_cmft_time()
 


### PR DESCRIPTION
Linked scenes are added during build process. With this fix all of these scenes get deleted if the user for some reason hits "stop" during this process.