### PR TITLE
Reduce export times

### DIFF
--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -104,16 +104,13 @@ FCURVE_TARGET_NAMES = {
 current_output = None
 
 
+#HACK: cache linked meshes and actions to prevent them from being re-exported per scene and reduce scene export time.
 class BuildExportCache:
     """Shared cache across all scene exports in a single build.
     Created once in make.py, passed to each ArmoryExporter instance."""
     def __init__(self):
         self.exported_mesh_files: set = set()
         self.exported_action_files: set = set()
-
-    def reset(self):
-        self.exported_mesh_files.clear()
-        self.exported_action_files.clear()
 
 
 class ArmoryExporter:

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -104,6 +104,29 @@ FCURVE_TARGET_NAMES = {
 current_output = None
 
 
+class BuildExportCache:
+    """Shared cache across all scene exports in a single build.
+    Created once in make.py, passed to each ArmoryExporter instance."""
+    def __init__(self):
+        # TODO?
+        # self.collection_exports: Dict = {}
+        # self.collection_objects: Dict = {}
+        # self.collection_camera_refs: Dict = {}
+        # self.collection_mesh_refs: Dict = {}
+        # self.collection_material_refs: Dict = {}
+        self.exported_mesh_files: set = set()
+        self.exported_action_files: set = set()
+
+    def reset(self):
+        # self.collection_exports.clear()
+        # self.collection_objects.clear()
+        # self.collection_camera_refs.clear()
+        # self.collection_mesh_refs.clear()
+        # self.collection_material_refs.clear()
+        self.exported_mesh_files.clear()
+        self.exported_action_files.clear()
+
+
 class ArmoryExporter:
     """Export to Armory format.
 
@@ -124,8 +147,10 @@ class ArmoryExporter:
     # Class names of referenced traits
     import_traits: List[str] = []
 
-    def __init__(self, context: bpy.types.Context, filepath: str, scene: bpy.types.Scene = None, depsgraph: bpy.types.Depsgraph = None):
+    def __init__(self, context: bpy.types.Context, filepath: str, scene: bpy.types.Scene = None, depsgraph: bpy.types.Depsgraph = None, build_cache=None):
         global current_output
+
+        self.build_cache = build_cache or BuildExportCache()
 
         self.filepath = filepath
         self.scene = context.scene if scene is None else scene
@@ -178,12 +203,12 @@ class ArmoryExporter:
         ArmoryExporter.preprocess()
 
     @classmethod
-    def export_scene(cls, context: bpy.types.Context, filepath: str, scene: bpy.types.Scene = None, depsgraph: bpy.types.Depsgraph = None) -> None:
+    def export_scene(cls, context: bpy.types.Context, filepath: str, scene: bpy.types.Scene = None, depsgraph: bpy.types.Depsgraph = None, build_cache=None) -> None:
         """Exports the given scene to the given file path. This is the
         function that is called in make.py and the entry point of the
         exporter."""
         with arm.profiler.Profile('profile_exporter.prof', arm.utils.get_pref_or_default('profile_exporter', False)):
-            cls(context, filepath, scene, depsgraph).execute()
+            cls(context, filepath, scene, depsgraph, build_cache).execute()
 
     @classmethod
     def preprocess(cls):
@@ -1233,7 +1258,7 @@ class ArmoryExporter:
                     skelobj.animation_data.action = action
                     fp = self.get_meshes_file_path('action_' + armatureid + '_' + aname, compressed=ArmoryExporter.compress_enabled)
                     assets.add(fp)
-                    if not bdata.arm_cached or not os.path.exists(fp):
+                    if (not bdata.arm_cached or not os.path.exists(fp)) and fp not in self.build_cache.exported_action_files:
                         # Store action to use it after autobake was handled
                         original_action = action
 
@@ -1279,6 +1304,7 @@ class ArmoryExporter:
                         # Save action separately
                         action_obj = {'name': aname, 'objects': bones}
                         arm.utils.write_arm(fp, action_obj)
+                        self.build_cache.exported_action_files.add(fp)
 
                 # Use relative bone constraints
                 out_object['relative_bone_constraints'] = bdata.arm_relative_bone_constraints
@@ -1957,7 +1983,7 @@ Make sure the mesh only has tris/quads.""")
             fp = self.get_meshes_file_path('mesh_' + oid, compressed=ArmoryExporter.compress_enabled)
             assets.add(fp)
             # No export necessary
-            if bobject.data.arm_cached and os.path.exists(fp):
+            if bobject.data.arm_cached and os.path.exists(fp) or fp in self.build_cache.exported_mesh_files:
                 return
 
         # Mesh users have different modifier stack
@@ -2053,6 +2079,7 @@ Make sure the mesh only has tris/quads.""")
             out_mesh['dynamic_usage'] = bobject.data.arm_dynamic_usage
 
         self.write_mesh(bobject, fp, out_mesh)
+        self.build_cache.exported_mesh_files.add(fp)
         # print('Mesh exported in ' + str(time.time() - profile_time))
 
         if hasattr(bobject, 'evaluated_get'):

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -111,6 +111,7 @@ class BuildExportCache:
     def __init__(self):
         self.exported_mesh_files: set = set()
         self.exported_action_files: set = set()
+        self.processed_mesh_names: set = set()
 
 
 class ArmoryExporter:
@@ -1098,8 +1099,9 @@ class ArmoryExporter:
                                         self.export_particle_system_ref(bobject.particle_systems[i], out_object)
 
                 aabb = bobject.data.arm_aabb
-                if aabb[0] == 0 and aabb[1] == 0 and aabb[2] == 0:
+                if oid not in self.build_cache.processed_mesh_names or (aabb[0] == 0 and aabb[1] == 0 and aabb[2] == 0):
                     self.calc_aabb(bobject)
+                    self.build_cache.processed_mesh_names.add(oid)
                 out_object['dimensions'] = [aabb[0], aabb[1], aabb[2]]
 
                 # shapeKeys = ArmoryExporter.get_shape_keys(objref)

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -104,7 +104,6 @@ FCURVE_TARGET_NAMES = {
 current_output = None
 
 
-#HACK: cache linked meshes and actions to prevent them from being re-exported per scene and reduce scene export time.
 class BuildExportCache:
     """Shared cache across all scene exports in a single build.
     Created once in make.py, passed to each ArmoryExporter instance."""

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -2838,8 +2838,7 @@ Make sure the mesh only has tris/quads.""")
             for collection in bpy.data.collections:
                 if collection.name.startswith(('RigidBodyWorld', 'Trait|')):
                     continue
-
-                if self.scene.user_of_id(collection) or collection.library and not self.scene.library or collection in self.referenced_collections:
+                if self.scene.user_of_id(collection) or collection in self.referenced_collections:
                     if collection not in self.inlined_collections:
                         self.export_collection(collection)
 

--- a/armory/blender/arm/exporter.py
+++ b/armory/blender/arm/exporter.py
@@ -108,21 +108,10 @@ class BuildExportCache:
     """Shared cache across all scene exports in a single build.
     Created once in make.py, passed to each ArmoryExporter instance."""
     def __init__(self):
-        # TODO?
-        # self.collection_exports: Dict = {}
-        # self.collection_objects: Dict = {}
-        # self.collection_camera_refs: Dict = {}
-        # self.collection_mesh_refs: Dict = {}
-        # self.collection_material_refs: Dict = {}
         self.exported_mesh_files: set = set()
         self.exported_action_files: set = set()
 
     def reset(self):
-        # self.collection_exports.clear()
-        # self.collection_objects.clear()
-        # self.collection_camera_refs.clear()
-        # self.collection_mesh_refs.clear()
-        # self.collection_material_refs.clear()
         self.exported_mesh_files.clear()
         self.exported_action_files.clear()
 
@@ -484,7 +473,6 @@ class ArmoryExporter:
             if btype is not NodeType.MESH and ArmoryExporter.option_mesh_only:
                 return
 
-            is_local_to_linked_scene = bobject.name in self.scene.objects and bobject.name not in self.scene.collection.children and self.scene.library
             if bobject.type == 'CAMERA' and bobject.library:
                 struct_name = bobject.name + '_' + (os.path.basename(self.scene.library.filepath) if self.scene.library else self.scene.name)
             else:
@@ -2208,7 +2196,6 @@ Make sure the mesh only has tris/quads.""")
             # outside the collection, then instantiate the full object
             # child tree if the collection gets spawned as a whole
             if bobject.parent is None or bobject.parent.name not in collection.objects:
-                is_local_to_linked_scene = bobject.name in self.scene.objects and bobject.name not in self.scene.collection.children and self.scene.library
                 if bobject.type == 'CAMERA':
                     asset_name = bobject.name + '_' + (os.path.basename(self.scene.library.filepath) if self.scene.library else self.scene.name)
                 else:

--- a/armory/blender/arm/make.py
+++ b/armory/blender/arm/make.py
@@ -251,7 +251,7 @@ def export_data(fp, sdk_path):
             continue
         for o in scene.collection.all_objects:
             if o.type in ('MESH', 'EMPTY'):
-                if o.name not in export_coll_names:
+                if o.name not in export_coll_names or o.library:
                     export_coll.objects.link(o)
                     export_coll_names.add(o.name)
     depsgraph = bpy.context.evaluated_depsgraph_get()

--- a/armory/blender/arm/make.py
+++ b/armory/blender/arm/make.py
@@ -18,6 +18,7 @@ import webbrowser
 import bpy
 
 from arm import assets
+from arm.exporter import BuildExportCache
 from arm.exporter import ArmoryExporter
 import arm.lib.make_datas
 import arm.lib.server
@@ -255,6 +256,7 @@ def export_data(fp, sdk_path):
                     export_coll_names.add(o.name)
     depsgraph = bpy.context.evaluated_depsgraph_get()
     bpy.data.collections.remove(export_coll)  # Destroy the "zoo" collection
+    build_cache = BuildExportCache()
 
     for scene in bpy.data.scenes:
         if scene.arm_export:
@@ -262,7 +264,7 @@ def export_data(fp, sdk_path):
             assets.reset_shader_cons()
             ext = '.lz4' if ArmoryExporter.compress_enabled else '.arm'
             asset_path = build_dir + '/compiled/Assets/' + arm.utils.safestr(scene.name + "_" + os.path.basename(scene.library.filepath).replace(".blend", "") if scene.library else scene.name) + ext
-            ArmoryExporter.export_scene(bpy.context, asset_path, scene=scene, depsgraph=depsgraph)
+            ArmoryExporter.export_scene(bpy.context, asset_path, scene=scene, depsgraph=depsgraph, build_cache=build_cache)
             if ArmoryExporter.export_physics:
                 physics_found = True
             if ArmoryExporter.export_navigation:


### PR DESCRIPTION
Significantly reduce the export time, the changes are mostly noticed with projects that heavily use linked objects:
- cache already exported meshes/animations to prevent them from re-exporting when they are re-used across multiple scenes
- prevent linked objects from being re-evaluated on every scene

This reduced the export time in a personal project that uses animations, from ~75 seconds to ~20 seconds.