### PR TITLE
Solve name referencing for linked objects

### DIFF
--- a/armory/Sources/iron/Scene.hx
+++ b/armory/Sources/iron/Scene.hx
@@ -522,6 +522,10 @@ class Scene {
 	static function traverseObjs(children: Array<TObj>, name: String): TObj {
 		for (o in children) {
 			if (o.name == name) return o;
+			else if (o.filename != "") {
+				var fn: String = name + "_" + o.filename;
+				if (o.name == fn) return o;
+			}
 			if (o.children != null) {
 				var res = traverseObjs(o.children, name);
 				if (res != null) return res;

--- a/armory/Sources/iron/Scene.hx
+++ b/armory/Sources/iron/Scene.hx
@@ -862,6 +862,7 @@ class Scene {
 		if (object != null) {
 			object.raw = o;
 			object.name = o.name;
+			if (o.filename != null) object.filename = o.filename;
 			if (o.visible != null) object.visible = o.visible;
 			if (o.visible_mesh != null) object.visibleMesh = o.visible_mesh;
 			if (o.visible_shadow != null) object.visibleShadow = o.visible_shadow;

--- a/armory/Sources/iron/Scene.hx
+++ b/armory/Sources/iron/Scene.hx
@@ -523,8 +523,8 @@ class Scene {
 		for (o in children) {
 			if (o.name == name) return o;
 			else if (o.filename != "") {
-				var fn: String = name + "_" + o.filename;
-				if (o.name == fn) return o;
+				var n: String = name + "_" + o.filename;
+				if (o.name == n) return o;
 			}
 			if (o.children != null) {
 				var res = traverseObjs(o.children, name);

--- a/armory/Sources/iron/Scene.hx
+++ b/armory/Sources/iron/Scene.hx
@@ -299,21 +299,25 @@ class Scene {
 		return root.children.length > 0 ? root.children[0].getTrait(c) : null;
 	}
 
+	// TODO: solve name referencing for linked objects
 	public function getMesh(name: String): MeshObject {
 		for (m in meshes) if (m.name == name) return m;
 		return null;
 	}
 
+	// TODO: solve name referencing for linked objects
 	public function getLight(name: String): LightObject {
 		for (l in lights) if (l.name == name) return l;
 		return null;
 	}
 
+	// TODO: solve name referencing for linked objects
 	public function getCamera(name: String): CameraObject {
 		for (c in cameras) if (c.name == name) return c;
 		return null;
 	}
 
+	// TODO: solve name referencing for linked objects
 	#if arm_audio
 	public function getSpeaker(name: String): SpeakerObject {
 		for (s in speakers) if (s.name == name) return s;
@@ -321,11 +325,13 @@ class Scene {
 	}
 	#end
 
+	// TODO: solve name referencing for linked objects
 	public function getEmpty(name: String): Object {
 		for (e in empties) if (e.name == name) return e;
 		return null;
 	}
 
+	// TODO: solve name referencing for linked objects
 	public function getGroup(name: String): Array<Object> {
 		if (groups == null) groups = new Map();
 		var g = groups.get(name);
@@ -494,6 +500,7 @@ class Scene {
 		spawnObjectTree(obj, parent, null, done);
 	}
 
+	// TODO: solve name referencing for linked objects
 	public function parseObject(sceneName: String, objectName: String, parent: Object, done: Object->Void) {
 		Data.getSceneRaw(sceneName, function(format: TSceneFormat) {
 			var o: TObj = getRawObjectByName(format, objectName);
@@ -803,6 +810,7 @@ class Scene {
 		#end
 	}
 
+	// TODO: solve name referencing for linked objects
 	public function returnMeshObject(object_file: String, data_ref: String, sceneName: String, armature: #if arm_skin Armature #else Null<Int> #end, materials: Vector<MaterialData>, parent: Object, parentObject: TObj, o: TObj, done: Object->Void) {
 		Data.getMesh(object_file, data_ref, function(mesh: MeshData) {
 			#if arm_skin

--- a/armory/Sources/iron/data/SceneFormat.hx
+++ b/armory/Sources/iron/data/SceneFormat.hx
@@ -466,6 +466,7 @@ typedef TObj = {
 	public var name: String;
 	public var data_ref: String;
 	public var transform: TTransform;
+	@:optional public var filename: String; // For objects instanced from external files
 	@:optional public var material_refs: Array<String>;
 	@:optional public var particle_refs: Array<TParticleReference>;
 	@:optional public var render_emitter: Bool;

--- a/armory/Sources/iron/object/Animation.hx
+++ b/armory/Sources/iron/object/Animation.hx
@@ -11,7 +11,7 @@ class Animation {
 
 	public var isSkinned: Bool;
 	public var isSampled: Bool;
-	public var action = "";
+	@:isVar public var action(get, default) = "";
 	#if arm_skin
 	public var armature: iron.data.Armature; // Bone
 	#end
@@ -51,6 +51,10 @@ class Animation {
 			frameTime = Scene.active.raw.frame_time;
 		}
 		play();
+	}
+
+	function get_action(): String {
+		return action;
 	}
 
 	public function play(action = "", onComplete: Void->Void = null, blendTime = 0.0, speed = 1.0, loop = true) {

--- a/armory/Sources/iron/object/BoneAnimation.hx
+++ b/armory/Sources/iron/object/BoneAnimation.hx
@@ -66,6 +66,15 @@ class BoneAnimation extends Animation {
 		}
 	}
 
+	override function get_action(): String {
+		var an: String = action; // an -> action name
+		if (an != "" && object != null && object.filename != "") {
+			var sufix = "_" + object.filename;
+			if (an.indexOf(sufix) != -1) an = StringTools.replace(an, sufix, "");
+		}
+		return an;
+	}
+
 	public inline function getNumBones(): Int {
 		if (skeletonBones == null) return 0;
 		return skeletonBones.length;

--- a/armory/Sources/iron/object/BoneAnimation.hx
+++ b/armory/Sources/iron/object/BoneAnimation.hx
@@ -101,14 +101,23 @@ class BoneAnimation extends Animation {
 		}
 		ar.push(o);
 	}
-	
+
 	public function removeBoneChild(bone: String, o: Object) {
 		if (boneChildren != null) {
 			var ar = boneChildren.get(bone);
 			if (ar != null) ar.remove(o);
 		}
 	}
- 
+
+	function getName(n: String): String {
+		var fn: String = n; // fn -> final name
+		if (fn != "" && object != null && object.filename != "") {
+			var sufix = "_" + object.filename;
+			if (fn.indexOf(sufix) == -1) fn += sufix;
+		}
+		return fn;
+	}
+
 	@:access(iron.object.Transform)
 	function updateBoneChildren(bone: TObj, bm: Mat4) {
 		var ar = boneChildren.get(bone.name);
@@ -201,21 +210,24 @@ class BoneAnimation extends Animation {
 	}
 
 	override public function play(action = "", onComplete: Void->Void = null, blendTime = 0.2, speed = 1.0, loop = true) {
-		super.play(action, onComplete, blendTime, speed, loop);
-		if (action != "") {
-			blendTime > 0 ? setActionBlend(action) : setAction(action);
+		var actionName: String = getName(action);
+		super.play(actionName, onComplete, blendTime, speed, loop);
+		if (actionName != "") {
+			blendTime > 0 ? setActionBlend(actionName) : setAction(actionName);
 		}
 		blendFactor = 0.0;
 	}
 
 	override public function blend(action1: String, action2: String, factor: FastFloat) {
+		var actionName1: String = getName(action1);
+		var actionName2: String = getName(action2);
 		if (factor == 0.0) {
-			setAction(action1);
+			setAction(actionName1);
 			return;
 		}
-		setAction(action2);
-		setActionBlend(action1);
-		super.blend(action1, action2, factor);
+		setAction(actionName2);
+		setActionBlend(actionName1);
+		super.blend(actionName1, actionName2, factor);
 	}
 
 	override public function update(delta: FastFloat) {

--- a/armory/Sources/iron/object/Object.hx
+++ b/armory/Sources/iron/object/Object.hx
@@ -11,6 +11,7 @@ class Object {
 	public var raw: TObj = null;
 
 	public var name: String = "";
+	public var filename: String = "";
 	public var transform: Transform;
 	public var constraints: Array<Constraint> = null;
 	public var traits: Array<Trait> = [];

--- a/armory/Sources/iron/object/Object.hx
+++ b/armory/Sources/iron/object/Object.hx
@@ -112,12 +112,15 @@ class Object {
 	**/
 	public function getChild(name: String): Object {
 		if (this.name == name) return this;
-		else {
-			for (c in children) {
-				var r = c.getChild(name);
-				if (r != null) return r;
-			}
+		else if (this.filename != "") {
+			if (this.name == name + "_" + this.filename) return this;
 		}
+
+		for (c in children) {
+			var r = c.getChild(name);
+			if (r != null) return r;
+		}
+
 		return null;
 	}
 
@@ -231,7 +234,8 @@ class Object {
 
 	#if arm_skin
 	public function getParentArmature(name: String): BoneAnimation {
-		for (a in Scene.active.animations) if (a.armature != null && a.armature.name == name) return cast a;
+		var n: String = filename != "" ? name + "_" + filename : name;
+		for (a in Scene.active.animations) if (a.armature != null && a.armature.name == n) return cast a;
 		return null;
 	}
 	#else

--- a/armory/Sources/iron/object/ObjectAnimation.hx
+++ b/armory/Sources/iron/object/ObjectAnimation.hx
@@ -28,7 +28,8 @@ class ObjectAnimation extends Animation {
 	}
 
 	override public function play(action = "", onComplete: Void->Void = null, blendTime = 0.0, speed = 1.0, loop = true) {
-		super.play(action, onComplete, blendTime, speed, loop);
+		var actionName: String = object != null && object.filename != "" ? action + "_" + object.filename : action;
+		super.play(actionName, onComplete, blendTime, speed, loop);
 		if (this.action == "" && oactions[0] != null) this.action = oactions[0].objects[0].name;
 		oaction = getAction(this.action);
 		if (oaction != null) {

--- a/armory/Sources/iron/object/ObjectAnimation.hx
+++ b/armory/Sources/iron/object/ObjectAnimation.hx
@@ -22,6 +22,15 @@ class ObjectAnimation extends Animation {
 		super();
 	}
 
+	override function get_action(): String {
+		var an: String = action; // an -> action name
+		if (an != "" && object != null && object.filename != "") {
+			var sufix = "_" + object.filename;
+			if (an.indexOf(sufix) != -1) an = StringTools.replace(an, sufix, "");
+		}
+		return an;
+	}
+
 	function getAction(action: String): TObj {
 		for (a in oactions) if (a != null && a.objects[0].name == action) return a.objects[0];
 		return null;

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -931,6 +931,14 @@ class ArmoryExporter:
 
             out_object['mobile'] = bobject.arm_mobile
 
+            lib = bobject.library
+            if lib is None and bobject.data:
+                lib = bobject.data.library
+            if lib is None and bobject.override_library:
+                lib = bobject.override_library.library
+            if lib is not None:
+                out_object['filename'] = lib.name
+
             if bobject.instance_type == 'COLLECTION' and bobject.instance_collection is not None:
                 out_object['group_ref'] = bobject.instance_collection.name
                 self.referenced_collections.append(bobject.instance_collection)


### PR DESCRIPTION
To reference linked object names without needing to manually add "_[filename].blend" sufix for each path. This should also prevent null reference/undefined crashes when referencing objects or animations with logic nodes from linked objects.

Applies to:
- [x] animations
- [x] object spawning
- [x] object getters

Leaving the rest from `iron.Scene` for another PR. Added `TODO` comments on pending implementations.