### PR TITLE
use point filter for r32ui voxels structure. Reenable voxel AO. fix ssgi

### DIFF
--- a/armory/Sources/armory/renderpath/RenderPathDeferred.hx
+++ b/armory/Sources/armory/renderpath/RenderPathDeferred.hx
@@ -1011,7 +1011,7 @@ class RenderPathDeferred {
 				path.bindTarget("gbuffer0", "gbuffer0");
 				path.drawShader("shader_datas/blur_edge_pass/blur_edge_pass_x");
 
-				path.setTarget("singlea");
+				path.setTarget("tex");
 				path.bindTarget("singleb", "tex");
 				path.bindTarget("gbuffer0", "gbuffer0");
 				path.drawShader("shader_datas/blur_edge_pass/blur_edge_pass_y");

--- a/armory/Sources/iron/object/Uniforms.hx
+++ b/armory/Sources/iron/object/Uniforms.hx
@@ -193,7 +193,7 @@ class Uniforms {
 						}
 						else if (rt.raw.name.startsWith("voxels"))
 						{
-							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.PointFilter, TextureFilter.LinearFilter, MipMapFilter.NoMipFilter);
+							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.PointFilter, TextureFilter.PointFilter, MipMapFilter.NoMipFilter);
 						}
 						else
 						{

--- a/armory/blender/arm/props_renderpath.py
+++ b/armory/blender/arm/props_renderpath.py
@@ -486,8 +486,8 @@ class ArmRPListItem(bpy.types.PropertyGroup):
     arm_ssr_half_res: BoolProperty(name="Half Res", description="Trace in half resolution", default=True, update=update_renderpath)
     rp_voxels: EnumProperty(
         items=[('Off', 'Off', 'Off'),
-               ('Voxel GI', 'Voxel GI', 'Voxel GI')
-               #('Voxel AO', 'Voxel AO', 'Voxel AO')
+               ('Voxel GI', 'Voxel GI', 'Voxel GI'),
+               ('Voxel AO', 'Voxel AO', 'Voxel AO')
                ],
         name="Voxels", description="Dynamic global illumination", default='Off', update=update_renderpath)
     rp_voxelgi_resolution: EnumProperty(


### PR DESCRIPTION
Hello @luboslenco,
I took note of the comment on the pull request and re-enabled AO, this way you can see for yourself. It actually looks correct.
I also made a small fix for ssgi to work.
Only bug is that screen space refraction for forward render path isn't working. It doesn't find some of the render target when seting it as target.