### PR TITLE
Scene addScene initialization fix

### DIFF
--- a/armory/Sources/iron/Scene.hx
+++ b/armory/Sources/iron/Scene.hx
@@ -401,6 +401,7 @@ class Scene {
 				#end
 
 				var objectsCount = getObjectsCount(format.objects);
+				spawnDepth++; // Defer trait creation until all objects are ready
 				function traverseObjects(parent: Object, objects: Array<TObj>, parentObject: TObj, done: Void->Void) {
 					if (objects == null) return;
 					for (i in 0...objects.length) {
@@ -418,11 +419,16 @@ class Scene {
 				}
 
 				if (format.objects == null || format.objects.length == 0) {
+					spawnDepth--;
 					createTraits(format.traits, parent); // Scene traits
 					done(parent);
 				}
 				else {
 					traverseObjects(parent, format.objects, null, function() { // Scene objects
+						spawnDepth--;
+						if (!initializing) {
+							createTraitsBottomUp(parent);
+						}
 						createTraits(format.traits, parent); // Scene traits
 						done(parent);
 					});


### PR DESCRIPTION
Adds traits from bottom to top to Scene.addScene. This prevents initialization errors.