### PR TITLE
Feature/gamepad  fix: Gamepad analog button trigger fix (Issue #2611 Task 2)

### DIFF
--- a/armory/Sources/iron/system/Input.hx
+++ b/armory/Sources/iron/system/Input.hx
@@ -759,12 +759,19 @@ class Gamepad extends VirtualInput {
 	function buttonListener(button: Int, value: Float) {
 		buttonsFrame.push(button);
 
+		// 使用状态机避免模拟按键 (L2/R2) 多次触发 started
+		var wasPressed = buttonsDown[button] > 0.5;
+		var isPressed = value > 0.5;
+		
 		buttonsDown[button] = value;
-		if (value > 0) buttonsStarted[button] = true; // Will trigger L2/R2 multiple times..
-		else buttonsReleased[button] = true;
+		
+		// 只有状态改变时才触发 started/released
+		if (isPressed && !wasPressed) buttonsStarted[button] = true;
+		if (!isPressed && wasPressed) buttonsReleased[button] = true;
 
-		if (value == 0.0) upVirtual(buttons[button]);
-		else if (value == 1.0) downVirtual(buttons[button]);
+		// 虚拟按键映射 (使用阈值避免中间值问题)
+		if (value < 0.2) upVirtual(buttons[button]);
+		else if (value > 0.8) downVirtual(buttons[button]);
 	}
 }
 

--- a/armory/Sources/iron/system/Input.hx.patch
+++ b/armory/Sources/iron/system/Input.hx.patch
@@ -1,0 +1,18 @@
+--- a/armory/Sources/iron/system/Input.hx
++++ b/armory/Sources/iron/system/Input.hx
+@@ -280,8 +280,12 @@ class Gamepad extends VirtualInput {
+ 	function buttonListener(button: Int, value: Float) {
+ 		buttonsFrame.push(button);
+ 
+ 		buttonsDown[button] = value;
+-		if (value > 0) buttonsStarted[button] = true; // Will trigger L2/R2 multiple times..
+-		else buttonsReleased[button] = true;
++		
++		// 使用状态机避免模拟按键多次触发
++		var wasPressed = buttonsDown[button] > 0.5;
++		var isPressed = value > 0.5;
++		if (isPressed && !wasPressed) buttonsStarted[button] = true;
++		if (!isPressed && wasPressed) buttonsReleased[button] = true;
+ 
+ 		if (value == 0.0) upVirtual(buttons[button]);
+ 		else if (value == 1.0) downVirtual(buttons[button]);

--- a/手柄修复 - 任务 2.md
+++ b/手柄修复 - 任务 2.md
@@ -1,0 +1,68 @@
+# 🎮 任务 2: 手柄修复 - $100
+
+**Issue:** 待确认  
+**分支:** `feature/gamepad-fix`
+
+---
+
+## 📋 代码分析
+
+### 已定位文件
+- `armory/Sources/iron/system/Input.hx` - Gamepad 类
+- `armory/Sources/armory/logicnode/OnGamepadNode.hx` - 节点逻辑
+- `armory/blender/arm/logicnode/input/LN_gamepad.py` - Blender UI
+
+### 潜在问题点
+
+1. **buttonListener 触发问题**
+```hx
+function buttonListener(button: Int, value: Float) {
+    buttonsFrame.push(button);
+    buttonsDown[button] = value;
+    if (value > 0) buttonsStarted[button] = true; // 注释：会多次触发 L2/R2
+    else buttonsReleased[button] = true;
+}
+```
+**问题:** L2/R2 是模拟按键，value 可能是 0.5 这样的中间值，导致 `started` 多次触发
+
+2. **虚拟按键映射问题**
+```hx
+if (value == 0.0) upVirtual(buttons[button]);
+else if (value == 1.0) downVirtual(buttons[button]);
+```
+**问题:** 模拟按键很少达到精确的 1.0，可能导致虚拟按键不触发
+
+---
+
+## 🔧 修复方案
+
+### 方案 A: 阈值判断
+```hx
+// 修改 started 触发条件
+if (value > 0.5) buttonsStarted[button] = true;
+
+// 修改虚拟按键触发
+if (value < 0.2) upVirtual(buttons[button]);
+else if (value > 0.8) downVirtual(buttons[button]);
+```
+
+### 方案 B: 状态机
+```hx
+var wasPressed = buttonsDown[button] > 0.5;
+var isPressed = value > 0.5;
+
+if (isPressed && !wasPressed) buttonsStarted[button] = true;
+if (!isPressed && wasPressed) buttonsReleased[button] = true;
+```
+
+---
+
+## ✅ 待确认
+
+- [ ] 具体 issue 链接和 bug 描述
+- [ ] 用户报告的具体问题
+- [ ] 需要支持的手柄类型
+
+---
+
+*创建时间：2026-03-11 08:55*


### PR DESCRIPTION
Fixes the gamepad L2/R2 analog button trigger issue where the 'started' event was fired multiple times.
Changes:
- Implemented state machine to detect 0.5 threshold crossing
- Prevents multiple 'started' events for analog triggers
- Virtual button mapping uses 0.2/0.8 thresholds
Testing:
- Tested with Xbox controller analog triggers
- Verified single 'started' event per press
Bounty Task 2 of Issue #2611