### PR TITLE
Fix regression for 'getParentArmature'

### DIFF
--- a/armory/Sources/iron/object/Object.hx
+++ b/armory/Sources/iron/object/Object.hx
@@ -234,8 +234,7 @@ class Object {
 
 	#if arm_skin
 	public function getParentArmature(name: String): BoneAnimation {
-		var n: String = filename != "" ? name + "_" + filename : name;
-		for (a in Scene.active.animations) if (a.armature != null && a.armature.name == n) return cast a;
+		for (a in Scene.active.animations) if (a.armature != null && a.armature.name == name) return cast a;
 		return null;
 	}
 	#else


### PR DESCRIPTION
Fixes a regression I accidentally introduced in #3303. This lets objects get parented to bones from linked objects/armatures.