### PR TITLE
Project icon updates

### DIFF
--- a/armory/blender/arm/props.py
+++ b/armory/blender/arm/props.py
@@ -191,7 +191,10 @@ def init_properties():
     bpy.types.World.arm_project_win_build_cpu = IntProperty(name="CPU Count", description="Specifies the maximum number of concurrent processes to use when building", default=1, min=1, max=multiprocessing.cpu_count())
     bpy.types.World.arm_project_win_build_open = BoolProperty(name="Open Build Directory", description="Open the build directory after successfully assemble", default=False)
 
-    bpy.types.World.arm_project_icon = StringProperty(name="Icon (PNG)", description="Exported project icon, must be a PNG image", default="", subtype="FILE_PATH", update=assets.invalidate_compiler_cache)
+    if bpy.app.version >= (4, 5, 0):
+        bpy.types.World.arm_project_icon = StringProperty(name="Icon (PNG)", description="Exported project icon, must be a PNG image", default="", subtype="FILE_PATH", update=assets.invalidate_compiler_cache, options={'PATH_SUPPORTS_BLEND_RELATIVE'})
+    else:
+        bpy.types.World.arm_project_icon = StringProperty(name="Icon (PNG)", description="Exported project icon, must be a PNG image", default="", subtype="FILE_PATH", update=assets.invalidate_compiler_cache)
     if bpy.app.version >= (4, 5, 0):
         bpy.types.World.arm_project_root = StringProperty(name="Root", description="Set root folder for linked assets", default="", subtype="DIR_PATH", update=assets.invalidate_compiler_cache, options={'PATH_SUPPORTS_BLEND_RELATIVE'})
     else:

--- a/armory/blender/arm/write_data.py
+++ b/armory/blender/arm/write_data.py
@@ -530,7 +530,10 @@ let project = new Project('""" + arm.utils.safesrc(wrd.arm_project_name + '-' + 
             khafile.write("project.targetOptions.ios.bundle = '{0}';\n".format(arm.utils.safestr(bundle)))
 
         if wrd.arm_project_icon != '':
-            shutil.copy(bpy.path.abspath(wrd.arm_project_icon), project_path + '/icon.png')
+            icon_src = os.path.normpath(bpy.path.abspath(wrd.arm_project_icon))
+            icon_dst = os.path.normpath(os.path.join(project_path, 'icon.png'))
+            if not os.path.isfile(icon_dst) or not os.path.samefile(icon_src, icon_dst):
+                shutil.copy2(icon_src, icon_dst)
 
         if wrd.arm_khafile is not None:
             khafile.write(wrd.arm_khafile.as_string())


### PR DESCRIPTION
Changes:
- fix permission error when the icon is copied during export
- use relative path in Blender's 4.5 UI