### PR TITLE
Small materials updates

### DIFF
--- a/armory/blender/arm/material/cycles_functions.py
+++ b/armory/blender/arm/material/cycles_functions.py
@@ -10,8 +10,8 @@ float noise(const vec3 x) {
 
 	vec3 i = floor(x);
 	vec3 f = fract(x);
- 
-	// For performance, compute the base input to a 1D hash from the integer part of the argument and the 
+
+	// For performance, compute the base input to a 1D hash from the integer part of the argument and the
 	// incremental change to the 1D based on the 3D -> 1D wrapping
     float n = dot(i, step);
 
@@ -46,7 +46,7 @@ float fractal_noise(const vec3 p, const float o)
     return (1.0 - rmd) * sum + rmd * sum2;
   }
   else {
-    sum *= float(pow(2, n)) / float(pow(2, n + 1) - 1); 
+    sum *= float(pow(2, n)) / float(pow(2, n + 1) - 1);
     return sum;
   }
 }
@@ -282,14 +282,14 @@ float tex_magic_f(const vec3 p) {
 str_tex_brick = """
 vec3 tex_brick(vec3 p, const vec3 c1, const vec3 c2, const vec3 c3) {
     p /= vec3(0.9, 0.49, 0.49) / 2;
-    if (fract(p.y * 0.5) > 0.5) p.x += 0.5;   
+    if (fract(p.y * 0.5) > 0.5) p.x += 0.5;
     p = fract(p);
     vec3 b = step(p, vec3(0.95, 0.9, 0.9));
     return mix(c3, c1, b.x * b.y * b.z);
 }
 float tex_brick_f(vec3 p) {
     p /= vec3(0.9, 0.49, 0.49) / 2;
-    if (fract(p.y * 0.5) > 0.5) p.x += 0.5;   
+    if (fract(p.y * 0.5) > 0.5) p.x += 0.5;
     p = fract(p);
     vec3 b = step(p, vec3(0.95, 0.9, 0.9));
     return mix(1.0, 0.0, b.x * b.y * b.z);
@@ -421,11 +421,12 @@ float tex_brick_blender_f(vec3 co,
 """
 
 str_tex_wave = """
-float tex_wave_f(const vec3 p, const int type, const int profile, const float dist, const float detail, const float detail_scale) {
+float tex_wave_f(const vec3 p, const int type, const int profile, const float dist, const float detail, const float detail_scale, const float phase_offset) {
     float n;
     if(type == 0) n = (p.x + p.y + p.z) * 9.5;
     else n = length(p) * 13.0;
     if(dist != 0.0) n += dist * fractal_noise(p * detail_scale, detail) * 2.0 - 1.0;
+    n += phase_offset;
     if(profile == 0) { return 0.5 + 0.5 * sin(n - PI); }
     else {
         n /= 2.0 * PI;

--- a/armory/blender/arm/material/cycles_nodes/nodes_texture.py
+++ b/armory/blender/arm/material/cycles_nodes/nodes_texture.py
@@ -556,6 +556,9 @@ def parse_tex_voronoi(node: bpy.types.ShaderNodeTexVoronoi, out_socket: bpy.type
         m = 2
     elif node.distance == 'MINKOWSKI':
         m = 3
+    # TODO: Add node.distance == 'MANHATHAN'
+    #       Add node.feature
+    #       Add node.voronoi_dimensions
 
     c.write_procedurals()
     state.curshader.add_function(c_functions.str_tex_voronoi)
@@ -592,6 +595,8 @@ def parse_tex_wave(node: bpy.types.ShaderNodeTexWave, out_socket: bpy.types.Node
     distortion = c.get_value_input(node, ['Distortion'])
     detail = c.get_value_input(node, ['Detail'])
     detail_scale = c.get_value_input(node, ['Detail Scale'])
+    phase_offset = c.get_value_input(node, ['Phase Offset'])
+
     if node.wave_profile == 'SIN':
         wave_profile = 0
     else:
@@ -603,9 +608,9 @@ def parse_tex_wave(node: bpy.types.ShaderNodeTexWave, out_socket: bpy.types.Node
 
     # Color
     if out_socket == node.outputs['Color']:
-        res = 'vec3(tex_wave_f({0} * {1},{2},{3},{4},{5},{6}))'.format(co, scale, wave_type, wave_profile, distortion, detail, detail_scale)
+        res = 'vec3(tex_wave_f({0} * {1},{2},{3},{4},{5},{6},{7}))'.format(co, scale, wave_type, wave_profile, distortion, detail, detail_scale, phase_offset)
     # Fac
     else:
-        res = 'tex_wave_f({0} * {1},{2},{3},{4},{5},{6})'.format(co, scale, wave_type, wave_profile, distortion, detail, detail_scale)
+        res = 'tex_wave_f({0} * {1},{2},{3},{4},{5},{6},{7})'.format(co, scale, wave_type, wave_profile, distortion, detail, detail_scale, phase_offset)
 
     return res

--- a/armory/blender/arm/material/make_mesh.py
+++ b/armory/blender/arm/material/make_mesh.py
@@ -710,7 +710,7 @@ def make_forward_base(con_mesh, parse_opacity=False, transluc_pass=False):
     if '_Sun' in wrd.world_defs:
         frag.add_uniform('vec3 sunCol', '_sunColor')
         frag.add_uniform('vec3 sunDir', '_sunDirection')
-        frag.write('float svisibility = 0.0;')
+        frag.write('float svisibility = 1.0;')
         frag.write('vec3 sh = normalize(vVec + sunDir);')
         frag.write('float sdotNL = max(dot(n, sunDir), 0);')
         frag.write('float sdotNH = max(dot(n, sh), 0);')


### PR DESCRIPTION
- sets the sunlight value to 1.0 by default. This make objects look "all light" instead of "all shadow" when `Material - Armory Props - Receive Shadow` is set to `false`
- add `phase_offset` to Wave Textures